### PR TITLE
feat: 공고 상세 페이지 UI 추가(#85)

### DIFF
--- a/app/(protected)/applications/[applicationId]/_components/BackLink.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/BackLink.tsx
@@ -1,0 +1,19 @@
+import { ArrowLeftIcon } from "lucide-react";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button/Button";
+
+export function BackLink() {
+  return (
+    <Button
+      asChild
+      className="h-auto w-fit px-0 text-sm font-medium text-muted-foreground hover:bg-transparent hover:text-foreground"
+      variant="ghost"
+    >
+      <Link href="/dashboard">
+        <ArrowLeftIcon aria-hidden="true" />
+        대시보드로 돌아가기
+      </Link>
+    </Button>
+  );
+}

--- a/app/(protected)/applications/[applicationId]/_components/DetailSection.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/DetailSection.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+
+export type DetailSectionProps = {
+  body: string;
+  icon: ReactNode;
+  title: string;
+};
+
+export function DetailSection({ body, icon, title }: DetailSectionProps) {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-2 text-foreground">
+        <span className="text-muted-foreground">{icon}</span>
+        <h2 className="text-base font-semibold tracking-[-0.01em]">{title}</h2>
+      </div>
+      <p className="text-[15px] leading-8 wrap-break-word whitespace-pre-wrap text-foreground">
+        {body}
+      </p>
+    </section>
+  );
+}

