### PR TITLE
feat: 지원 메모 수정 서버 액션 구현(#104)

### DIFF
--- a/lib/actions/index.ts
+++ b/lib/actions/index.ts
@@ -2,4 +2,5 @@ export { extractJobData } from "./extractJobData";
 export { getApplicationDetail } from "./getApplicationDetail";
 export { getApplications } from "./getApplications";
 export { saveJobApplication } from "./saveJobApplication";
+export { updateApplicationNotes } from "./updateApplicationNotes";
 export { updateApplicationStatus } from "./updateApplicationStatus";

--- a/lib/actions/updateApplicationNotes.ts
+++ b/lib/actions/updateApplicationNotes.ts
@@ -1,0 +1,97 @@
+"use server";
+
+import { z } from "zod";
+
+import { createClient } from "@/lib/supabase/server";
+import {
+  type UpdateApplicationNotesInput,
+  updateApplicationNotesInputSchema,
+  type UpdateApplicationNotesResult,
+} from "@/lib/types/application";
+
+const AUTH_ERROR_CODE = "28000";
+const ERROR_MESSAGES = {
+  AUTH_REQUIRED: "로그인이 필요합니다.",
+  NOT_FOUND: "메모를 수정할 지원 정보를 찾을 수 없습니다.",
+  VALIDATION_ERROR: "유효하지 않은 지원 메모 수정 입력입니다.",
+} as const;
+
+type QueryErrorLike = {
+  code?: string;
+  details?: null | string;
+  hint?: null | string;
+  message: string;
+};
+
+export async function updateApplicationNotes(
+  input: UpdateApplicationNotesInput,
+): Promise<UpdateApplicationNotesResult> {
+  const parsedInput = updateApplicationNotesInputSchema.safeParse(input);
+
+  if (!parsedInput.success) {
+    const flattened = z.flattenError(parsedInput.error);
+
+    return {
+      code: "VALIDATION_ERROR",
+      ok: false,
+      reason:
+        flattened.formErrors[0] ??
+        parsedInput.error.issues[0]?.message ??
+        ERROR_MESSAGES.VALIDATION_ERROR,
+    };
+  }
+
+  const supabase = await createClient();
+  const { data: authData, error: authError } = await supabase.auth.getUser();
+
+  if (authError || !authData.user) {
+    return {
+      code: "AUTH_REQUIRED",
+      ok: false,
+      reason: ERROR_MESSAGES.AUTH_REQUIRED,
+    };
+  }
+
+  const { data, error } = await supabase
+    .from("applications")
+    .update({
+      notes: parsedInput.data.notes,
+    })
+    .eq("id", parsedInput.data.applicationId)
+    .eq("user_id", authData.user.id)
+    .select("notes")
+    .maybeSingle();
+
+  if (error) {
+    return {
+      code: error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR",
+      ok: false,
+      reason: normalizeQueryError(error),
+    };
+  }
+
+  if (!data) {
+    return {
+      code: "NOT_FOUND",
+      ok: false,
+      reason: ERROR_MESSAGES.NOT_FOUND,
+    };
+  }
+
+  return {
+    data: {
+      notes: data.notes,
+    },
+    ok: true,
+  };
+}
+
+function normalizeQueryError(error: QueryErrorLike): string {
+  const metadata = [error.details, error.hint].filter(Boolean).join(" | ");
+
+  if (metadata.length > 0) {
+    return `${error.message} (${metadata})`;
+  }
+
+  return error.message;
+}

--- a/lib/types/application.ts
+++ b/lib/types/application.ts
@@ -8,11 +8,29 @@ import {
 } from "@/lib/types/job";
 
 export const applicationIdSchema = z.uuid("applicationId must be a valid UUID");
+const applicationNotesSchema = z
+  .string()
+  .trim()
+  .nullable()
+  .transform((value) => {
+    if (value === null || value.length === 0) {
+      return null;
+    }
+
+    return value;
+  });
 
 export const updateApplicationStatusInputSchema = z
   .object({
     applicationId: applicationIdSchema,
     status: jobStatusSchema,
+  })
+  .strict();
+
+export const updateApplicationNotesInputSchema = z
+  .object({
+    applicationId: applicationIdSchema,
+    notes: applicationNotesSchema,
   })
   .strict();
 
@@ -66,6 +84,29 @@ export type GetApplicationDetailResult =
     }
   | {
       data: ApplicationDetail;
+      ok: true;
+    };
+
+export type UpdateApplicationNotesErrorCode =
+  | "AUTH_REQUIRED"
+  | "NOT_FOUND"
+  | "QUERY_ERROR"
+  | "VALIDATION_ERROR";
+
+export type UpdateApplicationNotesInput = z.infer<
+  typeof updateApplicationNotesInputSchema
+>;
+
+export type UpdateApplicationNotesResult =
+  | {
+      code: UpdateApplicationNotesErrorCode;
+      ok: false;
+      reason: string;
+    }
+  | {
+      data: {
+        notes: null | string;
+      };
       ok: true;
     };
 


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #104

## 📌 작업 내용

- 지원 메모 수정 입력 스키마와 결과 타입 추가
- applications.notes를 갱신하는 updateApplicationNotes 서버 액션 구현
- 빈 문자열 메모는 trim 후 null로 정규화되도록 처리


