### PR TITLE
feat: BottomSheet 컴포넌트 구현(#33)

### DIFF
--- a/components/ui/bottom-sheet/BottomSheet.stories.tsx
+++ b/components/ui/bottom-sheet/BottomSheet.stories.tsx
@@ -1,0 +1,141 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button/Button";
+
+import { BottomSheet } from "./BottomSheet";
+
+const meta = {
+  args: {
+    children: null,
+    isOpen: false,
+    onClose: () => {},
+  },
+  component: BottomSheet,
+  tags: ["autodocs"],
+  title: "UI/BottomSheet",
+} satisfies Meta<typeof BottomSheet>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <>
+        <Button onClick={() => setIsOpen(true)}>시트 열기</Button>
+        <BottomSheet isOpen={isOpen} onClose={() => setIsOpen(false)}>
+          <BottomSheet.Overlay />
+          <BottomSheet.Content>
+            <BottomSheet.Header />
+            <div className="px-6 pb-2">
+              <BottomSheet.Title>기본 바텀시트</BottomSheet.Title>
+            </div>
+            <BottomSheet.Body>
+              <p className="text-gray-600">바텀시트 본문 내용입니다.</p>
+            </BottomSheet.Body>
+          </BottomSheet.Content>
+        </BottomSheet>
+      </>
+    );
+  },
+};
+
+export const WithLongContent: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <>
+        <Button onClick={() => setIsOpen(true)}>긴 컨텐츠 시트 열기</Button>
+        <BottomSheet isOpen={isOpen} onClose={() => setIsOpen(false)}>
+          <BottomSheet.Overlay />
+          <BottomSheet.Content>
+            <BottomSheet.Header />
+            <div className="px-6 pb-2">
+              <BottomSheet.Title>긴 컨텐츠</BottomSheet.Title>
+            </div>
+            <BottomSheet.Body>
+              {Array.from({ length: 20 }, (_, i) => (
+                <p className="border-b py-3 text-gray-600" key={i}>
+                  항목 {i + 1}
+                </p>
+              ))}
+            </BottomSheet.Body>
+          </BottomSheet.Content>
+        </BottomSheet>
+      </>
+    );
+  },
+};
+
+export const WithCustomHeader: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <>
+        <Button onClick={() => setIsOpen(true)}>커스텀 헤더 시트 열기</Button>
+        <BottomSheet isOpen={isOpen} onClose={() => setIsOpen(false)}>
+          <BottomSheet.Overlay />
+          <BottomSheet.Content>
+            <BottomSheet.Header>
+              <div className="flex w-full items-center justify-between px-6">
+                <BottomSheet.Title>커스텀 헤더</BottomSheet.Title>
+                <button
+                  className="text-sm text-gray-500"
+                  onClick={() => setIsOpen(false)}
+                >
+                  닫기
+                </button>
+              </div>
+            </BottomSheet.Header>
+            <BottomSheet.Body>
+              <p className="text-gray-600">
+                커스텀 헤더가 있는 바텀시트입니다.
+              </p>
+            </BottomSheet.Body>
+          </BottomSheet.Content>
+        </BottomSheet>
+      </>
+    );
+  },
+};
+
+export const WithActions: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <>
+        <Button onClick={() => setIsOpen(true)}>액션 시트 열기</Button>
+        <BottomSheet isOpen={isOpen} onClose={() => setIsOpen(false)}>
+          <BottomSheet.Overlay />
+          <BottomSheet.Content>
+            <BottomSheet.Header />
+            <div className="px-6 pb-2">
+              <BottomSheet.Title>작업 선택</BottomSheet.Title>
+            </div>
+            <BottomSheet.Body>
+              <div className="flex flex-col gap-3">
+                <Button className="w-full" onClick={() => setIsOpen(false)}>
+                  확인
+                </Button>
+                <Button
+                  className="w-full"
+                  onClick={() => setIsOpen(false)}
+                  variant="outline"
+                >
+                  취소
+                </Button>
+              </div>
+            </BottomSheet.Body>
+          </BottomSheet.Content>
+        </BottomSheet>
+      </>
+    );
+  },
+};

