### PR TITLE
feat: useDrag 훅 추가(#49)

### DIFF
--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -1,2 +1,3 @@
+export * from "./useDrag";
 export * from "./useGesture";
 export * from "./useIsMounted";

--- a/hooks/useDrag.ts
+++ b/hooks/useDrag.ts
@@ -1,0 +1,161 @@
+"use client";
+
+import { RefObject, useEffect, useEffectEvent, useRef } from "react";
+
+import { VelocityTracker } from "@/lib/utils";
+
+const RUBBER_BAND_FRICTION = 3.5;
+
+const getTranslateY = (element: HTMLElement): number => {
+  try {
+    const transform = window.getComputedStyle(element).transform;
+
+    if (!transform || transform === "none") {
+      return 0;
+    }
+
+    return new DOMMatrix(transform).m42;
+  } catch {
+    return 0;
+  }
+};
+
+type DragConfig = {
+  enabled: boolean;
+  handleRef?: RefObject<HTMLElement | null>;
+  onDragEnd: (state: DragEndState) => void;
+  targetRef: RefObject<HTMLElement | null>;
+};
+
+type DragEndState = {
+  translateY: number;
+  velocity: number;
+};
+
+export const useDrag = ({
+  enabled,
+  handleRef,
+  onDragEnd,
+  targetRef,
+}: DragConfig) => {
+  const onDragEndEvent = useEffectEvent(onDragEnd);
+
+  const activePointerIdRef = useRef<null | number>(null);
+  const startYRef = useRef(0);
+  const startTargetYRef = useRef(0);
+  const hasDraggedRef = useRef(false);
+  const latestTranslateYRef = useRef(0);
+  const rafRef = useRef<null | number>(null);
+  const velocityTrackerRef = useRef(new VelocityTracker());
+
+  useEffect(() => {
+    if (!enabled || !targetRef.current) {
+      return;
+    }
+
+    const target = targetRef.current;
+    const handle = handleRef?.current ?? null;
+
+    const handlePointerDown = (e: PointerEvent) => {
+      // 멀티터치 방어: 이미 드래그 중이면 무시
+      if (activePointerIdRef.current !== null) {
+        return;
+      }
+
+      const isFromHandle = handle ? handle.contains(e.target as Node) : true;
+      if (!isFromHandle) {
+        return;
+      }
+
+      activePointerIdRef.current = e.pointerId;
+      target.setPointerCapture(e.pointerId);
+
+      const targetY = getTranslateY(target);
+      startYRef.current = e.clientY;
+      startTargetYRef.current = targetY;
+      hasDraggedRef.current = false;
+      latestTranslateYRef.current = targetY;
+
+      velocityTrackerRef.current.reset();
+      velocityTrackerRef.current.track(e.clientY, performance.now());
+
+      target.style.willChange = "transform";
+      target.style.transition = "none";
+    };
+
+    const handlePointerMove = (e: PointerEvent) => {
+      if (e.pointerId !== activePointerIdRef.current) {
+        return;
+      }
+
+      velocityTrackerRef.current.track(e.clientY, performance.now());
+
+      hasDraggedRef.current = true;
+
+      const moveDistance = e.clientY - startYRef.current;
+      const newY = startTargetYRef.current + moveDistance;
+      const nextTranslateY = newY < 0 ? newY / RUBBER_BAND_FRICTION : newY;
+
+      latestTranslateYRef.current = nextTranslateY;
+
+      if (rafRef.current !== null) {
+        return;
+      }
+
+      rafRef.current = requestAnimationFrame(() => {
+        target.style.transform = `translateY(${latestTranslateYRef.current}px)`;
+        rafRef.current = null;
+      });
+    };
+
+    const handlePointerUp = (e: PointerEvent) => {
+      if (e.pointerId !== activePointerIdRef.current) {
+        return;
+      }
+
+      activePointerIdRef.current = null;
+
+      if (target.hasPointerCapture(e.pointerId)) {
+        target.releasePointerCapture(e.pointerId);
+      }
+
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+
+      target.style.willChange = "";
+      target.style.transition = "";
+
+      if (!hasDraggedRef.current) {
+        return;
+      }
+
+      onDragEndEvent({
+        translateY: latestTranslateYRef.current,
+        velocity: velocityTrackerRef.current.getVelocity(),
+      });
+    };
+
+    target.addEventListener("pointerdown", handlePointerDown);
+    target.addEventListener("pointermove", handlePointerMove);
+    target.addEventListener("pointerup", handlePointerUp);
+    target.addEventListener("pointercancel", handlePointerUp);
+
+    return () => {
+      target.removeEventListener("pointerdown", handlePointerDown);
+      target.removeEventListener("pointermove", handlePointerMove);
+      target.removeEventListener("pointerup", handlePointerUp);
+      target.removeEventListener("pointercancel", handlePointerUp);
+
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+
+      target.style.willChange = "";
+      target.style.transition = "";
+      activePointerIdRef.current = null;
+    };
+  }, [targetRef, handleRef, enabled]);
+};


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #49

## 📌 작업 내용

- pointerdown/pointermove/pointerup/pointercancel 4개 이벤트만 target에 부착
- setPointerCapture로 pointermove/pointerup을 target에서 직접 수신
- activePointerIdRef로 멀티터치 방어 (첫 번째 포인터만 처리)
- canDrag 로직을 handle 포함 여부 체크만으로 단순화
- VelocityTracker를 내부에서 생성해 px/s 단위 속도 계산
- 아래 복잡성 제거: window 리스너 등록/해제, touch/mouse 분기, getClientY 헬퍼, isMouseDraggingRef, passive: false, scrollTop/movingDirection/canDragFromScrollable 체크


