### PR TITLE
feat: 대시보드 지원 현황 UI 구현(#73)

### DIFF
--- a/app/(protected)/dashboard/_components/dashboard-view/DashboardView.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DashboardView.tsx
@@ -1,0 +1,34 @@
+import { cn, formatKoreanDate } from "@/lib/utils";
+
+import { ApplicationTabs } from "./components/ApplicationTabs";
+import { STATS } from "./mock-data";
+
+export function DashboardView() {
+  return (
+    <main className="flex flex-col">
+      <div className="px-5 pt-6 pb-5">
+        <p className="text-muted-foreground">{formatKoreanDate(new Date())}</p>
+        <h1 className="mt-0.5 text-3xl text-foreground">지원 현황</h1>
+      </div>
+
+      <div className="grid grid-cols-4 border-y border-border">
+        {STATS.map((stat, i) => (
+          <div
+            className={cn(
+              "flex flex-col items-center gap-1 py-5",
+              i < STATS.length - 1 && "border-r border-border",
+            )}
+            key={stat.label}
+          >
+            <span className="text-xl font-bold text-foreground">
+              {stat.value}
+            </span>
+            <span className="text-sm text-muted-foreground">{stat.label}</span>
+          </div>
+        ))}
+      </div>
+
+      <ApplicationTabs />
+    </main>
+  );
+}

--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationList.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationList.tsx
@@ -1,0 +1,32 @@
+import { Inbox } from "lucide-react";
+
+import type { ApplicationItem } from "../types";
+
+import { ApplicationRow } from "./ApplicationRow";
+
+type ApplicationListProps = {
+  applications: ApplicationItem[];
+  emptyMessage?: string;
+};
+
+export function ApplicationList({
+  applications,
+  emptyMessage = "해당하는 지원 내역이 없습니다",
+}: ApplicationListProps) {
+  if (applications.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-16 text-muted-foreground">
+        <Inbox className="size-8 stroke-[1.5]" />
+        <p className="text-sm">{emptyMessage}</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {applications.map((application) => (
+        <ApplicationRow application={application} key={application.id} />
+      ))}
+    </>
+  );
+}

--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationRow.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationRow.tsx
@@ -1,0 +1,38 @@
+import { cn, getTimeAgo } from "@/lib/utils";
+
+import type { ApplicationItem } from "../types";
+
+import { PLATFORM_LABEL, STATUS_META } from "../constants";
+
+type ApplicationRowProps = {
+  application: ApplicationItem;
+};
+
+export function ApplicationRow({ application }: ApplicationRowProps) {
+  const { color, label } = STATUS_META[application.status];
+
+  return (
+    <div className="flex items-start justify-between border-b border-border py-4">
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-col">
+          <span className="text-[15px] font-semibold text-foreground">
+            {application.companyName}
+          </span>
+          <span className="text-sm text-muted-foreground">
+            {application.positionTitle}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className={cn("text-sm font-medium", color)}>{label}</span>
+          <span className="text-sm text-muted-foreground">·</span>
+          <span className="text-sm text-muted-foreground">
+            {PLATFORM_LABEL[application.platform]}
+          </span>
+        </div>
+      </div>
+      <span className="shrink-0 text-sm text-muted-foreground">
+        {getTimeAgo(application.appliedAt)}
+      </span>
+    </div>
+  );
+}

--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationTabs.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationTabs.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Tabs } from "@/components/ui";
+
+import { DONE_STATUSES, IN_PROGRESS_STATUSES } from "../constants";
+import { MOCK_APPLICATIONS } from "../mock-data";
+import { ApplicationList } from "./ApplicationList";
+
+const TAB_TRIGGER_CLASS =
+  "h-12 flex-1 rounded-none border-b-2 border-transparent px-0 text-muted-foreground data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none";
+
+export function ApplicationTabs() {
+  const inProgressApplications = MOCK_APPLICATIONS.filter((a) =>
+    IN_PROGRESS_STATUSES.includes(a.status),
+  );
+  const doneApplications = MOCK_APPLICATIONS.filter((a) =>
+    DONE_STATUSES.includes(a.status),
+  );
+
+  return (
+    <Tabs defaultValue="all">
+      <Tabs.List className="h-auto w-full rounded-none border-b border-border bg-transparent p-0">
+        <Tabs.Trigger className={TAB_TRIGGER_CLASS} value="all">
+          전체
+        </Tabs.Trigger>
+        <Tabs.Trigger className={TAB_TRIGGER_CLASS} value="active">
+          진행중
+        </Tabs.Trigger>
+        <Tabs.Trigger className={TAB_TRIGGER_CLASS} value="done">
+          완료
+        </Tabs.Trigger>
+      </Tabs.List>
+
+      <Tabs.Content className="mt-0 px-5" value="all">
+        <ApplicationList
+          applications={MOCK_APPLICATIONS}
+          emptyMessage="아직 지원한 곳이 없습니다"
+        />
+      </Tabs.Content>
+      <Tabs.Content className="mt-0 px-5" value="active">
+        <ApplicationList
+          applications={inProgressApplications}
+          emptyMessage="진행 중인 지원이 없습니다"
+        />
+      </Tabs.Content>
+      <Tabs.Content className="mt-0 px-5" value="done">
+        <ApplicationList
+          applications={doneApplications}
+          emptyMessage="완료된 지원이 없습니다"
+        />
+      </Tabs.Content>
+    </Tabs>
+  );
+}

