### PR TITLE
feat: 공고 설명 수정 서버 액션 추가(#110)

### DIFF
--- a/lib/actions/index.ts
+++ b/lib/actions/index.ts
@@ -4,3 +4,4 @@ export { getApplications } from "./getApplications";
 export { saveJobApplication } from "./saveJobApplication";
 export { updateApplicationNotes } from "./updateApplicationNotes";
 export { updateApplicationStatus } from "./updateApplicationStatus";
+export { updateJobDescription } from "./updateJobDescription";

--- a/lib/actions/updateJobDescription.ts
+++ b/lib/actions/updateJobDescription.ts
@@ -1,0 +1,121 @@
+"use server";
+
+import { z } from "zod";
+
+import { createClient } from "@/lib/supabase/server";
+import {
+  type UpdateJobDescriptionInput,
+  updateJobDescriptionInputSchema,
+  type UpdateJobDescriptionResult,
+} from "@/lib/types/application";
+
+const AUTH_ERROR_CODE = "28000";
+const ERROR_MESSAGES = {
+  AUTH_REQUIRED: "로그인이 필요합니다.",
+  NOT_FOUND: "공고 설명을 수정할 지원 정보를 찾을 수 없습니다.",
+  VALIDATION_ERROR: "유효하지 않은 공고 설명 수정 입력입니다.",
+} as const;
+
+type QueryErrorLike = {
+  code?: string;
+  details?: null | string;
+  hint?: null | string;
+  message: string;
+};
+
+export async function updateJobDescription(
+  input: UpdateJobDescriptionInput,
+): Promise<UpdateJobDescriptionResult> {
+  const parsedInput = updateJobDescriptionInputSchema.safeParse(input);
+
+  if (!parsedInput.success) {
+    const flattened = z.flattenError(parsedInput.error);
+
+    return {
+      code: "VALIDATION_ERROR",
+      ok: false,
+      reason:
+        flattened.formErrors[0] ??
+        parsedInput.error.issues[0]?.message ??
+        ERROR_MESSAGES.VALIDATION_ERROR,
+    };
+  }
+
+  const supabase = await createClient();
+  const { data: authData, error: authError } = await supabase.auth.getUser();
+
+  if (authError || !authData.user) {
+    return {
+      code: "AUTH_REQUIRED",
+      ok: false,
+      reason: ERROR_MESSAGES.AUTH_REQUIRED,
+    };
+  }
+
+  // application을 통해 job_id를 조회하고, 해당 사용자 소유 여부를 검증합니다.
+  const { data: applicationData, error: applicationError } = await supabase
+    .from("applications")
+    .select("job_id")
+    .eq("id", parsedInput.data.applicationId)
+    .eq("user_id", authData.user.id)
+    .maybeSingle();
+
+  if (applicationError) {
+    return {
+      code:
+        applicationError.code === AUTH_ERROR_CODE
+          ? "AUTH_REQUIRED"
+          : "QUERY_ERROR",
+      ok: false,
+      reason: normalizeQueryError(applicationError),
+    };
+  }
+
+  if (!applicationData) {
+    return {
+      code: "NOT_FOUND",
+      ok: false,
+      reason: ERROR_MESSAGES.NOT_FOUND,
+    };
+  }
+
+  const { data, error } = await supabase
+    .from("jobs")
+    .update({ description: parsedInput.data.description })
+    .eq("id", applicationData.job_id)
+    .select("description")
+    .maybeSingle();
+
+  if (error) {
+    return {
+      code: error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR",
+      ok: false,
+      reason: normalizeQueryError(error),
+    };
+  }
+
+  if (!data) {
+    return {
+      code: "NOT_FOUND",
+      ok: false,
+      reason: ERROR_MESSAGES.NOT_FOUND,
+    };
+  }
+
+  return {
+    data: {
+      description: data.description,
+    },
+    ok: true,
+  };
+}
+
+function normalizeQueryError(error: QueryErrorLike): string {
+  const metadata = [error.details, error.hint].filter(Boolean).join(" | ");
+
+  if (metadata.length > 0) {
+    return `${error.message} (${metadata})`;
+  }
+
+  return error.message;
+}

--- a/lib/types/application.ts
+++ b/lib/types/application.ts
@@ -110,6 +110,25 @@ export type UpdateApplicationNotesResult =
       ok: true;
     };
 
+const jobDescriptionSchema = z
+  .string()
+  .trim()
+  .nullable()
+  .transform((value) => {
+    if (value === null || value.length === 0) {
+      return null;
+    }
+
+    return value;
+  });
+
+export const updateJobDescriptionInputSchema = z
+  .object({
+    applicationId: applicationIdSchema,
+    description: jobDescriptionSchema,
+  })
+  .strict();
+
 export type UpdateApplicationStatusErrorCode =
   | "AUTH_REQUIRED"
   | "NOT_FOUND"
