### PR TITLE
refactor: AUTH_ERROR_CODE, normalizeQueryError를 분리(#118)

### DIFF
--- a/lib/actions/_queryError.ts
+++ b/lib/actions/_queryError.ts
@@ -1,0 +1,18 @@
+export const AUTH_ERROR_CODE = "28000";
+
+export type QueryErrorLike = {
+  code?: string;
+  details?: null | string;
+  hint?: null | string;
+  message: string;
+};
+
+export function normalizeQueryError(error: QueryErrorLike): string {
+  const metadata = [error.details, error.hint].filter(Boolean).join(" | ");
+
+  if (metadata.length > 0) {
+    return `${error.message} (${metadata})`;
+  }
+
+  return error.message;
+}

--- a/lib/actions/_verifyApplicationOwnership.ts
+++ b/lib/actions/_verifyApplicationOwnership.ts
@@ -1,13 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 
-const AUTH_ERROR_CODE = "28000";
-
-export type QueryErrorLike = {
-  code?: string;
-  details?: null | string;
-  hint?: null | string;
-  message: string;
-};
+import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 
 type VerifyResult =
   | {
@@ -19,16 +12,6 @@ type VerifyResult =
       ok: true;
       supabase: Awaited<ReturnType<typeof createClient>>;
     };
-
-export function normalizeQueryError(error: QueryErrorLike): string {
-  const metadata = [error.details, error.hint].filter(Boolean).join(" | ");
-
-  if (metadata.length > 0) {
-    return `${error.message} (${metadata})`;
-  }
-
-  return error.message;
-}
 
 /**
  * 인증 및 application 소유권을 검증하고, 성공 시 supabase 클라이언트를 반환합니다.

--- a/lib/actions/getApplicationDetail.ts
+++ b/lib/actions/getApplicationDetail.ts
@@ -7,20 +7,14 @@ import {
   type GetApplicationDetailResult,
 } from "@/lib/types/application";
 
-const AUTH_ERROR_CODE = "28000";
+import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
+
 const ERROR_MESSAGES = {
   AUTH_REQUIRED: "로그인이 필요합니다.",
   INVALID_RESPONSE: "지원 상세 응답을 해석하지 못했습니다.",
   NOT_FOUND: "지원 상세 정보를 찾을 수 없습니다.",
   VALIDATION_ERROR: "유효하지 않은 applicationId입니다.",
 } as const;
-
-type QueryErrorLike = {
-  code?: string;
-  details?: null | string;
-  hint?: null | string;
-  message: string;
-};
 
 export async function getApplicationDetail(
   applicationId: string,
@@ -118,14 +112,4 @@ export async function getApplicationDetail(
     data: parsedDetail.data,
     ok: true,
   };
-}
-
-function normalizeQueryError(error: QueryErrorLike): string {
-  const metadata = [error.details, error.hint].filter(Boolean).join(" | ");
-
-  if (metadata.length > 0) {
-    return `${error.message} (${metadata})`;
-  }
-
-  return error.message;
 }

--- a/lib/actions/saveJobApplication.ts
+++ b/lib/actions/saveJobApplication.ts
@@ -11,20 +11,14 @@ import {
   type SaveJobApplicationResult,
 } from "@/lib/types/jobApplication";
 
-const AUTH_ERROR_CODE = "28000";
+import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
+
 const ERROR_MESSAGES = {
   AUTH_REQUIRED: "Authentication required.",
   INVALID_RPC_RESPONSE: "Failed to parse save_job_application response.",
   UNKNOWN_ERROR: "Unknown error",
   VALIDATION_ERROR: "Invalid saveJobApplication input.",
 } as const;
-
-type RpcErrorLike = {
-  code?: string;
-  details?: null | string;
-  hint?: null | string;
-  message: string;
-};
 
 export async function saveJobApplication(
   input: SaveJobApplicationInput,
@@ -72,7 +66,7 @@ export async function saveJobApplication(
     return {
       code: error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "RPC_ERROR",
       ok: false,
-      reason: normalizeRpcError(error),
+      reason: normalizeQueryError(error),
     };
   }
 
@@ -91,14 +85,4 @@ export async function saveJobApplication(
     data: parsedPayload.data,
     ok: true,
   };
-}
-
-function normalizeRpcError(error: RpcErrorLike): string {
-  const metadata = [error.details, error.hint].filter(Boolean).join(" | ");
-
-  if (metadata.length > 0) {
-    return `${error.message} (${metadata})`;
-  }
-
-  return error.message;
 }

--- a/lib/actions/updateApplicationNotes.ts
+++ b/lib/actions/updateApplicationNotes.ts
@@ -9,19 +9,13 @@ import {
   type UpdateApplicationNotesResult,
 } from "@/lib/types/application";
 
-const AUTH_ERROR_CODE = "28000";
+import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
+
 const ERROR_MESSAGES = {
   AUTH_REQUIRED: "로그인이 필요합니다.",
   NOT_FOUND: "메모를 수정할 지원 정보를 찾을 수 없습니다.",
   VALIDATION_ERROR: "유효하지 않은 지원 메모 수정 입력입니다.",
 } as const;
-
-type QueryErrorLike = {
-  code?: string;
-  details?: null | string;
-  hint?: null | string;
-  message: string;
-};
 
 export async function updateApplicationNotes(
   input: UpdateApplicationNotesInput,
@@ -84,14 +78,4 @@ export async function updateApplicationNotes(
     },
     ok: true,
   };
-}
-
-function normalizeQueryError(error: QueryErrorLike): string {
-  const metadata = [error.details, error.hint].filter(Boolean).join(" | ");
-
-  if (metadata.length > 0) {
-    return `${error.message} (${metadata})`;
-  }
-
-  return error.message;
 }

--- a/lib/actions/updateApplicationStatus.ts
+++ b/lib/actions/updateApplicationStatus.ts
@@ -9,19 +9,13 @@ import {
   type UpdateApplicationStatusResult,
 } from "@/lib/types/application";
 
-const AUTH_ERROR_CODE = "28000";
+import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
+
 const ERROR_MESSAGES = {
   AUTH_REQUIRED: "로그인이 필요합니다.",
   NOT_FOUND: "상태를 변경할 지원 정보를 찾을 수 없습니다.",
   VALIDATION_ERROR: "유효하지 않은 지원상태 변경 입력입니다.",
 } as const;
-
-type QueryErrorLike = {
-  code?: string;
-  details?: null | string;
-  hint?: null | string;
-  message: string;
-};
 
 export async function updateApplicationStatus(
   input: UpdateApplicationStatusInput,
@@ -81,14 +75,4 @@ export async function updateApplicationStatus(
   return {
     ok: true,
   };
-}
-
-function normalizeQueryError(error: QueryErrorLike): string {
-  const metadata = [error.details, error.hint].filter(Boolean).join(" | ");
-
-  if (metadata.length > 0) {
-    return `${error.message} (${metadata})`;
-  }
-
-  return error.message;
 }

--- a/lib/actions/updateJobDescription.ts
+++ b/lib/actions/updateJobDescription.ts
@@ -9,19 +9,13 @@ import {
   type UpdateJobDescriptionResult,
 } from "@/lib/types/application";
 
-const AUTH_ERROR_CODE = "28000";
+import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
+
 const ERROR_MESSAGES = {
   AUTH_REQUIRED: "로그인이 필요합니다.",
   NOT_FOUND: "공고 설명을 수정할 지원 정보를 찾을 수 없습니다.",
   VALIDATION_ERROR: "유효하지 않은 공고 설명 수정 입력입니다.",
 } as const;
-
-type QueryErrorLike = {
-  code?: string;
-  details?: null | string;
-  hint?: null | string;
-  message: string;
-};
 
 export async function updateJobDescription(
   input: UpdateJobDescriptionInput,
@@ -108,14 +102,4 @@ export async function updateJobDescription(
     },
     ok: true,
   };
-}
-
-function normalizeQueryError(error: QueryErrorLike): string {
-  const metadata = [error.details, error.hint].filter(Boolean).join(" | ");
-
-  if (metadata.length > 0) {
-    return `${error.message} (${metadata})`;
-  }
-
-  return error.message;
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #118 

## 📌 작업 내용

- AUTH_ERROR_CODE, normalizeQueryError를 actions/_queryError 로 분리