--- a/app/(protected)/dashboard/_components/dashboard-view/constants.ts
+++ b/app/(protected)/dashboard/_components/dashboard-view/constants.ts
@@ -1,0 +1,24 @@
+import { JobPlatform, JobStatus } from "@/lib/types/job";
+
+export const STATUS_META: Record<JobStatus, { color: string; label: string }> =
+  {
+    APPLIED: { color: "text-primary", label: "서류 제출" },
+    DOCS_PASSED: { color: "text-blue-700", label: "서류 통과" },
+    INTERVIEWING: { color: "text-amber-700", label: "면접 중" },
+    OFFERED: { color: "text-emerald-700", label: "최종 합격" },
+    REJECTED: { color: "text-muted-foreground", label: "불합격" },
+  };
+
+export const PLATFORM_LABEL: Record<JobPlatform, string> = {
+  LINKEDIN: "LinkedIn",
+  MANUAL: "직접 입력",
+  SARAMIN: "사람인",
+  WANTED: "원티드",
+};
+
+export const IN_PROGRESS_STATUSES: JobStatus[] = [
+  "APPLIED",
+  "DOCS_PASSED",
+  "INTERVIEWING",
+];
+export const DONE_STATUSES: JobStatus[] = ["OFFERED", "REJECTED"];

--- a/app/(protected)/dashboard/_components/dashboard-view/index.ts
+++ b/app/(protected)/dashboard/_components/dashboard-view/index.ts
@@ -1,0 +1,1 @@
+export { DashboardView } from "./DashboardView";