--- a/app/(protected)/applications/[applicationId]/_components/ErrorState.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/ErrorState.tsx
@@ -1,0 +1,41 @@
+import type { LucideIcon } from "lucide-react";
+
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button/Button";
+
+export type ErrorStateProps = {
+  description: string;
+  icon: LucideIcon;
+  reason: string;
+  title: string;
+};
+
+export function ErrorState({
+  description,
+  icon: Icon,
+  reason,
+  title,
+}: ErrorStateProps) {
+  return (
+    <section className="mt-10 py-8 text-center">
+      <div className="mx-auto flex max-w-md flex-col items-center gap-5">
+        <div className="flex size-12 items-center justify-center text-muted-foreground">
+          <Icon aria-hidden="true" className="size-6" />
+        </div>
+        <div className="space-y-3">
+          <h1 className="text-[28px] leading-tight font-semibold tracking-[-0.02em] text-foreground">
+            {title}
+          </h1>
+          <p className="text-sm leading-6 text-muted-foreground">
+            {description}
+          </p>
+          <p className="text-sm leading-6 text-foreground">{reason}</p>
+        </div>
+        <Button asChild className="h-10 px-4 text-sm">
+          <Link href="/dashboard">지원 현황으로 돌아가기</Link>
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/app/(protected)/applications/[applicationId]/_utils/formatAppliedAt.ts
+++ b/app/(protected)/applications/[applicationId]/_utils/formatAppliedAt.ts
@@ -1,0 +1,11 @@
+import { formatKoreanDate } from "@/lib/utils";
+
+export function formatAppliedAt(value: string) {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return formatKoreanDate(date, { includeDayName: false });
+}

--- a/app/(protected)/applications/[applicationId]/page.tsx
+++ b/app/(protected)/applications/[applicationId]/page.tsx
@@ -1,0 +1,149 @@
+import {
+  ExternalLinkIcon,
+  FileTextIcon,
+  LockKeyholeIcon,
+  NotebookPenIcon,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button/Button";
+import { getApplicationDetail } from "@/lib/actions";
+
+import { BackLink } from "./_components/BackLink";
+import { DetailSection } from "./_components/DetailSection";
+import { ErrorState } from "./_components/ErrorState";
+import { formatAppliedAt } from "./_utils/formatAppliedAt";
+
+type ApplicationDetailPageProps = {
+  params: Promise<{
+    applicationId: string;
+  }>;
+};
+
+const PLATFORM_LABEL = {
+  LINKEDIN: "LinkedIn",
+  MANUAL: "직접 입력",
+  SARAMIN: "사람인",
+  WANTED: "원티드",
+} as const;
+
+const ERROR_STATE_META = {
+  AUTH_REQUIRED: {
+    description: "상세 내용을 보려면 로그인 상태가 필요합니다.",
+    icon: LockKeyholeIcon,
+    title: "로그인이 필요합니다",
+  },
+  NOT_FOUND: {
+    description: "삭제되었거나 접근할 수 없는 공고일 수 있습니다.",
+    icon: FileTextIcon,
+    title: "공고 상세를 찾을 수 없습니다",
+  },
+  QUERY_ERROR: {
+    description: "잠시 후 다시 시도하거나 대시보드에서 다시 진입해 주세요.",
+    icon: FileTextIcon,
+    title: "상세 정보를 불러오지 못했습니다",
+  },
+  UNKNOWN_ERROR: {
+    description: "응답 형식을 확인하지 못했습니다. 잠시 후 다시 시도해 주세요.",
+    icon: FileTextIcon,
+    title: "예상하지 못한 오류가 발생했습니다",
+  },
+  VALIDATION_ERROR: {
+    description: "잘못된 상세 경로로 접근했습니다.",
+    icon: FileTextIcon,
+    title: "유효하지 않은 공고 경로입니다",
+  },
+} as const;
+
+export default async function ApplicationDetailPage({
+  params,
+}: ApplicationDetailPageProps) {
+  const { applicationId } = await params;
+  const result = await getApplicationDetail(applicationId);
+
+  if (!result.ok) {
+    const errorMeta = ERROR_STATE_META[result.code];
+
+    return (
+      <main className="px-5 py-6 sm:px-6 lg:px-8">
+        <div className="mx-auto w-full max-w-3xl">
+          <BackLink />
+          <ErrorState
+            description={errorMeta.description}
+            icon={errorMeta.icon}
+            reason={result.reason}
+            title={errorMeta.title}
+          />
+        </div>
+      </main>
+    );
+  }
+
+  const detail = result.data;
+  const hasOriginUrl = detail.originUrl.trim() !== "";
+
+  return (
+    <main className="px-5 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-5">
+        <BackLink />
+
+        <section className="space-y-5">
+          <div className="space-y-4">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+              <span className="text-sm font-medium tracking-[0.08em] text-muted-foreground uppercase">
+                {PLATFORM_LABEL[detail.platform]}
+              </span>
+              <span aria-hidden="true" className="text-muted-foreground">
+                /
+              </span>
+              <span className="text-sm text-muted-foreground">
+                지원일 {formatAppliedAt(detail.appliedAt)}
+              </span>
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-base font-medium text-muted-foreground">
+                {detail.companyName}
+              </p>
+              <div className="flex items-start gap-3">
+                <h1 className="max-w-3xl flex-1 text-[28px] leading-[1.15] font-semibold tracking-[-0.02em] text-foreground sm:text-[32px]">
+                  {detail.positionTitle}
+                </h1>
+                {hasOriginUrl && (
+                  <Button
+                    asChild
+                    className="size-10 shrink-0 rounded-full border border-border px-0 text-muted-foreground hover:bg-muted hover:text-foreground"
+                    variant="ghost"
+                  >
+                    <a
+                      aria-label="원문 공고 보러가기"
+                      href={detail.originUrl}
+                      rel="noreferrer noopener"
+                      target="_blank"
+                    >
+                      <ExternalLinkIcon aria-hidden="true" className="size-5" />
+                    </a>
+                  </Button>
+                )}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div aria-hidden="true" className="h-px w-full bg-border" />
+
+        <div className="grid gap-7">
+          <DetailSection
+            body={detail.description ?? "공고 설명이 없습니다"}
+            icon={<FileTextIcon aria-hidden="true" className="size-5" />}
+            title="공고 설명"
+          />
+          <DetailSection
+            body={detail.notes ?? "메모가 없습니다"}
+            icon={<NotebookPenIcon aria-hidden="true" className="size-5" />}
+            title="개인 메모"
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/lib/utils/date.ts
+++ b/lib/utils/date.ts
@@ -1,9 +1,22 @@
 const DAY_NAMES = ["일", "월", "화", "수", "목", "금", "토"] as const;
 
-export function formatKoreanDate(date: Date): string {
+type FormatKoreanDateOptions = {
+  includeDayName?: boolean;
+};
+
+export function formatKoreanDate(
+  date: Date,
+  options?: FormatKoreanDateOptions,
+): string {
   const year = date.getFullYear();
   const month = date.getMonth() + 1;
   const day = date.getDate();
+  const includeDayName = options?.includeDayName ?? true;
+
+  if (!includeDayName) {
+    return `${year}년 ${month}월 ${day}일`;
+  }
+
   const dayName = DAY_NAMES[date.getDay()];
 
   return `${year}년 ${month}월 ${day}일 ${dayName}요일`;


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #85

## 📌 작업 내용

- 공고 상세 페이지 레이아웃 및 섹션 구성
- 상세 조회 성공/실패 상태 UI 구현
- 페이지 내부 UI 컴포넌트와 날짜 포맷 유틸 분리
- formatKoreanDate 유틸을 dayName도 지원하도록 확장


