### PR TITLE
feat: 대시보드 공고 바텀시트 추가(#87)

### DIFF
--- a/app/(protected)/dashboard/_components/dashboard-view/DashboardView.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DashboardView.tsx
@@ -3,7 +3,7 @@ import { cn, formatKoreanDate } from "@/lib/utils";
 
 import { AddJobTrigger } from "../add-job";
 import { GoToTopFAB } from "../go-to-top";
-import { ApplicationTabs } from "./components/ApplicationTabs";
+import { DashboardApplicationsPanel } from "./components/DashboardApplicationsPanel";
 import { DOCS_STATUSES } from "./constants";
 
 export async function DashboardView() {
@@ -50,7 +50,7 @@ export async function DashboardView() {
         ))}
       </div>
 
-      <ApplicationTabs applications={applications} />
+      <DashboardApplicationsPanel applications={applications} />
       <GoToTopFAB />
       <AddJobTrigger />
     </main>

--- a/app/(protected)/dashboard/_components/dashboard-view/_utils/preview.ts
+++ b/app/(protected)/dashboard/_components/dashboard-view/_utils/preview.ts
@@ -1,0 +1,77 @@
+import type {
+  ApplicationDetail,
+  GetApplicationDetailResult,
+} from "@/lib/types/application";
+
+import { formatKoreanDate } from "@/lib/utils";
+
+const DEFAULT_MAX_LENGTH = 160;
+const EMPTY_DESCRIPTION = "공고 설명이 없습니다";
+const EMPTY_NOTES = "개인 메모가 없습니다";
+
+export type PreviewTextMeta = {
+  isEmpty: boolean;
+  text: string;
+};
+
+export function formatPreviewAppliedAt(value: string) {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return formatKoreanDate(date, { includeDayName: false });
+}
+
+export function getDescriptionMeta(
+  detail: ApplicationDetail | null,
+): PreviewTextMeta {
+  return {
+    isEmpty: !detail?.description?.trim(),
+    text: getPreviewText(detail?.description ?? null, EMPTY_DESCRIPTION),
+  };
+}
+
+export function getErrorSummary(
+  result: Extract<GetApplicationDetailResult, { ok: false }>,
+) {
+  switch (result.code) {
+    case "AUTH_REQUIRED": {
+      return "로그인이 필요한 공고입니다.";
+    }
+    case "NOT_FOUND": {
+      return "공고 상세를 찾을 수 없습니다.";
+    }
+    default: {
+      return "공고 정보를 불러오지 못했습니다.";
+    }
+  }
+}
+
+export function getNotesMeta(
+  detail: ApplicationDetail | null,
+): PreviewTextMeta {
+  return {
+    isEmpty: !detail?.notes?.trim(),
+    text: getPreviewText(detail?.notes ?? null, EMPTY_NOTES, 120),
+  };
+}
+
+export function getPreviewText(
+  value: null | string,
+  emptyText: string,
+  maxLength = DEFAULT_MAX_LENGTH,
+) {
+  const normalizedValue = value?.trim();
+
+  if (!normalizedValue) {
+    return emptyText;
+  }
+
+  if (normalizedValue.length <= maxLength) {
+    return normalizedValue;
+  }
+
+  return `${normalizedValue.slice(0, maxLength).trimEnd()}...`;
+}

--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationList.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationList.tsx
@@ -1,4 +1,4 @@
-import { Inbox } from "lucide-react";
+import { InboxIcon } from "lucide-react";
 
 import type { ApplicationListItem } from "../types";
 
