### PR TITLE
feat: 공고 상세 바텀시트용 application detail 액션 추가(#83)

### DIFF
--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationList.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationList.tsx
@@ -1,11 +1,11 @@
 import { Inbox } from "lucide-react";
 
-import type { ApplicationItem } from "../types";
+import type { ApplicationListItem } from "../types";
 
 import { ApplicationRow } from "./ApplicationRow";
 
 type ApplicationListProps = {
-  applications: ApplicationItem[];
+  applications: ApplicationListItem[];
   emptyMessage?: string;
 };
 

--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationRow.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationRow.tsx
@@ -1,11 +1,11 @@
 import { cn, getTimeAgo } from "@/lib/utils";
 
-import type { ApplicationItem } from "../types";
+import type { ApplicationListItem } from "../types";
 
 import { PLATFORM_LABEL, STATUS_META } from "../constants";
 
 type ApplicationRowProps = {
-  application: ApplicationItem;
+  application: ApplicationListItem;
 };
 
 export function ApplicationRow({ application }: ApplicationRowProps) {

--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationTabs.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationTabs.tsx
@@ -2,13 +2,13 @@
 
 import { Tabs } from "@/components/ui";
 
-import type { ApplicationItem } from "../types";
+import type { ApplicationListItem } from "../types";
 
 import { DONE_STATUSES, IN_PROGRESS_STATUSES } from "../constants";
 import { ApplicationList } from "./ApplicationList";
 
 type ApplicationTabsProps = {
-  applications: ApplicationItem[];
+  applications: ApplicationListItem[];
 };
 
 const TAB_TRIGGER_CLASS =

--- a/app/(protected)/dashboard/_components/dashboard-view/types.ts
+++ b/app/(protected)/dashboard/_components/dashboard-view/types.ts
@@ -1,10 +1,1 @@
-import type { JobPlatform, JobStatus } from "@/lib/types/job";
-
-export type ApplicationItem = {
-  appliedAt: string;
-  companyName: string;
-  id: string;
-  platform: JobPlatform;
-  positionTitle: string;
-  status: JobStatus;
-};
+export type { ApplicationListItem } from "@/lib/types/application";

--- a/lib/actions/getApplicationDetail.ts
+++ b/lib/actions/getApplicationDetail.ts
@@ -1,0 +1,131 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import {
+  applicationDetailSchema,
+  applicationIdSchema,
+  type GetApplicationDetailResult,
+} from "@/lib/types/application";
+
+const AUTH_ERROR_CODE = "28000";
+const ERROR_MESSAGES = {
+  AUTH_REQUIRED: "로그인이 필요합니다.",
+  INVALID_RESPONSE: "지원 상세 응답을 해석하지 못했습니다.",
+  NOT_FOUND: "지원 상세 정보를 찾을 수 없습니다.",
+  VALIDATION_ERROR: "유효하지 않은 applicationId입니다.",
+} as const;
+
+type QueryErrorLike = {
+  code?: string;
+  details?: null | string;
+  hint?: null | string;
+  message: string;
+};
+
+export async function getApplicationDetail(
+  applicationId: string,
+): Promise<GetApplicationDetailResult> {
+  const parsedApplicationId = applicationIdSchema.safeParse(applicationId);
+
+  if (!parsedApplicationId.success) {
+    return {
+      code: "VALIDATION_ERROR",
+      ok: false,
+      reason:
+        parsedApplicationId.error.issues[0]?.message ??
+        ERROR_MESSAGES.VALIDATION_ERROR,
+    };
+  }
+
+  const supabase = await createClient();
+  const { data: authData, error: authError } = await supabase.auth.getUser();
+
+  if (authError || !authData.user) {
+    return {
+      code: "AUTH_REQUIRED",
+      ok: false,
+      reason: ERROR_MESSAGES.AUTH_REQUIRED,
+    };
+  }
+
+  const { data, error } = await supabase
+    .from("applications")
+    .select(
+      `
+        id,
+        applied_at,
+        notes,
+        status,
+        jobs (
+          company_name,
+          description,
+          origin_url,
+          platform,
+          position_title
+        )
+      `,
+    )
+    .eq("id", parsedApplicationId.data)
+    .maybeSingle();
+
+  if (error) {
+    return {
+      code: error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR",
+      ok: false,
+      reason: normalizeQueryError(error),
+    };
+  }
+
+  if (!data) {
+    return {
+      code: "NOT_FOUND",
+      ok: false,
+      reason: ERROR_MESSAGES.NOT_FOUND,
+    };
+  }
+
+  const job = Array.isArray(data.jobs) ? data.jobs[0] : data.jobs;
+
+  if (!job) {
+    return {
+      code: "UNKNOWN_ERROR",
+      ok: false,
+      reason: ERROR_MESSAGES.INVALID_RESPONSE,
+    };
+  }
+
+  const parsedDetail = applicationDetailSchema.safeParse({
+    appliedAt: data.applied_at,
+    companyName: job.company_name,
+    description: job.description,
+    id: data.id,
+    notes: data.notes,
+    originUrl: job.origin_url,
+    platform: job.platform,
+    positionTitle: job.position_title,
+    status: data.status,
+  });
+
+  if (!parsedDetail.success) {
+    return {
+      code: "UNKNOWN_ERROR",
+      ok: false,
+      reason: ERROR_MESSAGES.INVALID_RESPONSE,
+    };
+  }
+
+  return {
+    data: parsedDetail.data,
+    ok: true,
+  };
+}
+
+function normalizeQueryError(error: QueryErrorLike): string {
+  const metadata = [error.details, error.hint].filter(Boolean).join(" | ");
+
+  if (metadata.length > 0) {
+    return `${error.message} (${metadata})`;
+  }
+
+  return error.message;
+}

--- a/lib/actions/getApplications.ts
+++ b/lib/actions/getApplications.ts
@@ -1,10 +1,10 @@
 "use server";
 
-import type { ApplicationItem } from "@/app/(protected)/dashboard/_components/dashboard-view/types";
+import type { ApplicationListItem } from "@/lib/types/application";
 
 import { createClient } from "../supabase/server";
 
-export async function getApplications(): Promise<ApplicationItem[]> {
+export async function getApplications(): Promise<ApplicationListItem[]> {
   const supabase = await createClient();
 
   const { data, error } = await supabase

--- a/lib/actions/index.ts
+++ b/lib/actions/index.ts
@@ -1,3 +1,4 @@
 export { extractJobData } from "./extractJobData";
+export { getApplicationDetail } from "./getApplicationDetail";
 export { getApplications } from "./getApplications";
 export { saveJobApplication } from "./saveJobApplication";

--- a/lib/types/application.ts
+++ b/lib/types/application.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+
+import {
+  type JobPlatform,
+  jobPlatformSchema,
+  type JobStatus,
+  jobStatusSchema,
+} from "@/lib/types/job";
+
+export const applicationIdSchema = z.uuid("applicationId must be a valid UUID");
+
+export type ApplicationListItem = {
+  appliedAt: string;
+  companyName: string;
+  id: string;
+  platform: JobPlatform;
+  positionTitle: string;
+  status: JobStatus;
+};
+
+export const applicationDetailSchema = z
+  .object({
+    appliedAt: z.string(),
+    companyName: z.string(),
+    description: z.string().nullable(),
+    id: z.uuid(),
+    notes: z.string().nullable(),
+    originUrl: z.string(),
+    platform: jobPlatformSchema,
+    positionTitle: z.string(),
+    status: jobStatusSchema,
+  })
+  .strict();
+
+export type ApplicationDetail = {
+  appliedAt: string;
+  companyName: string;
+  description: null | string;
+  id: string;
+  notes: null | string;
+  originUrl: string;
+  platform: JobPlatform;
+  positionTitle: string;
+  status: JobStatus;
+};
+
+export type GetApplicationDetailErrorCode =
+  | "AUTH_REQUIRED"
+  | "NOT_FOUND"
+  | "QUERY_ERROR"
+  | "UNKNOWN_ERROR"
+  | "VALIDATION_ERROR";
+
+export type GetApplicationDetailResult =
+  | {
+      code: GetApplicationDetailErrorCode;
+      ok: false;
+      reason: string;
+    }
+  | {
+      data: ApplicationDetail;
+      ok: true;
+    };


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #83

## 📌 작업 내용

- 리스트 전용 application 타입과 상세 전용 타입 분리
- applicationId 기반 getApplicationDetail 서버 액션 추가
- 공고 링크, 설명, 메모를 포함한 상세 응답 구조 정의
- 인증 실패, 검증 실패, 미존재, 조회 실패를 구분하는 결과 타입 정리
- 기존 대시보드 리스트 소비처를 분리된 리스트 타입으로 정리