--- a/components/ui/bottom-sheet/BottomSheet.tsx
+++ b/components/ui/bottom-sheet/BottomSheet.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import React, { createContext, useContext, useId } from "react";
+
+import { Portal } from "@/components/common/Portal";
+import { cn } from "@/lib/utils";
+
+import { useBottomSheet } from "./hooks/useBottomSheet";
+
+type BottomSheetContextValue = ReturnType<typeof useBottomSheet> & {
+  titleId: string;
+};
+
+const BottomSheetContext = createContext<BottomSheetContextValue | null>(null);
+
+type BottomSheetRootProps = {
+  children: React.ReactNode;
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+function Body({
+  children,
+  className,
+  style,
+  ...props
+}: React.ComponentProps<"div">) {
+  const { contentRef } = useBottomSheetContext();
+
+  return (
+    <div
+      {...props}
+      className={cn("flex-1 touch-pan-y overflow-y-auto px-6 pb-10", className)}
+      ref={contentRef}
+      style={style}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Content({
+  children,
+  className,
+  style,
+  ...props
+}: React.ComponentProps<"div">) {
+  const { sheetRef, titleId } = useBottomSheetContext();
+
+  return (
+    <div
+      aria-labelledby={titleId}
+      aria-modal={true}
+      role="dialog"
+      tabIndex={-1}
+      {...props}
+      className={cn(
+        "w-full max-w-md rounded-t-[20px] bg-white shadow-2xl",
+        "pointer-events-auto relative flex flex-col",
+        "max-h-[90vh] min-h-[50vh]",
+        "transition-transform duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)]",
+        "pb-[env(safe-area-inset-bottom)]",
+        "after:absolute after:top-[calc(100%-1px)] after:right-0 after:left-0 after:h-screen after:bg-white",
+        className,
+      )}
+      ref={sheetRef}
+      style={{ ...style, transform: "translateY(100%)" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Header({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  const { headerRef } = useBottomSheetContext();
+
+  return (
+    <div
+      {...props}
+      className={cn(
+        "flex w-full cursor-grab touch-none justify-center pt-3 pb-5 select-none active:cursor-grabbing",
+        className,
+      )}
+      ref={headerRef}
+    >
+      {children ?? (
+        <div
+          aria-hidden="true"
+          className="h-1.5 w-12 rounded-full bg-gray-300"
+        />
+      )}
+    </div>
+  );
+}
+
+function Overlay({ className, ...props }: React.ComponentProps<"div">) {
+  const { handleClose, isVisible } = useBottomSheetContext();
+
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        "pointer-events-auto absolute inset-0 bg-black/50 transition-opacity duration-300",
+        isVisible ? "opacity-100" : "opacity-0",
+        className,
+      )}
+      onClick={handleClose}
+      {...props}
+    />
+  );
+}
+
+function Root({ children, isOpen, onClose }: BottomSheetRootProps) {
+  const bottomSheetLogic = useBottomSheet({ isOpen, onClose });
+  const titleId = useId();
+
+  if (!isOpen && !bottomSheetLogic.isVisible) {
+    return null;
+  }
+
+  return (
+    <Portal>
+      <BottomSheetContext value={{ ...bottomSheetLogic, titleId }}>
+        <div className="pointer-events-none fixed inset-0 z-50 flex items-end justify-center">
+          {children}
+        </div>
+      </BottomSheetContext>
+    </Portal>
+  );
+}
+
+function Title({ children, className, ...props }: React.ComponentProps<"h2">) {
+  const { titleId } = useBottomSheetContext();
+
+  return (
+    <h2
+      className={cn("text-lg font-bold", className)}
+      id={titleId}
+      tabIndex={-1}
+      {...props}
+    >
+      {children}
+    </h2>
+  );
+}
+
+function useBottomSheetContext() {
+  const context = useContext(BottomSheetContext);
+
+  if (!context) {
+    throw new Error(
+      "바텀시트 컴포넌트는 BottomSheet 아래에서 사용되어야 합니다.",
+    );
+  }
+  return context;
+}
+
+export const BottomSheet = Object.assign(Root, {
+  Body,
+  Content,
+  Header,
+  Overlay,
+  Title,
+});

--- a/components/ui/bottom-sheet/hooks/useBottomSheet.ts
+++ b/components/ui/bottom-sheet/hooks/useBottomSheet.ts
@@ -1,0 +1,352 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { useGesture } from "@/hooks";
+
+const ANIMATION_DURATION_MS = 300;
+const TRANSFORM_HIDDEN = "translateY(100%)";
+const TRANSFORM_VISIBLE = "translateY(0px)";
+
+// 여러 바텀시트가 동시에 열릴 때 scroll lock을 올바르게 관리하기 위한 Set
+const scrollLockOwners = new Set<object>();
+const VELOCITY_CLOSE_THRESHOLD = 0.5;
+const POSITION_CLOSE_RATIO = 0.3;
+const FOCUSABLE_ELEMENTS_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(", ");
+
+const getTitleElement = (sheet: HTMLElement): HTMLElement | null => {
+  const labelledElementId = sheet.getAttribute("aria-labelledby");
+  if (!labelledElementId) {
+    return null;
+  }
+
+  const titleElement = document.getElementById(labelledElementId);
+  return titleElement instanceof HTMLElement ? titleElement : null;
+};
+
+const getFocusableTargets = (sheet: HTMLElement) => {
+  const elements = sheet.querySelectorAll<HTMLElement>(
+    FOCUSABLE_ELEMENTS_SELECTOR,
+  );
+  return {
+    firstElement: elements[0] ?? null,
+    lastElement: elements[elements.length - 1] ?? null,
+    titleElement: getTitleElement(sheet),
+  };
+};
+
+type BottomSheetConfig = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export const useBottomSheet = ({ isOpen, onClose }: BottomSheetConfig) => {
+  const [isVisible, setIsVisible] = useState(false);
+  // isOpen이 false → true로 반복 전환될 때, isVisible이 이미 true여도
+  // 포커스 초기화 effect를 재실행하기 위한 카운터
+  const [openCount, setOpenCount] = useState(0);
+
+  const sheetRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const headerRef = useRef<HTMLDivElement>(null);
+
+  const prevFocusRef = useRef<HTMLElement | null>(null);
+  const isVisibleRef = useRef(false);
+  const isClosingRef = useRef(false);
+  const closeTimerRef = useRef<null | ReturnType<typeof setTimeout>>(null);
+  const transitionEndListenerRef = useRef<
+    ((e: TransitionEvent) => void) | null
+  >(null);
+  const attachedSheetRef = useRef<HTMLDivElement | null>(null);
+  const closeTokenRef = useRef(0);
+
+  const onCloseRef = useRef(onClose);
+
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current) {
+        clearTimeout(closeTimerRef.current);
+      }
+      if (transitionEndListenerRef.current && attachedSheetRef.current) {
+        attachedSheetRef.current.removeEventListener(
+          "transitionend",
+          transitionEndListenerRef.current,
+        );
+      }
+    };
+  }, []);
+
+  const handleClose = useCallback(() => {
+    const sheet = sheetRef.current;
+    if (!sheet || isClosingRef.current || !isVisibleRef.current) {
+      return;
+    }
+
+    // 닫히는 도중 다시 열릴 경우 이전 cleanup이 실행되지 않도록 토큰으로 무효화
+    closeTokenRef.current += 1;
+    const closeToken = closeTokenRef.current;
+    isClosingRef.current = true;
+
+    const cleanup = () => {
+      if (closeToken !== closeTokenRef.current) {
+        return;
+      }
+
+      if (closeTimerRef.current) {
+        clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = null;
+      }
+
+      if (transitionEndListenerRef.current && attachedSheetRef.current) {
+        attachedSheetRef.current.removeEventListener(
+          "transitionend",
+          transitionEndListenerRef.current,
+        );
+        transitionEndListenerRef.current = null;
+      }
+      attachedSheetRef.current = null;
+
+      isVisibleRef.current = false;
+      setIsVisible(false);
+      isClosingRef.current = false;
+      onCloseRef.current();
+
+      if (prevFocusRef.current) {
+        const isFocusInSheet = sheetRef.current?.contains(
+          document.activeElement,
+        );
+        const isFocusLost = document.activeElement === document.body;
+
+        if (isFocusInSheet || isFocusLost) {
+          prevFocusRef.current.focus();
+        }
+        prevFocusRef.current = null;
+      }
+    };
+
+    const onTransitionEnd = (e: TransitionEvent) => {
+      if (e.propertyName !== "transform" || e.target !== sheet) {
+        return;
+      }
+
+      if (!isClosingRef.current) {
+        return;
+      }
+
+      cleanup();
+    };
+
+    if (transitionEndListenerRef.current) {
+      sheet.removeEventListener(
+        "transitionend",
+        transitionEndListenerRef.current,
+      );
+    }
+
+    transitionEndListenerRef.current = onTransitionEnd;
+    attachedSheetRef.current = sheet;
+    sheet.addEventListener("transitionend", onTransitionEnd);
+    sheet.style.transform = TRANSFORM_HIDDEN;
+
+    closeTimerRef.current = setTimeout(() => {
+      if (isClosingRef.current) {
+        cleanup();
+      }
+    }, ANIMATION_DURATION_MS);
+  }, []);
+
+  useGesture({
+    enabled: isVisible,
+    handleRef: headerRef,
+    onDragEnd: ({ translateY, velocity }) => {
+      const sheet = sheetRef.current;
+      const isFastSwipe = velocity > VELOCITY_CLOSE_THRESHOLD;
+      const isDraggedEnough =
+        sheet !== null &&
+        translateY > sheet.offsetHeight * POSITION_CLOSE_RATIO;
+      const shouldClose = isFastSwipe || isDraggedEnough;
+
+      if (shouldClose) {
+        handleClose();
+      } else if (sheet) {
+        sheet.style.transform = TRANSFORM_VISIBLE;
+      }
+    },
+    scrollableRef: contentRef,
+    targetRef: sheetRef,
+  });
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        handleClose();
+        return;
+      }
+
+      if (e.key === "Tab" && sheetRef.current) {
+        const { firstElement, lastElement, titleElement } = getFocusableTargets(
+          sheetRef.current,
+        );
+
+        if (firstElement === null) {
+          e.preventDefault();
+          if (titleElement) {
+            titleElement.focus();
+          } else {
+            sheetRef.current.focus();
+          }
+          return;
+        }
+
+        if (!sheetRef.current.contains(document.activeElement)) {
+          e.preventDefault();
+          firstElement.focus();
+          return;
+        }
+
+        if (e.shiftKey) {
+          if (
+            document.activeElement === firstElement ||
+            document.activeElement === sheetRef.current
+          ) {
+            e.preventDefault();
+            lastElement.focus();
+          }
+        } else {
+          if (document.activeElement === lastElement) {
+            e.preventDefault();
+            firstElement.focus();
+          }
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, handleClose]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    closeTokenRef.current += 1;
+
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+
+    if (transitionEndListenerRef.current && attachedSheetRef.current) {
+      attachedSheetRef.current.removeEventListener(
+        "transitionend",
+        transitionEndListenerRef.current,
+      );
+      transitionEndListenerRef.current = null;
+    }
+
+    prevFocusRef.current = document.activeElement as HTMLElement;
+    isClosingRef.current = false;
+
+    // Content의 초기 transform(translateY(100%))이 DOM에 먼저 적용된 후
+    // 애니메이션이 시작되도록 렌더링 이후 다음 태스크로 지연
+    const timer = setTimeout(() => {
+      isVisibleRef.current = true;
+      setIsVisible(true);
+      setOpenCount((c) => c + 1);
+    }, 0);
+
+    return () => clearTimeout(timer);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isVisible || !sheetRef.current || isClosingRef.current) {
+      return;
+    }
+
+    let raf2: number | undefined;
+
+    const raf1 = requestAnimationFrame(() => {
+      raf2 = requestAnimationFrame(() => {
+        if (sheetRef.current) {
+          const { firstElement, titleElement } = getFocusableTargets(
+            sheetRef.current,
+          );
+
+          sheetRef.current.style.transform = TRANSFORM_VISIBLE;
+          if (firstElement) {
+            firstElement.focus();
+            return;
+          }
+
+          if (titleElement) {
+            titleElement.focus();
+            return;
+          }
+
+          sheetRef.current.focus();
+        }
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(raf1);
+      if (raf2) {
+        cancelAnimationFrame(raf2);
+      }
+    };
+  }, [isVisible, openCount]);
+
+  useEffect(() => {
+    if (isOpen) {
+      return;
+    }
+    if (!isVisible || isClosingRef.current) {
+      return;
+    }
+
+    handleClose();
+  }, [isOpen, isVisible, handleClose]);
+
+  useEffect(() => {
+    if (!isVisible) {
+      return;
+    }
+
+    const token = {};
+    scrollLockOwners.add(token);
+
+    if (scrollLockOwners.size === 1) {
+      document.documentElement.style.scrollbarGutter = "stable";
+      document.body.style.overflow = "hidden";
+      document.body.style.overscrollBehavior = "none";
+    }
+
+    return () => {
+      scrollLockOwners.delete(token);
+
+      if (scrollLockOwners.size === 0) {
+        document.documentElement.style.scrollbarGutter = "";
+        document.body.style.overflow = "";
+        document.body.style.overscrollBehavior = "";
+      }
+    };
+  }, [isVisible]);
+
+  return { contentRef, handleClose, headerRef, isVisible, sheetRef };
+};

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -1,2 +1,3 @@
+export { BottomSheet } from "./bottom-sheet/BottomSheet";
 export { Button } from "./button/Button";
 export { Tabs } from "./tabs/Tabs";

--- a/hooks/useGesture.ts
+++ b/hooks/useGesture.ts
@@ -100,6 +100,7 @@ export const useGesture = ({
       if (isHandleTouched) {
         return true;
       }
+      // 시트가 이미 아래로 내려간 상태에서는 스크롤 영역 밖이어도 드래그 허용
       if (touchStart.targetY > 0 && !isScrollableTouched) {
         return true;
       }
@@ -312,7 +313,8 @@ export const useGesture = ({
 
       target.style.willChange = "";
       target.style.transition = "";
-      target.style.transform = "";
+      // transform은 외부에서 닫기 애니메이션으로 관리하므로 여기서는 초기화하지 않음
+      // (초기화 시 애니메이션이 끝나기 전에 요소가 순간적으로 원위치로 표시될 수 있음)
     };
   }, [targetRef, scrollableRef, handleRef, rubberBand, enabled]);
 };

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./cn";


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #33

## 📌 작업 내용

- BottomSheet.tsx: Compound Component 패턴으로 Root, Body, Content, Header, Overlay, Title 서브컴포넌트 구현
- useBottomSheet.ts: 열기/닫기 애니메이션, 포커스 트랩(Tab/Shift+Tab/Escape), 스크롤 락, 드래그 제스처 연동 로직 구현
- BottomSheet.stories.tsx: Default, WithLongContent, WithCustomHeader, WithActions 스토리 추가
- hooks/useGesture.ts: 닫기 애니메이션 충돌 방지를 위해 드래그 종료 시 transform 초기화 제거
- lib/utils/index.ts: cn 유틸리티 barrel export 추가
- components/ui/index.ts: BottomSheet export 추가