@@ -127,5 +146,28 @@ export type UpdateApplicationStatusResult =
       reason: string;
     }
   | {
+      ok: true;
+    };
+
+export type UpdateJobDescriptionErrorCode =
+  | "AUTH_REQUIRED"
+  | "NOT_FOUND"
+  | "QUERY_ERROR"
+  | "VALIDATION_ERROR";
+
+export type UpdateJobDescriptionInput = z.infer<
+  typeof updateJobDescriptionInputSchema
+>;
+
+export type UpdateJobDescriptionResult =
+  | {
+      code: UpdateJobDescriptionErrorCode;
+      ok: false;
+      reason: string;
+    }
+  | {
+      data: {
+        description: null | string;
+      };
       ok: true;
     };

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "prettier": "^3.8.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "storybook": "^10.2.10",
-    "supabase": "^2.76.2",
+    "supabase": "^2.78.1",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vite": "^7.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,8 +117,8 @@ importers:
         specifier: ^10.2.10
         version: 10.2.10(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       supabase:
-        specifier: ^2.76.2
-        version: 2.76.2
+        specifier: ^2.78.1
+        version: 2.78.1
       tailwindcss:
         specifier: ^4
         version: 4.1.18
@@ -4232,13 +4232,6 @@ packages:
         integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==,
       }
 
-  minipass@7.1.2:
-    resolution:
-      {
-        integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==,
-      }
-    engines: { node: ">=16 || 14 >=14.17" }
-
   minipass@7.1.3:
     resolution:
       {
@@ -5175,10 +5168,10 @@ packages:
       babel-plugin-macros:
         optional: true
 
-  supabase@2.76.2:
+  supabase@2.78.1:
     resolution:
       {
-        integrity: sha512-nRsd7e9QM+Dth8ipYN9fuSev9RhUOA+CuQ3XEXp9rjG9NIaEnVYad9PK3C1KH9vweEoJ/RG5GWI52x1nNlSb5w==,
+        integrity: sha512-fCIE/LTTr1IGrrYLqYBI3w89QU1qW+mRVtUi/Dmrtj+oXtDX4E8VgfFlXZpoYsXy86cfE9RZXUJVAGgvdNfTPg==,
       }
     engines: { npm: ">=8" }
     hasBin: true
@@ -5216,10 +5209,10 @@ packages:
       }
     engines: { node: ">=6" }
 
-  tar@7.5.7:
+  tar@7.5.11:
     resolution:
       {
-        integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==,
+        integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==,
       }
     engines: { node: ">=18" }
 
@@ -5635,10 +5628,10 @@ packages:
       }
     engines: { node: ">=18" }
 
-  write-file-atomic@7.0.0:
+  write-file-atomic@7.0.1:
     resolution:
       {
-        integrity: sha512-YnlPC6JqnZl6aO4uRc+dx5PHguiR9S6WeoLtpxNT9wIG+BDya7ZNE1q7KOjVgaA73hKhKLpVPgJ5QA9THQ5BRg==,
+        integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==,
       }
     engines: { node: ^20.17.0 || >=22.9.0 }
 
@@ -6087,7 +6080,7 @@ snapshots:
 
   "@isaacs/fs-minipass@4.0.1":
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   "@joshwooding/vite-plugin-react-docgen-typescript@0.6.4(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.30)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))":
     dependencies:
@@ -7014,7 +7007,7 @@ snapshots:
       npm-normalize-package-bin: 5.0.0
       proc-log: 6.1.0
       read-cmd-shim: 6.0.0
-      write-file-atomic: 7.0.0
+      write-file-atomic: 7.0.1
 
   boolbase@1.0.0: {}
 
@@ -8224,13 +8217,11 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minipass@7.1.2: {}
-
   minipass@7.1.3: {}
 
   minizlib@3.1.0:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   module-alias@2.3.4: {}
 
@@ -8840,12 +8831,12 @@ snapshots:
     optionalDependencies:
       "@babel/core": 7.28.6
 
-  supabase@2.76.2:
+  supabase@2.78.1:
     dependencies:
       bin-links: 6.0.0
       https-proxy-agent: 7.0.6
       node-fetch: 3.3.2
-      tar: 7.5.7
+      tar: 7.5.11
     transitivePeerDependencies:
       - supports-color
 
@@ -8861,11 +8852,11 @@ snapshots:
 
   tapable@2.3.0: {}
 
-  tar@7.5.7:
+  tar@7.5.11:
     dependencies:
       "@isaacs/fs-minipass": 4.0.1
       chownr: 3.0.0
-      minipass: 7.1.2
+      minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
 
@@ -9172,9 +9163,8 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.1.2
 
-  write-file-atomic@7.0.0:
+  write-file-atomic@7.0.1:
     dependencies:
-      imurmurhash: 0.1.4
       signal-exit: 4.1.0
 
   ws@8.19.0: {}

--- a/supabase/migrations/20260315000000_allow_applicants_to_update_job_description.sql
+++ b/supabase/migrations/20260315000000_allow_applicants_to_update_job_description.sql
@@ -1,0 +1,29 @@
+BEGIN;
+
+-- Allow users to update the description of jobs they have applied to.
+-- The jobs table is shared (one row per public posting), so this lets any
+-- applicant improve the shared description. All other columns are protected
+-- because UPDATE in PostgreSQL only grants row access — column-level changes
+-- are still subject to the application's own query (which only writes description).
+CREATE POLICY "Users can update jobs they applied to"
+  ON jobs
+  FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM applications a
+      WHERE a.job_id = jobs.id
+        AND a.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM applications a
+      WHERE a.job_id = jobs.id
+        AND a.user_id = auth.uid()
+    )
+  );
+
+COMMIT;


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #110

## 📌 작업 내용

- jobs 테이블에 UPDATE RLS 정책 추가(지원서 보유 사용자에 한해 허용)
- updateJobDescriptionInputSchema, UpdateJobDescriptionInput/Result 타입 정의
- updateJobDescription 서버 액션 구현(applicationId로 소유권 검증 후 job description 업데이트)
- supabase를 devDependency로 이동


