### PR TITLE
feat: 면접 일정 삭제 기능 추가(#130)

### DIFF
--- a/app/(protected)/applications/[applicationId]/_components/DeleteInterviewButton.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/DeleteInterviewButton.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import type {
+  DeleteInterviewInput,
+  DeleteInterviewResult,
+} from "@/lib/types/interview";
+
+import { Button } from "@/components/ui";
+import { BottomSheet } from "@/components/ui/bottom-sheet/BottomSheet";
+
+type DeleteInterviewAction = (
+  input: DeleteInterviewInput,
+) => Promise<DeleteInterviewResult>;
+
+type DeleteInterviewButtonProps = {
+  applicationId: string;
+  deleteAction: DeleteInterviewAction;
+  interviewId: string;
+  round: number;
+};
+
+export function DeleteInterviewButton({
+  applicationId,
+  deleteAction,
+  interviewId,
+  round,
+}: DeleteInterviewButtonProps) {
+  const router = useRouter();
+  const [isOpen, setIsOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<null | string>(null);
+
+  function handleOpen() {
+    setErrorMessage(null);
+    setIsOpen(true);
+  }
+
+  function handleClose() {
+    if (isDeleting) {
+      return;
+    }
+    setIsOpen(false);
+  }
+
+  async function handleConfirm() {
+    if (isDeleting) {
+      return;
+    }
+
+    setIsDeleting(true);
+    setErrorMessage(null);
+
+    try {
+      const result = await deleteAction({ applicationId, interviewId });
+
+      if (!result.ok) {
+        setErrorMessage(result.reason);
+        return;
+      }
+
+      setIsOpen(false);
+      router.refresh();
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  return (
+    <>
+      <Button onClick={handleOpen} size="sm" variant="ghost">
+        삭제
+      </Button>
+
+      <BottomSheet isOpen={isOpen} onClose={handleClose}>
+        <BottomSheet.Overlay
+          onClick={(e) => {
+            if (isDeleting) {
+              e.preventDefault();
+            }
+          }}
+        />
+        <BottomSheet.Content>
+          <BottomSheet.Header />
+          <BottomSheet.Body>
+            <BottomSheet.Title className="mb-2">
+              면접 일정 삭제
+            </BottomSheet.Title>
+            <p className="mb-6 text-[15px] text-muted-foreground">
+              {round}차 면접 일정을 삭제하시겠습니까? 이 작업은 되돌릴 수
+              없습니다.
+            </p>
+
+            {errorMessage !== null && (
+              <p className="mb-4 text-sm text-red-600" role="alert">
+                {errorMessage}
+              </p>
+            )}
+
+            <div className="flex justify-end gap-2">
+              <Button
+                disabled={isDeleting}
+                onClick={handleClose}
+                type="button"
+                variant="outline"
+              >
+                취소
+              </Button>
+              <Button
+                disabled={isDeleting}
+                onClick={handleConfirm}
+                type="button"
+                variant="destructive"
+              >
+                {isDeleting ? "삭제하는 중..." : "삭제"}
+              </Button>
+            </div>
+          </BottomSheet.Body>
+        </BottomSheet.Content>
+      </BottomSheet>
+    </>
+  );
+}

--- a/app/(protected)/applications/[applicationId]/_components/InterviewSection.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/InterviewSection.tsx
@@ -2,11 +2,13 @@ import { CalendarIcon } from "lucide-react";
 
 import type { InterviewDetail } from "@/lib/types/interview";
 
+import { deleteInterview } from "@/lib/actions/deleteInterview";
 import { getInterviews } from "@/lib/actions/getInterviews";
 import { upsertInterview } from "@/lib/actions/upsertInterview";
 import { INTERVIEW_TYPE_LABEL } from "@/lib/constants/interview-type";
 import { formatScheduledAt } from "@/lib/utils";
 
+import { DeleteInterviewButton } from "./DeleteInterviewButton";
 import { InterviewFormSheet } from "./InterviewFormSheet";
 
 type InterviewListProps = {
@@ -79,12 +81,18 @@ function InterviewList({ applicationId, interviews }: InterviewListProps) {
                 임시저장
               </span>
             )}
-            <div className="ml-auto">
+            <div className="ml-auto flex items-center gap-1">
               <InterviewFormSheet
                 applicationId={applicationId}
                 interview={interview}
                 mode="edit"
                 upsertAction={upsertInterview}
+              />
+              <DeleteInterviewButton
+                applicationId={applicationId}
+                deleteAction={deleteInterview}
+                interviewId={interview.id}
+                round={interview.round}
               />
             </div>
           </div>


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #130

## 📌 작업 내용

- DeleteInterviewButton 컴포넌트 추가
- 삭제 전 BottomSheet 확인 다이얼로그 표시
- 삭제 중 중복 요청 방지 및 에러 메시지 인라인 표시
- 성공 시 router.refresh()로 목록 갱신
- InterviewSection 각 면접 항목에 삭제 버튼 연결


