### PR TITLE
fix: application 관련 UI 용어 통일(#100)

### DIFF
--- a/app/(protected)/applications/[applicationId]/page.tsx
+++ b/app/(protected)/applications/[applicationId]/page.tsx
@@ -30,9 +30,9 @@ const ERROR_STATE_META = {
     title: "로그인이 필요합니다",
   },
   NOT_FOUND: {
-    description: "삭제되었거나 접근할 수 없는 공고일 수 있습니다.",
+    description: "삭제되었거나 접근할 수 없는 지원 기록일 수 있습니다.",
     icon: FileTextIcon,
-    title: "공고 상세를 찾을 수 없습니다",
+    title: "지원 기록을 찾을 수 없습니다",
   },
   QUERY_ERROR: {
     description: "잠시 후 다시 시도하거나 대시보드에서 다시 진입해 주세요.",
@@ -47,7 +47,7 @@ const ERROR_STATE_META = {
   VALIDATION_ERROR: {
     description: "잘못된 상세 경로로 접근했습니다.",
     icon: FileTextIcon,
-    title: "유효하지 않은 공고 경로입니다",
+    title: "유효하지 않은 지원 경로입니다",
   },
 } as const;
 
@@ -127,7 +127,7 @@ export default async function ApplicationDetailPage({
 
           <ApplicationStatusSelector
             applicationId={detail.id}
-            ariaLabel="공고 상태 변경"
+            ariaLabel="지원 상태 변경"
             icon={<ListChecksIcon aria-hidden="true" className="size-4" />}
             label="지원 상태"
             status={detail.status}

--- a/app/(protected)/dashboard/_components/dashboard-view/_utils/preview.ts
+++ b/app/(protected)/dashboard/_components/dashboard-view/_utils/preview.ts
@@ -30,13 +30,13 @@ export function getErrorSummary(
 ) {
   switch (result.code) {
     case "AUTH_REQUIRED": {
-      return "로그인이 필요한 공고입니다.";
+      return "로그인이 필요합니다.";
     }
     case "NOT_FOUND": {
-      return "공고 상세를 찾을 수 없습니다.";
+      return "지원 기록을 찾을 수 없습니다.";
     }
     default: {
-      return "공고 정보를 불러오지 못했습니다.";
+      return "지원 정보를 불러오지 못했습니다.";
     }
   }
 }

--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationPreviewSheet.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationPreviewSheet.tsx
@@ -106,7 +106,7 @@ export function ApplicationPreviewSheet({
 
   const detail = previewState.status === "ready" ? previewState.detail : null;
   const title =
-    detail?.positionTitle ?? application?.positionTitle ?? "공고 미리보기";
+    detail?.positionTitle ?? application?.positionTitle ?? "지원 미리보기";
   const companyName = detail?.companyName ?? application?.companyName ?? "";
   const platform = detail?.platform ?? application?.platform;
   const appliedAt = detail?.appliedAt ?? application?.appliedAt;
@@ -115,7 +115,7 @@ export function ApplicationPreviewSheet({
 
   const footerButtonContent = (
     <>
-      공고 상세 보기
+      지원 상세 보기
       <ChevronRightIcon aria-hidden="true" className="size-4" />
     </>
   );
@@ -157,7 +157,7 @@ export function ApplicationPreviewSheet({
           {application && (
             <ApplicationStatusSelector
               applicationId={application.id}
-              ariaLabel="공고 상태 변경"
+              ariaLabel="지원 상태 변경"
               className="mt-2"
               icon={<ListChecksIcon aria-hidden="true" className="size-4" />}
               label="지원 상태"
@@ -176,7 +176,7 @@ export function ApplicationPreviewSheet({
               role="status"
             >
               <p className="text-sm text-muted-foreground">
-                공고 정보를 불러오는 중입니다.
+                지원 정보를 불러오는 중입니다.
               </p>
             </div>
           )}

--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationRow.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationRow.tsx
@@ -16,7 +16,7 @@ export function ApplicationRow({ application, onSelect }: ApplicationRowProps) {
 
   return (
     <button
-      aria-label={`${application.companyName} ${application.positionTitle} 공고 미리보기 열기`}
+      aria-label={`${application.companyName} ${application.positionTitle} 지원 미리보기 열기`}
       className={cn(
         "flex w-full items-start justify-between gap-4 border-b border-border py-4 text-left",
         "cursor-pointer transition-colors",


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #100

## 📌 작업 내용

- application(지원 기록)을 공고로 잘못 표기한 텍스트를 '지원'으로 수정. 공고 자체를 가리키는 '공고 설명', '원문 공고 보러가기'는 유지.

