### PR TITLE
fix: 데스크톱 스크롤 영역에서 바텀시트가 드래그되는 문제 수정(#45)

### DIFF
--- a/hooks/useGesture.ts
+++ b/hooks/useGesture.ts
@@ -101,6 +101,11 @@ export const useGesture = ({
       if (isHandleTouched) {
         return true;
       }
+
+      if (e instanceof MouseEvent) {
+        return false;
+      }
+
       if (
         !isScrollableTouched &&
         canDragFromScrollableEvent(touchStart.targetY)
@@ -111,8 +116,10 @@ export const useGesture = ({
         return true;
       }
 
-      if (isScrollableTouched && touchMove.movingDirection === "down") {
-        return (scrollable?.scrollTop ?? 0) === 0;
+      if (isScrollableTouched) {
+        if (touchMove.movingDirection === "down") {
+          return (scrollable?.scrollTop ?? 0) < 1;
+        }
       }
 
       return false;


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #45

## 📌 작업 내용

- canDrag에 MouseEvent 조기 반환 추가로 스크롤 영역 드래그 차단
- scrollTop 소수점 대응을 위해 === 0 비교를 < 1로 변경


