### PR TITLE
ci: supabase 프리티어 정지를 막기 위한 깃허브 액션 추가(#63)

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,16 @@
+name: Keep Supabase Alive
+
+on:
+  schedule:
+    - cron: "0 0 * * 1" # 매주 월요일 자정 실행 (UTC)
+  workflow_dispatch:
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Supabase
+        run: |
+          curl -s "https://${{ secrets.SUPABASE_PROJECT_REF }}.supabase.co/rest/v1/" \
+            -H "apikey: ${{ secrets.SUPABASE_PUBLISHABLE_KEY }}" \
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_PUBLISHABLE_KEY }}"


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #63

## 📌 작업 내용

- keep-alive.yml 추가


