### PR TITLE
feat: 인증 기반 라우팅 및 protected 페이지 구조 추가 (#71)

### DIFF
--- a/app/(protected)/_components/Header.tsx
+++ b/app/(protected)/_components/Header.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { LogOut } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button/Button";
+import { createClient } from "@/lib/supabase/client";
+
+export function Header() {
+  const router = useRouter();
+  const supabase = createClient();
+
+  async function handleLogout() {
+    await supabase.auth.signOut();
+    router.push("/");
+  }
+
+  return (
+    <header className="flex items-center justify-between border-b px-6 py-3">
+      <span className="text-lg font-bold">201</span>
+      <Button onClick={handleLogout} size="sm" variant="ghost">
+        <LogOut />
+        로그아웃
+      </Button>
+    </header>
+  );
+}

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1,0 +1,7 @@
+export default function DashboardPage() {
+  return (
+    <div>
+      <h1>Dashboard</h1>
+    </div>
+  );
+}

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -1,0 +1,16 @@
+export const dynamic = "force-dynamic";
+
+import { Header } from "./_components/Header";
+
+export default function ProtectedLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <Header />
+      {children}
+    </>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,13 @@
 @import "tailwindcss";
 
+@layer base {
+  html,
+  body {
+    width: 100%;
+    height: 100%;
+  }
+}
+
 @theme {
   /* Base */
   --color-background: #ffffff;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,18 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button/Button";
+
 export default function Home() {
   return (
-    <div>
-      <h1>Hello World</h1>
+    <div className="flex h-full flex-col justify-center gap-2 p-4">
+      <h1 className="flex flex-col text-4xl font-light">
+        <span>201</span>
+        <span>Escape</span>
+      </h1>
+      <p>개인 채용 공고 관리 대시보드</p>
+      <Button asChild size={"lg"}>
+        <Link href="/login">로그인</Link>
+      </Button>
     </div>
   );
 }

--- a/lib/supabase/proxy.ts
+++ b/lib/supabase/proxy.ts
@@ -40,15 +40,22 @@ export async function updateSession(request: NextRequest) {
   const { data } = await supabase.auth.getClaims();
 
   const user = data?.claims;
+  const { pathname } = request.nextUrl;
 
-  if (
-    !user &&
-    !request.nextUrl.pathname.startsWith("/login") &&
-    !request.nextUrl.pathname.startsWith("/auth")
-  ) {
-    // no user, potentially respond by redirecting the user to the login page
+  const isPublicPath =
+    pathname === "/" ||
+    pathname.startsWith("/login") ||
+    pathname.startsWith("/auth");
+
+  if (!user && !isPublicPath) {
     const url = request.nextUrl.clone();
     url.pathname = "/login";
+    return NextResponse.redirect(url);
+  }
+
+  if (user && pathname === "/") {
+    const url = request.nextUrl.clone();
+    url.pathname = "/dashboard";
     return NextResponse.redirect(url);
   }
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "cheerio": "^1.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "lucide-react": "^0.577.0",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      lucide-react:
+        specifier: ^0.577.0
+        version: 0.577.0(react@19.2.3)
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.28.6)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -4134,6 +4137,14 @@ packages:
         integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==,
       }
 
+  lucide-react@0.577.0:
+    resolution:
+      {
+        integrity: sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==,
+      }
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   lz-string@1.5.0:
     resolution:
       {
@@ -8165,6 +8176,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@0.577.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
 
   lz-string@1.5.0: {}
 


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #71

## 📌 작업 내용

- 메인 페이지(/)를 비로그인 접근 허용으로 변경
- 로그인 상태에서 / 접근 시 /dashboard로 리다이렉트
- app/(protected) 폴더 및 dashboard 페이지 생성
- protected 레이아웃에 헤더(로고 + 로그아웃 버튼) 추가
- globals.css에 html/body 전체 높이 베이스 스타일 추가
- lucide-react 라이브러리 추가