@@ -7,16 +7,18 @@ import { ApplicationRow } from "./ApplicationRow";
 type ApplicationListProps = {
   applications: ApplicationListItem[];
   emptyMessage?: string;
+  onSelectApplication: (application: ApplicationListItem) => void;
 };
 
 export function ApplicationList({
   applications,
   emptyMessage = "해당하는 지원 내역이 없습니다",
+  onSelectApplication,
 }: ApplicationListProps) {
   if (applications.length === 0) {
     return (
       <div className="flex flex-col items-center gap-3 py-16 text-muted-foreground">
-        <Inbox className="size-8 stroke-[1.5]" />
+        <InboxIcon className="size-8 stroke-[1.5]" />
         <p className="text-sm">{emptyMessage}</p>
       </div>
     );
@@ -25,7 +27,11 @@ export function ApplicationList({
   return (
     <>
       {applications.map((application) => (
-        <ApplicationRow application={application} key={application.id} />
+        <ApplicationRow
+          application={application}
+          key={application.id}
+          onSelect={onSelectApplication}
+        />
       ))}
     </>
   );

--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationPreviewSection.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationPreviewSection.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export type ApplicationPreviewSectionProps = {
+  body: string;
+  className?: string;
+  icon: ReactNode;
+  isEmpty: boolean;
+  title: string;
+};
+
+export function ApplicationPreviewSection({
+  body,
+  className,
+  icon,
+  isEmpty,
+  title,
+}: ApplicationPreviewSectionProps) {
+  return (
+    <section className={cn("space-y-2 py-1", className)}>
+      <div className="flex items-center gap-2 text-foreground">
+        <span className="text-muted-foreground">{icon}</span>
+        <h3 className="text-sm font-semibold">{title}</h3>
+      </div>
+      <p
+        className={cn(
+          "text-sm leading-6 whitespace-pre-wrap text-foreground",
+          isEmpty && "text-muted-foreground",
+        )}
+      >
+        {body}
+      </p>
+    </section>
+  );
+}

--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationPreviewSheet.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationPreviewSheet.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import type { Route } from "next";
+
+import {
+  AlertCircleIcon,
+  ChevronRightIcon,
+  FileTextIcon,
+  StickyNoteIcon,
+} from "lucide-react";
+import Link from "next/link";
+import { useEffect, useEffectEvent, useRef, useState } from "react";
+
+import type {
+  ApplicationDetail,
+  ApplicationListItem,
+} from "@/lib/types/application";
+
+import { BottomSheet, Button } from "@/components/ui";
+import { getApplicationDetail } from "@/lib/actions";
+import { cn } from "@/lib/utils";
+
+import {
+  formatPreviewAppliedAt,
+  getDescriptionMeta,
+  getErrorSummary,
+  getNotesMeta,
+} from "../_utils/preview";
+import { PLATFORM_LABEL, STATUS_META } from "../constants";
+import { ApplicationPreviewSection } from "./ApplicationPreviewSection";
+
+type ApplicationPreviewSheetProps = {
+  application: ApplicationListItem | null;
+  isOpen: boolean;
+  onCloseAction: () => void;
+};
+
+type ApplicationPreviewState =
+  | {
+      detail: ApplicationDetail;
+      status: "ready";
+    }
+  | {
+      status: "error";
+      summary: string;
+    }
+  | {
+      status: "idle";
+    }
+  | {
+      status: "loading";
+    };
+
+export function ApplicationPreviewSheet({
+  application,
+  isOpen,
+  onCloseAction,
+}: ApplicationPreviewSheetProps) {
+  const [previewState, setPreviewState] = useState<ApplicationPreviewState>({
+    status: "idle",
+  });
+  const requestSequenceRef = useRef(0);
+
+  const loadApplicationDetail = useEffectEvent(
+    async (applicationId: string) => {
+      requestSequenceRef.current += 1;
+      const requestSequence = requestSequenceRef.current;
+
+      setPreviewState({ status: "loading" });
+
+      const result = await getApplicationDetail(applicationId);
+
+      if (requestSequenceRef.current !== requestSequence) {
+        return;
+      }
+
+      if (!result.ok) {
+        setPreviewState({
+          status: "error",
+          summary: getErrorSummary(result),
+        });
+        return;
+      }
+
+      setPreviewState({
+        detail: result.data,
+        status: "ready",
+      });
+    },
+  );
+
+  useEffect(() => {
+    if (!isOpen || !application) {
+      requestSequenceRef.current += 1;
+      return;
+    }
+
+    void loadApplicationDetail(application.id);
+  }, [application, isOpen]);
+
+  const detail = previewState.status === "ready" ? previewState.detail : null;
+  const { color, label } = application
+    ? STATUS_META[application.status]
+    : { color: "text-muted-foreground", label: "" };
+
+  const title =
+    detail?.positionTitle ?? application?.positionTitle ?? "공고 미리보기";
+  const companyName = detail?.companyName ?? application?.companyName ?? "";
+  const platform = detail?.platform ?? application?.platform;
+  const appliedAt = detail?.appliedAt ?? application?.appliedAt;
+  const descriptionMeta = getDescriptionMeta(detail);
+  const notesMeta = getNotesMeta(detail);
+
+  const footerButtonContent = (
+    <>
+      공고 상세 보기
+      <ChevronRightIcon aria-hidden="true" className="size-4" />
+    </>
+  );
+
+  return (
+    <BottomSheet isOpen={isOpen} onClose={onCloseAction}>
+      <BottomSheet.Overlay />
+      <BottomSheet.Content>
+        <BottomSheet.Header />
+        <div className="px-6 pb-4">
+          <BottomSheet.Title className="text-xl tracking-[-0.02em] text-foreground">
+            {title}
+          </BottomSheet.Title>
+          {companyName && (
+            <p className="mt-2 text-sm font-medium text-muted-foreground">
+              {companyName}
+            </p>
+          )}
+        </div>
+
+        <BottomSheet.Body className="space-y-4 px-6 pb-4">
+          {application && (
+            <div className="flex flex-wrap items-center gap-2">
+              <span
+                className={cn(
+                  "rounded-full bg-muted px-3 py-1 text-xs font-semibold",
+                  color,
+                )}
+              >
+                {label}
+              </span>
+              {platform && (
+                <span className="rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground">
+                  {PLATFORM_LABEL[platform]}
+                </span>
+              )}
+              {appliedAt && (
+                <span className="rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground">
+                  지원일 {formatPreviewAppliedAt(appliedAt)}
+                </span>
+              )}
+            </div>
+          )}
+
+          {previewState.status === "loading" && (
+            <div
+              aria-live="polite"
+              className="rounded-2xl border border-dashed border-border px-4 py-5"
+              role="status"
+            >
+              <p className="text-sm text-muted-foreground">
+                공고 정보를 불러오는 중입니다.
+              </p>
+            </div>
+          )}
+
+          {previewState.status === "error" && (
+            <section
+              aria-live="polite"
+              className="rounded-2xl border border-red-200 bg-red-50 px-4 py-4 text-red-700"
+            >
+              <div className="flex items-start gap-3">
+                <AlertCircleIcon
+                  aria-hidden="true"
+                  className="mt-0.5 size-5 shrink-0"
+                />
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold">
+                    미리보기를 불러오지 못했습니다
+                  </p>
+                  <p className="text-sm leading-6">{previewState.summary}</p>
+                </div>
+              </div>
+            </section>
+          )}
+
+          {detail && (
+            <>
+              <ApplicationPreviewSection
+                body={descriptionMeta.text}
+                className="pt-6"
+                icon={<FileTextIcon aria-hidden="true" className="size-4" />}
+                isEmpty={descriptionMeta.isEmpty}
+                title="공고 설명"
+              />
+              <ApplicationPreviewSection
+                body={notesMeta.text}
+                icon={<StickyNoteIcon aria-hidden="true" className="size-4" />}
+                isEmpty={notesMeta.isEmpty}
+                title="개인 메모"
+              />
+            </>
+          )}
+        </BottomSheet.Body>
+
+        <div className="border-t border-border bg-white px-6 py-4">
+          {application ? (
+            <Button
+              asChild
+              className="h-11 w-full justify-between rounded-xl px-4"
+            >
+              <Link href={`/applications/${application.id}` as Route}>
+                {footerButtonContent}
+              </Link>
+            </Button>
+          ) : (
+            <Button
+              className="h-11 w-full justify-between rounded-xl px-4"
+              disabled
+            >
+              {footerButtonContent}
+            </Button>
+          )}
+        </div>
+      </BottomSheet.Content>
+    </BottomSheet>
+  );
+}

--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationRow.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationRow.tsx
@@ -1,3 +1,5 @@
+import { ChevronRightIcon } from "lucide-react";
+
 import { cn, getTimeAgo } from "@/lib/utils";
 
 import type { ApplicationListItem } from "../types";
@@ -6,19 +8,33 @@ import { PLATFORM_LABEL, STATUS_META } from "../constants";
 
 type ApplicationRowProps = {
   application: ApplicationListItem;
+  onSelect: (application: ApplicationListItem) => void;
 };
 
-export function ApplicationRow({ application }: ApplicationRowProps) {
+export function ApplicationRow({ application, onSelect }: ApplicationRowProps) {
   const { color, label } = STATUS_META[application.status];
 
   return (
-    <div className="flex items-start justify-between border-b border-border py-4">
-      <div className="flex flex-col gap-2">
+    <button
+      aria-label={`${application.companyName} ${application.positionTitle} 공고 미리보기 열기`}
+      className={cn(
+        "flex w-full items-start justify-between gap-4 border-b border-border py-4 text-left",
+        "cursor-pointer transition-colors",
+        "hover:bg-muted/60",
+        "focus-visible:rounded-xl focus-visible:border-transparent focus-visible:bg-muted/70 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
+        "active:bg-muted",
+      )}
+      onClick={() => {
+        onSelect(application);
+      }}
+      type="button"
+    >
+      <div className="flex min-w-0 flex-1 flex-col gap-2">
         <div className="flex flex-col">
           <span className="text-[15px] font-semibold text-foreground">
             {application.companyName}
           </span>
-          <span className="text-sm text-muted-foreground">
+          <span className="truncate text-sm text-muted-foreground">
             {application.positionTitle}
           </span>
         </div>
@@ -30,9 +46,10 @@ export function ApplicationRow({ application }: ApplicationRowProps) {
           </span>
         </div>
       </div>
-      <span className="shrink-0 text-sm text-muted-foreground">
-        {getTimeAgo(application.appliedAt)}
-      </span>
-    </div>
+      <div className="flex shrink-0 items-center gap-2 text-muted-foreground">
+        <span className="text-sm">{getTimeAgo(application.appliedAt)}</span>
+        <ChevronRightIcon aria-hidden="true" className="mt-0.5 size-4" />
+      </div>
+    </button>
   );
 }

--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationTabs.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationTabs.tsx
@@ -9,12 +9,16 @@ import { ApplicationList } from "./ApplicationList";
 
 type ApplicationTabsProps = {
   applications: ApplicationListItem[];
+  onSelectApplication: (application: ApplicationListItem) => void;
 };
 
 const TAB_TRIGGER_CLASS =
   "h-12 flex-1 rounded-none border-b-2 border-transparent px-0 text-muted-foreground data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none";
 
-export function ApplicationTabs({ applications }: ApplicationTabsProps) {
+export function ApplicationTabs({
+  applications,
+  onSelectApplication,
+}: ApplicationTabsProps) {
   const inProgressApplications = applications.filter((a) =>
     IN_PROGRESS_STATUSES.includes(a.status),
   );
@@ -40,18 +44,21 @@ export function ApplicationTabs({ applications }: ApplicationTabsProps) {
         <ApplicationList
           applications={applications}
           emptyMessage="아직 지원한 곳이 없습니다"
+          onSelectApplication={onSelectApplication}
         />
       </Tabs.Content>
       <Tabs.Content className="mt-0 px-5" value="active">
         <ApplicationList
           applications={inProgressApplications}
           emptyMessage="진행 중인 지원이 없습니다"
+          onSelectApplication={onSelectApplication}
         />
       </Tabs.Content>
       <Tabs.Content className="mt-0 px-5" value="done">
         <ApplicationList
           applications={doneApplications}
           emptyMessage="완료된 지원이 없습니다"
+          onSelectApplication={onSelectApplication}
         />
       </Tabs.Content>
     </Tabs>

--- a/app/(protected)/dashboard/_components/dashboard-view/components/DashboardApplicationsPanel.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/DashboardApplicationsPanel.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+
+import type { ApplicationListItem } from "../types";
+
+import { ApplicationPreviewSheet } from "./ApplicationPreviewSheet";
+import { ApplicationTabs } from "./ApplicationTabs";
+
+type DashboardApplicationsPanelProps = {
+  applications: ApplicationListItem[];
+};
+
+export function DashboardApplicationsPanel({
+  applications,
+}: DashboardApplicationsPanelProps) {
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const [selectedApplication, setSelectedApplication] =
+    useState<ApplicationListItem | null>(null);
+
+  const handleSelectApplication = (application: ApplicationListItem) => {
+    setSelectedApplication(application);
+    setIsPreviewOpen(true);
+  };
+
+  const handleClosePreview = () => {
+    setIsPreviewOpen(false);
+  };
+
+  return (
+    <>
+      <ApplicationTabs
+        applications={applications}
+        onSelectApplication={handleSelectApplication}
+      />
+      <ApplicationPreviewSheet
+        application={selectedApplication}
+        isOpen={isPreviewOpen}
+        onCloseAction={handleClosePreview}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #87

## 📌 작업 내용

- 대시보드 공고 목록에 바텀시트 기반 미리보기 흐름 추가
- 공고 행 전체를 탭 가능한 버튼으로 변경하고 상세 이동 CTA 연결
- 공고 설명/개인 메모 미리보기 UI와 관련 유틸 분리


