### PR TITLE
feat: jobs 테이블 RLS 정책 강화(#19)

### DIFF
--- a/supabase/migrations/20260220080319_restrict_jobs_read_access.sql
+++ b/supabase/migrations/20260220080319_restrict_jobs_read_access.sql
@@ -1,0 +1,20 @@
+BEGIN;
+
+-- Drop the existing public read policy
+DROP POLICY IF EXISTS "Authenticated users can read jobs" ON jobs;
+
+-- Create a new policy that only allows reading jobs the user has applied to
+CREATE POLICY "Users can only read jobs they applied to"
+  ON jobs
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM applications a
+      WHERE a.job_id = jobs.id
+        AND a.user_id = auth.uid()
+    )
+  );
+
+COMMIT;


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #19

## 📌 작업 내용

- 기존의 접근 허용(USING TRUE) RLS 정책 삭제
- 본인이 지원한 이력(applications 테이블)이 있는 공고만 조회 가능하도록 제한
- 다른 사용자가 저장/분석한 공고 목록이 노출되는 문제 해결


