### PR TITLE
feat: SAVED 상태 추가 및 공고 등록 기본값 변경(#79)

### DIFF
--- a/app/(protected)/dashboard/_components/dashboard-view/constants.ts
+++ b/app/(protected)/dashboard/_components/dashboard-view/constants.ts
@@ -7,6 +7,7 @@ export const STATUS_META: Record<JobStatus, { color: string; label: string }> =
     INTERVIEWING: { color: "text-amber-700", label: "면접 중" },
     OFFERED: { color: "text-emerald-700", label: "최종 합격" },
     REJECTED: { color: "text-muted-foreground", label: "불합격" },
+    SAVED: { color: "text-slate-500", label: "관심 공고" },
   };
 
 export const PLATFORM_LABEL: Record<JobPlatform, string> = {
@@ -18,6 +19,7 @@ export const PLATFORM_LABEL: Record<JobPlatform, string> = {
 
 export const DOCS_STATUSES: JobStatus[] = ["APPLIED", "DOCS_PASSED"];
 export const IN_PROGRESS_STATUSES: JobStatus[] = [
+  "SAVED",
   "APPLIED",
   "DOCS_PASSED",
   "INTERVIEWING",

--- a/lib/types/job.ts
+++ b/lib/types/job.ts
@@ -23,7 +23,7 @@ export type UserId = Brand<string, "UserId">;
 export const MANUAL_JOB_DEFAULTS = {
   companyName: "회사명 미입력",
   platform: "MANUAL",
-  status: "APPLIED",
+  status: "SAVED",
   title: "제목 없는 공고",
   url: "",
 } satisfies Pick<
@@ -34,7 +34,7 @@ export const MANUAL_JOB_DEFAULTS = {
 export const WANTED_JOB_DEFAULTS = {
   companyName: "회사명 미입력",
   platform: "WANTED",
-  status: "APPLIED",
+  status: "SAVED",
   title: "제목 없는 공고",
   url: "",
 } satisfies Pick<
@@ -45,7 +45,7 @@ export const WANTED_JOB_DEFAULTS = {
 export const SARAMIN_JOB_DEFAULTS = {
   companyName: "회사명 미입력",
   platform: "SARAMIN",
-  status: "APPLIED",
+  status: "SAVED",
   title: "제목 없는 공고",
   url: "",
 } satisfies Pick<

--- a/lib/types/supabase.ts
+++ b/lib/types/supabase.ts
@@ -3,218 +3,219 @@ export type CompositeTypes<
     | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
   : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
     ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-    : never
+    : never;
 
 export type Database = {
   // Allows to automatically instantiate createClient with right options
   // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
-    PostgrestVersion: "14.1"
-  }
+    PostgrestVersion: "14.1";
+  };
   public: {
     CompositeTypes: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Enums: {
-      interview_type: "CULTURE" | "FINAL" | "HR" | "OTHER" | "TECH"
-      job_platform: "LINKEDIN" | "MANUAL" | "SARAMIN" | "WANTED"
+      interview_type: "CULTURE" | "FINAL" | "HR" | "OTHER" | "TECH";
+      job_platform: "LINKEDIN" | "MANUAL" | "SARAMIN" | "WANTED";
       job_status:
         | "APPLIED"
         | "DOCS_PASSED"
         | "INTERVIEWING"
         | "OFFERED"
         | "REJECTED"
-    }
+        | "SAVED";
+    };
     Functions: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Tables: {
       applications: {
         Insert: {
-          applied_at?: string
-          created_at?: string
-          id?: string
-          job_id: string
-          notes?: null | string
-          status?: Database["public"]["Enums"]["job_status"]
-          updated_at?: string
-          user_id: string
-        }
+          applied_at?: string;
+          created_at?: string;
+          id?: string;
+          job_id: string;
+          notes?: null | string;
+          status?: Database["public"]["Enums"]["job_status"];
+          updated_at?: string;
+          user_id: string;
+        };
         Relationships: [
           {
-            columns: ["job_id"]
-            foreignKeyName: "applications_job_id_fkey"
-            isOneToOne: false
-            referencedColumns: ["id"]
-            referencedRelation: "jobs"
+            columns: ["job_id"];
+            foreignKeyName: "applications_job_id_fkey";
+            isOneToOne: false;
+            referencedColumns: ["id"];
+            referencedRelation: "jobs";
           },
-        ]
+        ];
         Row: {
-          applied_at: string
-          created_at: string
-          id: string
-          job_id: string
-          notes: null | string
-          status: Database["public"]["Enums"]["job_status"]
-          updated_at: string
-          user_id: string
-        }
+          applied_at: string;
+          created_at: string;
+          id: string;
+          job_id: string;
+          notes: null | string;
+          status: Database["public"]["Enums"]["job_status"];
+          updated_at: string;
+          user_id: string;
+        };
         Update: {
-          applied_at?: string
-          created_at?: string
-          id?: string
-          job_id?: string
-          notes?: null | string
-          status?: Database["public"]["Enums"]["job_status"]
-          updated_at?: string
-          user_id?: string
-        }
-      }
+          applied_at?: string;
+          created_at?: string;
+          id?: string;
+          job_id?: string;
+          notes?: null | string;
+          status?: Database["public"]["Enums"]["job_status"];
+          updated_at?: string;
+          user_id?: string;
+        };
+      };
       interviews: {
         Insert: {
-          application_id: string
-          created_at?: string
-          id?: string
-          interview_type: Database["public"]["Enums"]["interview_type"]
-          is_draft?: boolean
-          location?: null | string
-          round: number
-          scheduled_at: string
-          scratchpad?: null | string
-          updated_at?: string
-        }
+          application_id: string;
+          created_at?: string;
+          id?: string;
+          interview_type: Database["public"]["Enums"]["interview_type"];
+          is_draft?: boolean;
+          location?: null | string;
+          round: number;
+          scheduled_at: string;
+          scratchpad?: null | string;
+          updated_at?: string;
+        };
         Relationships: [
           {
-            columns: ["application_id"]
-            foreignKeyName: "interviews_application_id_fkey"
-            isOneToOne: false
-            referencedColumns: ["id"]
-            referencedRelation: "applications"
+            columns: ["application_id"];
+            foreignKeyName: "interviews_application_id_fkey";
+            isOneToOne: false;
+            referencedColumns: ["id"];
+            referencedRelation: "applications";
           },
-        ]
+        ];
         Row: {
-          application_id: string
-          created_at: string
-          id: string
-          interview_type: Database["public"]["Enums"]["interview_type"]
-          is_draft: boolean
-          location: null | string
-          round: number
-          scheduled_at: string
-          scratchpad: null | string
-          updated_at: string
-        }
+          application_id: string;
+          created_at: string;
+          id: string;
+          interview_type: Database["public"]["Enums"]["interview_type"];
+          is_draft: boolean;
+          location: null | string;
+          round: number;
+          scheduled_at: string;
+          scratchpad: null | string;
+          updated_at: string;
+        };
         Update: {
-          application_id?: string
-          created_at?: string
-          id?: string
-          interview_type?: Database["public"]["Enums"]["interview_type"]
-          is_draft?: boolean
-          location?: null | string
-          round?: number
-          scheduled_at?: string
-          scratchpad?: null | string
-          updated_at?: string
-        }
-      }
+          application_id?: string;
+          created_at?: string;
+          id?: string;
+          interview_type?: Database["public"]["Enums"]["interview_type"];
+          is_draft?: boolean;
+          location?: null | string;
+          round?: number;
+          scheduled_at?: string;
+          scratchpad?: null | string;
+          updated_at?: string;
+        };
+      };
       job_snapshots: {
         Insert: {
-          created_at?: string
-          id?: string
-          job_id: string
-          raw_data?: Json | null
-          updated_at?: string
-          user_id: string
-        }
+          created_at?: string;
+          id?: string;
+          job_id: string;
+          raw_data?: Json | null;
+          updated_at?: string;
+          user_id: string;
+        };
         Relationships: [
           {
-            columns: ["job_id"]
-            foreignKeyName: "job_snapshots_job_id_fkey"
-            isOneToOne: false
-            referencedColumns: ["id"]
-            referencedRelation: "jobs"
+            columns: ["job_id"];
+            foreignKeyName: "job_snapshots_job_id_fkey";
+            isOneToOne: false;
+            referencedColumns: ["id"];
+            referencedRelation: "jobs";
           },
-        ]
+        ];
         Row: {
-          created_at: string
-          id: string
-          job_id: string
-          raw_data: Json | null
-          updated_at: string
-          user_id: string
-        }
+          created_at: string;
+          id: string;
+          job_id: string;
+          raw_data: Json | null;
+          updated_at: string;
+          user_id: string;
+        };
         Update: {
-          created_at?: string
-          id?: string
-          job_id?: string
-          raw_data?: Json | null
-          updated_at?: string
-          user_id?: string
-        }
-      }
+          created_at?: string;
+          id?: string;
+          job_id?: string;
+          raw_data?: Json | null;
+          updated_at?: string;
+          user_id?: string;
+        };
+      };
       jobs: {
         Insert: {
-          company_name: string
-          created_at?: string
-          description?: null | string
-          id?: string
-          origin_url: string
-          platform: Database["public"]["Enums"]["job_platform"]
-          position_title: string
-        }
-        Relationships: []
+          company_name: string;
+          created_at?: string;
+          description?: null | string;
+          id?: string;
+          origin_url: string;
+          platform: Database["public"]["Enums"]["job_platform"];
+          position_title: string;
+        };
+        Relationships: [];
         Row: {
-          company_name: string
-          created_at: string
-          description: null | string
-          id: string
-          origin_url: string
-          platform: Database["public"]["Enums"]["job_platform"]
-          position_title: string
-        }
+          company_name: string;
+          created_at: string;
+          description: null | string;
+          id: string;
+          origin_url: string;
+          platform: Database["public"]["Enums"]["job_platform"];
+          position_title: string;
+        };
         Update: {
-          company_name?: string
-          created_at?: string
-          description?: null | string
-          id?: string
-          origin_url?: string
-          platform?: Database["public"]["Enums"]["job_platform"]
-          position_title?: string
-        }
-      }
-    }
+          company_name?: string;
+          created_at?: string;
+          description?: null | string;
+          id?: string;
+          origin_url?: string;
+          platform?: Database["public"]["Enums"]["job_platform"];
+          position_title?: string;
+        };
+      };
+    };
     Views: {
-      [_ in never]: never
-    }
-  }
-}
+      [_ in never]: never;
+    };
+  };
+};
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
     | keyof DefaultSchema["Enums"]
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
   : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
     ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