--- a/app/(protected)/dashboard/_components/dashboard-view/mock-data.ts
+++ b/app/(protected)/dashboard/_components/dashboard-view/mock-data.ts
@@ -1,0 +1,78 @@
+import type { ApplicationItem } from "./types";
+
+export const MOCK_APPLICATIONS: ApplicationItem[] = [
+  {
+    appliedAt: "2026-03-09",
+    companyName: "토스",
+    id: "1",
+    platform: "WANTED",
+    positionTitle: "프론트엔드 엔지니어",
+    status: "APPLIED",
+  },
+  {
+    appliedAt: "2026-03-11",
+    companyName: "카카오",
+    id: "2",
+    platform: "SARAMIN",
+    positionTitle: "백엔드 엔지니어",
+    status: "INTERVIEWING",
+  },
+  {
+    appliedAt: "2026-03-08",
+    companyName: "네이버",
+    id: "3",
+    platform: "LINKEDIN",
+    positionTitle: "UI/UX 디자이너",
+    status: "DOCS_PASSED",
+  },
+  {
+    appliedAt: "2026-03-10",
+    companyName: "라인",
+    id: "4",
+    platform: "WANTED",
+    positionTitle: "프론트엔드 엔지니어",
+    status: "OFFERED",
+  },
+  {
+    appliedAt: "2026-03-06",
+    companyName: "쿠팡",
+    id: "5",
+    platform: "MANUAL",
+    positionTitle: "백엔드 엔지니어",
+    status: "REJECTED",
+  },
+  {
+    appliedAt: "2026-03-11",
+    companyName: "당근",
+    id: "6",
+    platform: "LINKEDIN",
+    positionTitle: "프로덕트 매니저",
+    status: "INTERVIEWING",
+  },
+  {
+    appliedAt: "2026-03-11",
+    companyName: "배달의민족",
+    id: "7",
+    platform: "SARAMIN",
+    positionTitle: "iOS 개발자",
+    status: "APPLIED",
+  },
+];
+
+export const STATS = [
+  { label: "전체", value: MOCK_APPLICATIONS.length },
+  {
+    label: "서류",
+    value: MOCK_APPLICATIONS.filter(
+      (a) => a.status === "APPLIED" || a.status === "DOCS_PASSED",
+    ).length,
+  },
+  {
+    label: "면접",
+    value: MOCK_APPLICATIONS.filter((a) => a.status === "INTERVIEWING").length,
+  },
+  {
+    label: "합격",
+    value: MOCK_APPLICATIONS.filter((a) => a.status === "OFFERED").length,
+  },
+];

--- a/app/(protected)/dashboard/_components/dashboard-view/types.ts
+++ b/app/(protected)/dashboard/_components/dashboard-view/types.ts
@@ -1,0 +1,10 @@
+import type { JobPlatform, JobStatus } from "@/lib/types/job";
+
+export type ApplicationItem = {
+  appliedAt: string;
+  companyName: string;
+  id: string;
+  platform: JobPlatform;
+  positionTitle: string;
+  status: JobStatus;
+};

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1,7 +1,5 @@
+import { DashboardView } from "./_components/dashboard-view";
+
 export default function DashboardPage() {
-  return (
-    <div>
-      <h1>Dashboard</h1>
-    </div>
-  );
+  return <DashboardView />;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -14,7 +14,7 @@
   --color-foreground: #171717;
 
   /* Primary */
-  --color-primary: #3f503a;
+  --color-primary: #40513b;
   --color-primary-foreground: #ffffff;
 
   /* Secondary */
@@ -36,5 +36,5 @@
   /* Border / Input / Ring */
   --color-border: #e5e5e5;
   --color-input: #e5e5e5;
-  --color-ring: #3f503a;
+  --color-ring: #40513b;
 }

--- a/lib/utils/date.ts
+++ b/lib/utils/date.ts
@@ -1,0 +1,21 @@
+const DAY_NAMES = ["일", "월", "화", "수", "목", "금", "토"] as const;
+
+export function formatKoreanDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const dayName = DAY_NAMES[date.getDay()];
+
+  return `${year}년 ${month}월 ${day}일 ${dayName}요일`;
+}
+
+export function getTimeAgo(dateString: string): string {
+  const diffMs = new Date().getTime() - new Date(dateString).getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) {
+    return "오늘";
+  }
+
+  return `${diffDays}일 전`;
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./cn";
+export * from "./date";
 export * from "./SpringAnimator";
 export * from "./VelocityTracker";


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #73

## 📌 작업 내용

- 지원 현황 통계, 탭별 지원 목록 UI 구현
- getTimeAgo, formatKoreanDate 날짜 유틸 추가
- globals.css의 color-primary를 #40513b로 변경

