### PR TITLE
fix: useDrag capture 지연 및 Overlay onClick 버그 수정(#61)

### DIFF
--- a/components/ui/bottom-sheet/BottomSheet.tsx
+++ b/components/ui/bottom-sheet/BottomSheet.tsx
@@ -116,7 +116,10 @@ function Overlay({ className, ...props }: React.ComponentProps<"div">) {
         isVisible ? "opacity-100" : "opacity-0",
         className,
       )}
-      onClick={() => handleClose()}
+      onClick={(e) => {
+        handleClose();
+        props.onClick?.(e);
+      }}
     />
   );
 }

--- a/hooks/useDrag.ts
+++ b/hooks/useDrag.ts
@@ -68,6 +68,7 @@ export const useDrag = ({
       }
 
       activePointerIdRef.current = e.pointerId;
+      target.setPointerCapture(e.pointerId);
 
       const targetY = getTranslateY(target);
       startYRef.current = e.clientY;
@@ -87,8 +88,6 @@ export const useDrag = ({
       velocityTrackerRef.current.track(e.clientY, performance.now());
 
       if (!hasDraggedRef.current) {
-        // 첫 move 시점에 capture — click 이벤트 억제를 방지하기 위해 pointerdown에서 지연
-        target.setPointerCapture(e.pointerId);
         target.style.willChange = "transform";
         target.style.transition = "none";
       }
@@ -133,6 +132,13 @@ export const useDrag = ({
       if (!hasDraggedRef.current) {
         return;
       }
+
+      // setPointerCapture를 pointerdown에서 설정하면 capture된 상태에서
+      // pointerup이 발생해 click이 억제될 수 있으므로, 드래그 완료 시 명시적으로 억제
+      target.addEventListener("click", (e) => e.stopPropagation(), {
+        capture: true,
+        once: true,
+      });
 
       onDragEndEvent({
         translateY: latestTranslateYRef.current,


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #61

## 📌 작업 내용

- useDrag: setPointerCapture를 pointermove에서 pointerdown으로 이동
  - pointermove 발생 전 포인터가 target을 벗어나면 capture가 설정되지 않아 추적이 끊기는 엣지케이스 대응
- useDrag: 드래그 완료 시 click 이벤트를 명시적으로 억제
  - pointerdown capture로 인해 drageend 후 click이 발생하는 것을 방지
  - hasDraggedRef가 false면(탭/클릭) click이 자연스럽게 허용됨
- Overlay: {...props} 이후에 onClick을 덮어쓰던 버그 수정
  - handleClose와 props.onClick을 합성해 외부 핸들러가 무시되지 않도록 처리


