### PR TITLE
feat: 공고 지원상태 변경 UI 구현(#93)

### DIFF
--- a/app/(protected)/applications/[applicationId]/page.tsx
+++ b/app/(protected)/applications/[applicationId]/page.tsx
@@ -1,12 +1,15 @@
 import {
   ExternalLinkIcon,
   FileTextIcon,
+  ListChecksIcon,
   LockKeyholeIcon,
   NotebookPenIcon,
 } from "lucide-react";
 
+import { ApplicationStatusSelector } from "@/app/(protected)/_components/ApplicationStatusSelector";
 import { Button } from "@/components/ui/button/Button";
 import { getApplicationDetail } from "@/lib/actions";
+import { updateApplicationStatus } from "@/lib/actions/updateApplicationStatus";
 import { PLATFORM_LABEL } from "@/lib/constants/job-platform";
 import { formatAppliedAt } from "@/lib/utils";
 
@@ -98,14 +101,14 @@ export default async function ApplicationDetailPage({
               <p className="text-base font-medium text-muted-foreground">
                 {detail.companyName}
               </p>
-              <div className="flex items-start gap-3">
+              <div className="flex items-start">
                 <h1 className="max-w-3xl flex-1 text-[28px] leading-[1.15] font-semibold tracking-[-0.02em] text-foreground sm:text-[32px]">
                   {detail.positionTitle}
                 </h1>
                 {hasOriginUrl && (
                   <Button
                     asChild
-                    className="size-10 shrink-0 rounded-full border border-border px-0 text-muted-foreground hover:bg-muted hover:text-foreground"
+                    className="ml-auto size-10 shrink-0 rounded-full border border-border px-0 text-muted-foreground hover:bg-muted hover:text-foreground"
                     variant="ghost"
                   >
                     <a
@@ -121,6 +124,15 @@ export default async function ApplicationDetailPage({
               </div>
             </div>
           </div>
+
+          <ApplicationStatusSelector
+            applicationId={detail.id}
+            ariaLabel="공고 상태 변경"
+            icon={<ListChecksIcon aria-hidden="true" className="size-4" />}
+            label="지원 상태"
+            status={detail.status}
+            updateStatusAction={updateApplicationStatus}
+          />
         </section>
 
         <div aria-hidden="true" className="h-px w-full bg-border" />

--- a/app/(protected)/dashboard/_components/dashboard-view/DashboardView.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DashboardView.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from "react";
+
 import { getApplications } from "@/lib/actions";
 import { cn, formatKoreanDate } from "@/lib/utils";
 
@@ -50,7 +52,9 @@ export async function DashboardView() {
         ))}
       </div>
 
-      <DashboardApplicationsPanel applications={applications} />
+      <Suspense>
+        <DashboardApplicationsPanel applications={applications} />
+      </Suspense>
       <GoToTopFAB />
       <AddJobTrigger />
     </main>

--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationPreviewSheet.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationPreviewSheet.tsx
@@ -6,6 +6,7 @@ import {
   AlertCircleIcon,
   ChevronRightIcon,
   FileTextIcon,
+  ListChecksIcon,
   StickyNoteIcon,
 } from "lucide-react";
 import Link from "next/link";
@@ -15,10 +16,12 @@ import type {
   ApplicationDetail,
   ApplicationListItem,
 } from "@/lib/types/application";
+import type { JobStatus } from "@/lib/types/job";
 
+import { ApplicationStatusSelector } from "@/app/(protected)/_components/ApplicationStatusSelector";
 import { BottomSheet, Button } from "@/components/ui";
 import { getApplicationDetail } from "@/lib/actions";
-import { cn } from "@/lib/utils";
+import { updateApplicationStatus } from "@/lib/actions/updateApplicationStatus";
 
 import {
   formatAppliedAt,
@@ -26,13 +29,14 @@ import {
   getErrorSummary,
   getNotesMeta,
 } from "../_utils/preview";
-import { PLATFORM_LABEL, STATUS_META } from "../constants";
+import { PLATFORM_LABEL } from "../constants";
 import { ApplicationPreviewSection } from "./ApplicationPreviewSection";
 
 type ApplicationPreviewSheetProps = {
   application: ApplicationListItem | null;
   isOpen: boolean;
   onCloseAction: () => void;
+  onStatusChangeAction: (applicationId: string, nextStatus: JobStatus) => void;
 };
 
 type ApplicationPreviewState =
@@ -55,11 +59,13 @@ export function ApplicationPreviewSheet({
   application,
   isOpen,
   onCloseAction,
+  onStatusChangeAction,
 }: ApplicationPreviewSheetProps) {
   const [previewState, setPreviewState] = useState<ApplicationPreviewState>({
     status: "idle",
   });
   const requestSequenceRef = useRef(0);
+  const applicationId = application?.id;
 
   const loadApplicationDetail = useEffectEvent(
     async (applicationId: string) => {
@@ -90,19 +96,15 @@ export function ApplicationPreviewSheet({
   );
 
   useEffect(() => {
-    if (!isOpen || !application) {
+    if (!isOpen || !applicationId) {
       requestSequenceRef.current += 1;
       return;
     }
 
-    void loadApplicationDetail(application.id);
-  }, [application, isOpen]);
+    void loadApplicationDetail(applicationId);
+  }, [applicationId, isOpen]);
 
   const detail = previewState.status === "ready" ? previewState.detail : null;
-  const { color, label } = application
-    ? STATUS_META[application.status]
-    : { color: "text-muted-foreground", label: "" };
-
   const title =
     detail?.positionTitle ?? application?.positionTitle ?? "공고 미리보기";
   const companyName = detail?.companyName ?? application?.companyName ?? "";
@@ -124,6 +126,23 @@ export function ApplicationPreviewSheet({
       <BottomSheet.Content>
         <BottomSheet.Header />
         <div className="px-6 pb-4">
+          {(platform || appliedAt) && (
+            <div className="mb-2 flex flex-wrap items-center gap-0">
+              {platform && (
+                <span className="text-xs font-medium text-muted-foreground">
+                  {PLATFORM_LABEL[platform]}
+                </span>
+              )}
+              {platform && appliedAt && (
+                <span className="mx-2 text-xs text-muted-foreground/40">|</span>
+              )}
+              {appliedAt && (
+                <span className="text-xs font-medium text-muted-foreground">
+                  지원일 {formatAppliedAt(appliedAt)}
+                </span>
+              )}
+            </div>
+          )}
           <BottomSheet.Title className="text-xl tracking-[-0.02em] text-foreground">
             {title}
           </BottomSheet.Title>
@@ -136,26 +155,18 @@ export function ApplicationPreviewSheet({
 
         <BottomSheet.Body className="space-y-4 px-6 pb-4">
           {application && (
-            <div className="flex flex-wrap items-center gap-2">
-              <span
-                className={cn(
-                  "rounded-full bg-muted px-3 py-1 text-xs font-semibold",
-                  color,
-                )}
-              >
-                {label}
-              </span>
-              {platform && (
-                <span className="rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground">
-                  {PLATFORM_LABEL[platform]}
-                </span>
-              )}
-              {appliedAt && (
-                <span className="rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground">
-                  지원일 {formatAppliedAt(appliedAt)}
-                </span>
-              )}
-            </div>
+            <ApplicationStatusSelector
+              applicationId={application.id}
+              ariaLabel="공고 상태 변경"
+              className="mt-2"
+              icon={<ListChecksIcon aria-hidden="true" className="size-4" />}
+              label="지원 상태"
+              onStatusChangeAction={(nextStatus) => {
+                onStatusChangeAction(application.id, nextStatus);
+              }}
+              status={application.status}
+              updateStatusAction={updateApplicationStatus}
+            />
           )}
 
           {previewState.status === "loading" && (
@@ -194,7 +205,6 @@ export function ApplicationPreviewSheet({
             <>
               <ApplicationPreviewSection
                 body={descriptionMeta.text}
-                className="pt-6"
                 icon={<FileTextIcon aria-hidden="true" className="size-4" />}
                 isEmpty={descriptionMeta.isEmpty}
                 title="공고 설명"

--- a/app/(protected)/dashboard/_components/dashboard-view/components/DashboardApplicationsPanel.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/DashboardApplicationsPanel.tsx
@@ -1,11 +1,18 @@
 "use client";
 
-import { useState } from "react";
+import type { Route } from "next";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import type { JobStatus } from "@/lib/types/job";
 
 import type { ApplicationListItem } from "../types";
 
 import { ApplicationPreviewSheet } from "./ApplicationPreviewSheet";
 import { ApplicationTabs } from "./ApplicationTabs";
+
+const PREVIEW_PARAM = "preview";
 
 type DashboardApplicationsPanelProps = {
   applications: ApplicationListItem[];
@@ -14,29 +21,60 @@ type DashboardApplicationsPanelProps = {
 export function DashboardApplicationsPanel({
   applications,
 }: DashboardApplicationsPanelProps) {
-  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
-  const [selectedApplication, setSelectedApplication] =
-    useState<ApplicationListItem | null>(null);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const [applicationItems, setApplicationItems] = useState(applications);
+
+  useEffect(() => {
+    setApplicationItems(applications);
+  }, [applications]);
+
+  const selectedApplicationId = searchParams.get(PREVIEW_PARAM);
+  const isPreviewOpen = selectedApplicationId !== null;
 
   const handleSelectApplication = (application: ApplicationListItem) => {
-    setSelectedApplication(application);
-    setIsPreviewOpen(true);
+    router.push(
+      `${pathname}?${PREVIEW_PARAM}=${application.id}` as unknown as Route,
+    );
   };
 
   const handleClosePreview = () => {
-    setIsPreviewOpen(false);
+    router.replace(pathname as unknown as Route);
   };
+
+  const handleStatusChange = (applicationId: string, nextStatus: JobStatus) => {
+    setApplicationItems((currentApplications) =>
+      currentApplications.map((application) => {
+        if (application.id !== applicationId) {
+          return application;
+        }
+
+        return {
+          ...application,
+          status: nextStatus,
+        };
+      }),
+    );
+  };
+
+  const selectedApplication =
+    applicationItems.find(
+      (application) => application.id === selectedApplicationId,
+    ) ?? null;
 
   return (
     <>
       <ApplicationTabs
-        applications={applications}
+        applications={applicationItems}
         onSelectApplication={handleSelectApplication}
       />
       <ApplicationPreviewSheet
         application={selectedApplication}
         isOpen={isPreviewOpen}
         onCloseAction={handleClosePreview}
+        onStatusChangeAction={handleStatusChange}
       />
     </>
   );

--- a/components/ui/tab-selector/TabSelector.tsx
+++ b/components/ui/tab-selector/TabSelector.tsx
@@ -177,7 +177,7 @@ function TabSelector({
             <button
               aria-checked={isSelected}
               className={cn(
-                "flex min-w-0 flex-1 items-center justify-center rounded-xl px-4 py-2.5 text-sm font-semibold transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+                "flex min-w-0 flex-1 cursor-pointer items-center justify-center rounded-xl px-4 py-2.5 text-sm font-semibold transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
                 defaultStateClassName,
                 itemClassName,
                 stateClassName,


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #93

## 📌 작업 내용

- 대시보드 바텀시트 및 공고 상세 페이지에 ApplicationStatusSelector 적용
- 바텀시트 열림 상태를 쿼리파라미터(preview)로 관리하여 상세 페이지 뒤로가기시 복원
- 바텀시트 헤더에 플랫폼/지원일 메타 정보 이동, 테두리 제거 후 | 구분자 방식으로 변경
- useSearchParams 사용을 위해 DashboardApplicationsPanel을 Suspense로 래핑
- TabSelector 버튼에 cursor-pointer 적용
- 공고 상세 페이지 원문 공고 버튼을 항상 오른쪽 끝에 고정


