### PR TITLE
fix: 지원 바텀시트 콘텐츠 높이 고정으로 레이아웃 시프트 해소(#108)

### DIFF
--- a/app/(protected)/dashboard/_components/dashboard-view/_utils/preview.ts
+++ b/app/(protected)/dashboard/_components/dashboard-view/_utils/preview.ts
@@ -7,7 +7,6 @@ import { formatAppliedAt } from "@/lib/utils";
 
 export { formatAppliedAt };
 
-const DEFAULT_MAX_LENGTH = 160;
 const EMPTY_DESCRIPTION = "공고 설명이 없습니다";
 const EMPTY_NOTES = "개인 메모가 없습니다";
 
@@ -21,7 +20,7 @@ export function getDescriptionMeta(
 ): PreviewTextMeta {
   return {
     isEmpty: !detail?.description?.trim(),
-    text: getPreviewText(detail?.description ?? null, EMPTY_DESCRIPTION),
+    text: detail?.description?.trim() || EMPTY_DESCRIPTION,
   };
 }
 
@@ -46,24 +45,6 @@ export function getNotesMeta(
 ): PreviewTextMeta {
   return {
     isEmpty: !detail?.notes?.trim(),
-    text: getPreviewText(detail?.notes ?? null, EMPTY_NOTES, 120),
+    text: detail?.notes?.trim() || EMPTY_NOTES,
   };
-}
-
-export function getPreviewText(
-  value: null | string,
-  emptyText: string,
-  maxLength = DEFAULT_MAX_LENGTH,
-) {
-  const normalizedValue = value?.trim();
-
-  if (!normalizedValue) {
-    return emptyText;
-  }
-
-  if (normalizedValue.length <= maxLength) {
-    return normalizedValue;
-  }
-
-  return `${normalizedValue.slice(0, maxLength).trimEnd()}...`;
 }

--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationPreviewSection.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationPreviewSection.tsx
@@ -25,7 +25,7 @@ export function ApplicationPreviewSection({
       </div>
       <p
         className={cn(
-          "text-sm leading-6 whitespace-pre-wrap text-foreground",
+          "line-clamp-3 text-sm leading-6 whitespace-pre-wrap text-foreground",
           isEmpty && "text-muted-foreground",
         )}
       >

--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationPreviewSheet.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationPreviewSheet.tsx
@@ -19,7 +19,7 @@ import type {
 import type { JobStatus } from "@/lib/types/job";
 
 import { ApplicationStatusSelector } from "@/app/(protected)/_components/ApplicationStatusSelector";
-import { BottomSheet, Button } from "@/components/ui";
+import { BottomSheet, Button, Skeleton } from "@/components/ui";
 import { getApplicationDetail } from "@/lib/actions";
 import { updateApplicationStatus } from "@/lib/actions/updateApplicationStatus";
 
@@ -171,13 +171,13 @@ export function ApplicationPreviewSheet({
 
           {previewState.status === "loading" && (
             <div
-              aria-live="polite"
-              className="rounded-2xl border border-dashed border-border px-4 py-5"
+              aria-busy="true"
+              aria-label="지원 정보를 불러오는 중입니다"
+              className="space-y-4"
               role="status"
             >
-              <p className="text-sm text-muted-foreground">
-                지원 정보를 불러오는 중입니다.
-              </p>
+              <ApplicationPreviewSectionSkeleton />
+              <ApplicationPreviewSectionSkeleton />
             </div>
           )}
 
@@ -240,5 +240,21 @@ export function ApplicationPreviewSheet({
         </div>
       </BottomSheet.Content>
     </BottomSheet>
+  );
+}
+
+function ApplicationPreviewSectionSkeleton() {
+  return (
+    <section className="space-y-2 py-1">
+      <div className="flex items-center gap-2">
+        <Skeleton className="size-4" />
+        <Skeleton className="h-4 w-16" />
+      </div>
+      <div className="space-y-1.5">
+        <Skeleton className="h-6 w-full" />
+        <Skeleton className="h-6 w-full" />
+        <Skeleton className="h-6 w-5/6" />
+      </div>
+    </section>
   );
 }

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -1,4 +1,5 @@
 export { BottomSheet } from "./bottom-sheet/BottomSheet";
 export { Button } from "./button/Button";
+export { Skeleton } from "./skeleton/Skeleton";
 export { TabSelector } from "./tab-selector/TabSelector";
 export { Tabs } from "./tabs/Tabs";

--- a/components/ui/skeleton/Skeleton.tsx
+++ b/components/ui/skeleton/Skeleton.tsx
@@ -1,0 +1,14 @@
+import type { HTMLAttributes } from "react";
+
+import { cn } from "@/lib/utils";
+
+type SkeletonProps = HTMLAttributes<HTMLDivElement>;
+
+export function Skeleton({ className, ...props }: SkeletonProps) {
+  return (
+    <div
+      className={cn("animate-pulse rounded bg-muted", className)}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #108

## 📌 작업 내용

- 공고 설명/개인 메모를 line-clamp로 줄 수 고정
- 로딩 스켈레톤도 동일하게 맞춰 전환 시 높이 변화 제거
- 글자 수 truncate 로직 제거(CSS 줄 제한으로 대체)
- 스켈레톤 공통 컴포넌트 추가