-    : never
+    : never;
 
 export type Json =
   | boolean
@@ -222,24 +223,24 @@ export type Json =
   | null
   | number
   | string
-  | { [key: string]: Json | undefined }
+  | { [key: string]: Json | undefined };
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
     | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
         DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
       DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R
+      Row: infer R;
     }
     ? R
     : never
@@ -247,65 +248,68 @@ export type Tables<
         DefaultSchema["Views"])
     ? (DefaultSchema["Tables"] &
         DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R
+        Row: infer R;
       }
       ? R
       : never
-    : never
+    : never;
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I
+      Insert: infer I;
     }
     ? I
     : never
   : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
     ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I
+        Insert: infer I;
       }
       ? I
       : never
-    : never
+    : never;
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U
+      Update: infer U;
     }
     ? U
     : never
   : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
     ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U
+        Update: infer U;
       }
       ? U
       : never
-    : never
+    : never;
 
-type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">;
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+type DefaultSchema = DatabaseWithoutInternals[Extract<
+  keyof Database,
+  "public"
+>];
 
 export const Constants = {
   public: {
@@ -313,6 +317,7 @@ export const Constants = {
       interview_type: ["TECH", "HR", "CULTURE", "FINAL", "OTHER"],
       job_platform: ["WANTED", "SARAMIN", "LINKEDIN", "MANUAL"],
       job_status: [
+        "SAVED",
         "APPLIED",
         "DOCS_PASSED",
         "INTERVIEWING",
@@ -321,4 +326,4 @@ export const Constants = {
       ],
     },
   },
-} as const
+} as const;

