### PR TITLE
feat: 면접 일정 추가/편집 폼 구현(#128)

### DIFF
--- a/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import type {
+  InterviewDetail,
+  InterviewType,
+  UpsertInterviewInput,
+  UpsertInterviewResult,
+} from "@/lib/types/interview";
+
+import { Button } from "@/components/ui";
+import { BottomSheet } from "@/components/ui/bottom-sheet/BottomSheet";
+import { INTERVIEW_TYPE_LABEL } from "@/lib/constants/interview-type";
+import { Constants } from "@/lib/types/supabase";
+import { toDatetimeLocalValue } from "@/lib/utils";
+
+const INTERVIEW_TYPES = Constants.public.Enums.interview_type;
+
+const INPUT_CLASS =
+  "w-full rounded-md border border-input bg-background px-3 py-2 text-[15px] text-foreground placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50";
+
+export type InterviewFormSheetProps = AddModeProps | EditModeProps;
+
+type AddModeProps = {
+  applicationId: string;
+  defaultRound?: number;
+  mode: "add";
+  upsertAction: UpsertAction;
+};
+
+type EditModeProps = {
+  applicationId: string;
+  interview: InterviewDetail;
+  mode: "edit";
+  upsertAction: UpsertAction;
+};
+
+type FormValues = {
+  interviewType: InterviewType;
+  location: string;
+  round: number;
+  scheduledAt: string;
+  scratchpad: string;
+};
+
+type UpsertAction = (
+  input: UpsertInterviewInput,
+) => Promise<UpsertInterviewResult>;
+
+export function InterviewFormSheet(props: InterviewFormSheetProps) {
+  const router = useRouter();
+  const [isOpen, setIsOpen] = useState(false);
+  const [values, setValues] = useState<FormValues>(() =>
+    getInitialValues(props),
+  );
+  const [isSaving, setIsSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<null | string>(null);
+
+  const isEditMode = props.mode === "edit";
+  const title = isEditMode ? "면접 일정 편집" : "면접 일정 추가";
+  const triggerLabel = isEditMode ? "편집" : "추가";
+
+  function handleOpen() {
+    setValues(getInitialValues(props));
+    setErrorMessage(null);
+    setIsOpen(true);
+  }
+
+  function handleClose() {
+    if (isSaving) {
+      return;
+    }
+    setIsOpen(false);
+  }
+
+  async function handleSubmit(e: React.SubmitEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (isSaving) {
+      return;
+    }
+
+    setIsSaving(true);
+    setErrorMessage(null);
+
+    try {
+      const result = await props.upsertAction({
+        applicationId: props.applicationId,
+        interviewType: values.interviewType,
+        location: values.location,
+        round: values.round,
+        scheduledAt: new Date(values.scheduledAt).toISOString(),
+        scratchpad: values.scratchpad,
+      });
+
+      if (!result.ok) {
+        setErrorMessage(result.reason);
+        return;
+      }
+
+      setIsOpen(false);
+      router.refresh();
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <>
+      <Button onClick={handleOpen} size="sm" variant="ghost">
+        {triggerLabel}
+      </Button>
+
+      <BottomSheet isOpen={isOpen} onClose={handleClose}>
+        <BottomSheet.Overlay
+          onClick={(e) => {
+            if (isSaving) {
+              e.preventDefault();
+            }
+          }}
+        />
+        <BottomSheet.Content>
+          <BottomSheet.Header />
+          <BottomSheet.Body>
+            <BottomSheet.Title className="mb-6">{title}</BottomSheet.Title>
+
+            <form className="space-y-4" onSubmit={handleSubmit}>
+              <div className="space-y-1.5">
+                <label
+                  className="text-sm font-medium text-foreground"
+                  htmlFor="interview-round"
+                >
+                  차수
+                </label>
+                <input
+                  className={INPUT_CLASS}
+                  disabled={isEditMode || isSaving}
+                  id="interview-round"
+                  min={1}
+                  onChange={(e) =>
+                    setValues((prev) => ({
+                      ...prev,
+                      round: Number(e.target.value),
+                    }))
+                  }
+                  required
+                  type="number"
+                  value={values.round}
+                />
+                {isEditMode && (
+                  <p className="text-xs text-muted-foreground">
+                    차수는 변경할 수 없습니다.
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-1.5">
+                <label
+                  className="text-sm font-medium text-foreground"
+                  htmlFor="interview-type"
+                >
+                  면접 유형
+                </label>
+                <select
+                  className={INPUT_CLASS}
+                  disabled={isSaving}
+                  id="interview-type"
+                  onChange={(e) =>
+                    setValues((prev) => ({
+                      ...prev,
+                      interviewType: e.target.value as InterviewType,
+                    }))
+                  }
+                  value={values.interviewType}
+                >
+                  {INTERVIEW_TYPES.map((type) => (
+                    <option key={type} value={type}>
+                      {INTERVIEW_TYPE_LABEL[type]}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="space-y-1.5">
+                <label
+                  className="text-sm font-medium text-foreground"
+                  htmlFor="interview-scheduled-at"
+                >
+                  일시
+                </label>
+                <input
+                  className={INPUT_CLASS}
+                  disabled={isSaving}
+                  id="interview-scheduled-at"
+                  onChange={(e) =>
+                    setValues((prev) => ({
+                      ...prev,
+                      scheduledAt: e.target.value,
+                    }))
+                  }
+                  required
+                  type="datetime-local"
+                  value={values.scheduledAt}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <label
+                  className="flex gap-1 text-sm font-medium text-foreground"
+                  htmlFor="interview-location"
+                >
+                  <span>장소</span>
+                  <span className="font-normal text-muted-foreground">
+                    (선택)
+                  </span>
+                </label>
+                <input
+                  className={INPUT_CLASS}
+                  disabled={isSaving}
+                  id="interview-location"
+                  onChange={(e) =>
+                    setValues((prev) => ({
+                      ...prev,
+                      location: e.target.value,
+                    }))
+                  }
+                  placeholder="예) 강남역 본사 3층"
+                  type="text"
+                  value={values.location}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <label
+                  className="flex gap-1 text-sm font-medium text-foreground"
+                  htmlFor="interview-scratchpad"
+                >
+                  <span>메모</span>
+                  <span className="font-normal text-muted-foreground">
+                    (선택)
+                  </span>
+                </label>
+                <textarea
+                  className={INPUT_CLASS}
+                  disabled={isSaving}
+                  id="interview-scratchpad"
+                  onChange={(e) =>
+                    setValues((prev) => ({
+                      ...prev,
+                      scratchpad: e.target.value,
+                    }))
+                  }
+                  placeholder="준비 사항, 질문 등을 자유롭게 기록하세요"
+                  rows={4}
+                  value={values.scratchpad}
+                />
+              </div>
+
+              {errorMessage !== null && (
+                <p className="text-sm text-red-600" role="alert">
+                  {errorMessage}
+                </p>
+              )}
+
+              <div className="flex justify-end gap-2 pt-2">
+                <Button
+                  disabled={isSaving}
+                  onClick={handleClose}
+                  type="button"
+                  variant="outline"
+                >
+                  취소
+                </Button>
+                <Button disabled={isSaving} type="submit">
+                  {isSaving ? "저장하는 중..." : "저장"}
+                </Button>
+              </div>
+            </form>
+          </BottomSheet.Body>
+        </BottomSheet.Content>
+      </BottomSheet>
+    </>
+  );
+}
+
+function getInitialValues(props: InterviewFormSheetProps): FormValues {
+  if (props.mode === "edit") {
+    return {
+      interviewType: props.interview.interviewType,
+      location: props.interview.location ?? "",
+      round: props.interview.round,
+      scheduledAt: toDatetimeLocalValue(props.interview.scheduledAt),
+      scratchpad: props.interview.scratchpad ?? "",
+    };
+  }
+  return {
+    interviewType: "TECH",
+    location: "",
+    round: props.defaultRound ?? 1,
+    scheduledAt: "",
+    scratchpad: "",
+  };
+}

--- a/app/(protected)/applications/[applicationId]/_components/InterviewSection.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/InterviewSection.tsx
@@ -1,11 +1,17 @@
 import { CalendarIcon } from "lucide-react";
 
+import type { InterviewDetail } from "@/lib/types/interview";
+
 import { getInterviews } from "@/lib/actions/getInterviews";
+import { upsertInterview } from "@/lib/actions/upsertInterview";
 import { INTERVIEW_TYPE_LABEL } from "@/lib/constants/interview-type";
 import { formatScheduledAt } from "@/lib/utils";
 
+import { InterviewFormSheet } from "./InterviewFormSheet";
+
 type InterviewListProps = {
-  result: Awaited<ReturnType<typeof getInterviews>>;
+  applicationId: string;
+  interviews: InterviewDetail[];
 };
 
 type InterviewSectionProps = {
@@ -26,23 +32,29 @@ export async function InterviewSection({
         <h2 className="text-base font-semibold tracking-[-0.01em]">
           면접 일정
         </h2>
+        <div className="ml-auto">
+          <InterviewFormSheet
+            applicationId={applicationId}
+            defaultRound={result.ok ? result.data.length + 1 : 1}
+            mode="add"
+            upsertAction={upsertInterview}
+          />
+        </div>
       </div>
 
-      <InterviewList result={result} />
+      {!result.ok ? (
+        <p className="text-[15px] text-muted-foreground">
+          면접 일정을 불러오지 못했습니다.
+        </p>
+      ) : (
+        <InterviewList applicationId={applicationId} interviews={result.data} />
+      )}
     </section>
   );
 }
 
-function InterviewList({ result }: InterviewListProps) {
-  if (!result.ok) {
-    return (
-      <p className="text-[15px] text-muted-foreground">
-        면접 일정을 불러오지 못했습니다.
-      </p>
-    );
-  }
-
-  if (result.data.length === 0) {
+function InterviewList({ applicationId, interviews }: InterviewListProps) {
+  if (interviews.length === 0) {
     return (
       <p className="text-[15px] text-muted-foreground">
         등록된 면접 일정이 없습니다.
@@ -52,7 +64,7 @@ function InterviewList({ result }: InterviewListProps) {
 
   return (
     <ul className="space-y-2">
-      {result.data.map((interview) => (
+      {interviews.map((interview) => (
         <li
           className="space-y-1 rounded-lg border border-border px-4 py-3"
           key={interview.id}
@@ -67,6 +79,14 @@ function InterviewList({ result }: InterviewListProps) {
                 임시저장
               </span>
             )}
+            <div className="ml-auto">
+              <InterviewFormSheet
+                applicationId={applicationId}
+                interview={interview}
+                mode="edit"
+                upsertAction={upsertInterview}
+              />
+            </div>
           </div>
           <p className="text-sm text-muted-foreground">
             {formatScheduledAt(interview.scheduledAt)}

--- a/components/ui/bottom-sheet/BottomSheet.tsx
+++ b/components/ui/bottom-sheet/BottomSheet.tsx
@@ -117,8 +117,10 @@ function Overlay({ className, ...props }: React.ComponentProps<"div">) {
         className,
       )}
       onClick={(e) => {
-        handleClose();
         props.onClick?.(e);
+        if (!e.defaultPrevented) {
+          handleClose();
+        }
       }}
     />
   );

--- a/lib/actions/index.ts
+++ b/lib/actions/index.ts
@@ -6,3 +6,4 @@ export { saveJobApplication } from "./saveJobApplication";
 export { updateApplicationNotes } from "./updateApplicationNotes";
 export { updateApplicationStatus } from "./updateApplicationStatus";
 export { updateJobDescription } from "./updateJobDescription";
+export { upsertInterview } from "./upsertInterview";

--- a/lib/utils/date.ts
+++ b/lib/utils/date.ts
@@ -56,3 +56,12 @@ export function getTimeAgo(dateString: string): string {
 
   return `${diffDays}일 전`;
 }
+
+export function toDatetimeLocalValue(isoString: string): string {
+  const date = new Date(isoString);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #128

## 📌 작업 내용

- InterviewFormSheet 컴포넌트 추가
- InterviewSection에 추가/편집 버튼 연결
- toDatetimeLocalValue 유틸 추가(lib/utils/date.ts)
- upsertInterview actions index export 추가


