### PR TITLE
fix: 서버 액션 인증 및 소유권 검증 추가(#136)

### DIFF
--- a/app/(protected)/dashboard/_components/dashboard-view/DashboardView.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DashboardView.tsx
@@ -9,7 +9,13 @@ import { DashboardApplicationsPanel } from "./components/DashboardApplicationsPa
 import { DOCS_STATUSES } from "./constants";
 
 export async function DashboardView() {
-  const applications = await getApplications();
+  const applicationsResult = await getApplications();
+
+  if (!applicationsResult.ok) {
+    throw new Error(applicationsResult.reason);
+  }
+
+  const applications = applicationsResult.data;
 
   const stats = [
     { label: "전체", value: applications.length },

--- a/lib/actions/extractJobData.ts
+++ b/lib/actions/extractJobData.ts
@@ -2,28 +2,45 @@
 
 import { AdapterFactory } from "@/lib/adapters/AdapterFactory";
 import { validateSafeUrl } from "@/lib/adapters/utils/url-validator";
+import { createClient } from "@/lib/supabase/server";
 import { JobPost } from "@/lib/types/job";
 
 const UNKNOWN_ERROR_MESSAGE = "Unknown error";
 
+const ERROR_MESSAGES = {
+  AUTH_REQUIRED: "로그인이 필요합니다.",
+} as const;
+
 export type ExtractJobDataResult =
-  | { data: JobPost; ok: true; }
+  | { data: JobPost; ok: true }
   | { ok: false; reason: string };
 
-export async function extractJobData(url: string): Promise<ExtractJobDataResult> {
+export async function extractJobData(
+  url: string,
+): Promise<ExtractJobDataResult> {
+  const supabase = await createClient();
+  const { data: authData, error: authError } = await supabase.auth.getUser();
+
+  if (authError || !authData.user) {
+    return { ok: false, reason: ERROR_MESSAGES.AUTH_REQUIRED };
+  }
+
   const validatedUrlResult = await validateSafeUrl(url);
   if (!validatedUrlResult.ok) {
     return validatedUrlResult;
   }
 
   try {
-    const data = await AdapterFactory.extractFromUrl(validatedUrlResult.value.toString());
+    const data = await AdapterFactory.extractFromUrl(
+      validatedUrlResult.value.toString(),
+    );
     return {
       data,
       ok: true,
     };
   } catch (error) {
-    const message = error instanceof Error ? error.message : UNKNOWN_ERROR_MESSAGE;
+    const message =
+      error instanceof Error ? error.message : UNKNOWN_ERROR_MESSAGE;
     return {
       ok: false,
       reason: `Failed to extract job data: ${message}`,

--- a/lib/actions/getApplicationDetail.ts
+++ b/lib/actions/getApplicationDetail.ts
@@ -60,6 +60,7 @@ export async function getApplicationDetail(
       `,
     )
     .eq("id", parsedApplicationId.data)
+    .eq("user_id", authData.user.id)
     .maybeSingle();
 
   if (error) {

--- a/lib/actions/getApplications.ts
+++ b/lib/actions/getApplications.ts
@@ -1,11 +1,28 @@
 "use server";
 
-import type { ApplicationListItem } from "@/lib/types/application";
+import type {
+  ApplicationListItem,
+  GetApplicationsResult,
+} from "@/lib/types/application";
 
 import { createClient } from "../supabase/server";
+import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 
-export async function getApplications(): Promise<ApplicationListItem[]> {
+const ERROR_MESSAGES = {
+  AUTH_REQUIRED: "로그인이 필요합니다.",
+} as const;
+
+export async function getApplications(): Promise<GetApplicationsResult> {
   const supabase = await createClient();
+  const { data: authData, error: authError } = await supabase.auth.getUser();
+
+  if (authError || !authData.user) {
+    return {
+      code: "AUTH_REQUIRED",
+      ok: false,
+      reason: ERROR_MESSAGES.AUTH_REQUIRED,
+    };
+  }
 
   const { data, error } = await supabase
     .from("applications")
@@ -21,13 +38,18 @@ export async function getApplications(): Promise<ApplicationListItem[]> {
       )
     `,
     )
+    .eq("user_id", authData.user.id)
     .order("applied_at", { ascending: false });
 
-  if (error || !data) {
-    return [];
+  if (error) {
+    return {
+      code: error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR",
+      ok: false,
+      reason: normalizeQueryError(error),
+    };
   }
 
-  return data
+  const items: ApplicationListItem[] = data
     .map((row) => {
       const job = Array.isArray(row.jobs) ? row.jobs[0] : row.jobs;
 
@@ -45,4 +67,6 @@ export async function getApplications(): Promise<ApplicationListItem[]> {
       };
     })
     .filter((item) => item !== null);
+
+  return { data: items, ok: true };
 }

--- a/lib/types/application.ts
+++ b/lib/types/application.ts
@@ -107,6 +107,12 @@ export type GetApplicationDetailResult =
       ok: true;
     };
 
+export type GetApplicationsErrorCode = "AUTH_REQUIRED" | "QUERY_ERROR";
+
+export type GetApplicationsResult =
+  | { code: GetApplicationsErrorCode; ok: false; reason: string }
+  | { data: ApplicationListItem[]; ok: true };
+
 export type UpdateApplicationNotesErrorCode =
   | "AUTH_REQUIRED"
   | "NOT_FOUND"


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #136

## 📌 작업 내용

- getApplications: getUser() 인증 추가, 에러 시 Result 타입 반환
- getApplicationDetail: user_id 소유권 검증 쿼리 조건 추가
- extractJobData: getUser() 인증 추가로 미인증 외부 HTTP 요청 차단