--- a/supabase/migrations/20260312100000_add_saved_job_status.sql
+++ b/supabase/migrations/20260312100000_add_saved_job_status.sql
@@ -1,0 +1,4 @@
+-- Add SAVED to job_status enum (before APPLIED)
+-- NOTE: ALTER TYPE ... ADD VALUE must run in its own migration (own transaction)
+-- so that the new value is committed before being used in the next migration.
+ALTER TYPE public.job_status ADD VALUE IF NOT EXISTS 'SAVED' BEFORE 'APPLIED';

--- a/supabase/migrations/20260312100001_update_save_job_application_default_status.sql
+++ b/supabase/migrations/20260312100001_update_save_job_application_default_status.sql
@@ -1,0 +1,113 @@
+BEGIN;
+
+-- Update RPC default status from 'APPLIED' to 'SAVED'
+CREATE OR REPLACE FUNCTION public.save_job_application(
+  p_platform public.job_platform,
+  p_origin_url text,
+  p_company_name text,
+  p_position_title text,
+  p_description text DEFAULT NULL,
+  p_status public.job_status DEFAULT 'SAVED',
+  p_applied_at timestamptz DEFAULT NULL,
+  p_notes text DEFAULT NULL,
+  p_raw_data jsonb DEFAULT NULL
+)
+RETURNS TABLE ("jobId" uuid, "applicationId" uuid, "snapshotId" uuid)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id uuid;
+BEGIN
+  v_user_id := auth.uid();
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required'
+      USING
+        ERRCODE = '28000',
+        DETAIL = 'save_job_application requires an authenticated user.',
+        HINT = 'Sign in and retry.';
+  END IF;
+
+  INSERT INTO public.jobs AS j (
+    platform,
+    origin_url,
+    company_name,
+    position_title,
+    description
+  )
+  VALUES (
+    p_platform,
+    p_origin_url,
+    p_company_name,
+    p_position_title,
+    p_description
+  )
+  ON CONFLICT (platform, origin_url) DO UPDATE
+  SET
+    company_name = COALESCE(j.company_name, EXCLUDED.company_name),
+    position_title = COALESCE(j.position_title, EXCLUDED.position_title),
+    description = COALESCE(j.description, EXCLUDED.description)
+  RETURNING j.id
+  INTO "jobId";
+
+  INSERT INTO public.applications AS a (
+    user_id,
+    job_id,
+    status,
+    applied_at,
+    notes
+  )
+  VALUES (
+    v_user_id,
+    "jobId",
+    COALESCE(p_status, 'SAVED'::public.job_status),
+    COALESCE(p_applied_at, NOW()),
+    p_notes
+  )
+  ON CONFLICT (user_id, job_id) DO UPDATE
+  SET
+    status = EXCLUDED.status,
+    applied_at = COALESCE(p_applied_at, a.applied_at),
+    notes = EXCLUDED.notes
+  RETURNING a.id
+  INTO "applicationId";
+
+  "snapshotId" := NULL;
+
+  IF p_raw_data IS NOT NULL THEN
+    INSERT INTO public.job_snapshots AS js (
+      user_id,
+      job_id,
+      raw_data
+    )
+    VALUES (
+      v_user_id,
+      "jobId",
+      p_raw_data
+    )
+    ON CONFLICT (user_id, job_id) DO UPDATE
+    SET
+      raw_data = EXCLUDED.raw_data
+    RETURNING js.id
+    INTO "snapshotId";
+  END IF;
+
+  RETURN NEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION public.save_job_application(
+  public.job_platform,
+  text,
+  text,
+  text,
+  text,
+  public.job_status,
+  timestamptz,
+  text,
+  jsonb
+) IS 'Idempotently upserts jobs/applications and optional user-specific snapshots. Shared jobs are only backfilled when existing values are NULL. Default status is SAVED (bookmark stage before applying).';
+
+COMMIT;


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #79

## 📌 작업 내용

- job_status enum에 SAVED 추가 (DB 마이그레이션)
- save_job_application RPC 기본 status를 APPLIED → SAVED로 변경
- 플랫폼별 JOB_DEFAULTS(MANUAL, WANTED, SARAMIN) 기본 status 동일하게 변경
- STATUS_META에 SAVED 메타 추가 (label: "관심 공고")
- IN_PROGRESS_STATUSES에 SAVED 포함 (진행중 탭에 노출)
- DOCS_STATUSES는 변경 없음 (서류 통계에는 미포함)


