### PR TITLE
fix: 폼 검증, 애니메이션 cleanup, 코드 품질 개선(#150)

### DIFF
--- a/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
@@ -81,6 +81,17 @@ export function InterviewFormSheet(props: InterviewFormSheetProps) {
       return;
     }
 
+    if (!values.scheduledAt) {
+      setErrorMessage("면접 일시를 입력해 주세요.");
+      return;
+    }
+
+    const scheduledAtDate = new Date(values.scheduledAt);
+    if (isNaN(scheduledAtDate.getTime())) {
+      setErrorMessage("올바른 면접 일시를 입력해 주세요.");
+      return;
+    }
+
     setIsSaving(true);
     setErrorMessage(null);
 
@@ -90,7 +101,7 @@ export function InterviewFormSheet(props: InterviewFormSheetProps) {
         interviewType: values.interviewType,
         location: values.location,
         round: values.round,
-        scheduledAt: new Date(values.scheduledAt).toISOString(),
+        scheduledAt: scheduledAtDate.toISOString(),
         scratchpad: values.scratchpad,
       });
 

--- a/components/ui/bottom-sheet/hooks/useBottomSheetState.ts
+++ b/components/ui/bottom-sheet/hooks/useBottomSheetState.ts
@@ -109,8 +109,10 @@ export const useBottomSheetState = ({
       return;
     }
 
+    let cancelled = false;
+
     onAnimateOutRef.current(closingVelocityRef.current, () => {
-      if (phaseRef.current !== "closing") {
+      if (cancelled || phaseRef.current !== "closing") {
         return;
       }
 
@@ -118,6 +120,10 @@ export const useBottomSheetState = ({
       setPhase("idle");
       onCloseRef.current();
     });
+
+    return () => {
+      cancelled = true;
+    };
   }, [phase]);
 
   const handleClose = useCallback((velocity = 0) => {

--- a/components/ui/tabs/TabsContext.ts
+++ b/components/ui/tabs/TabsContext.ts
@@ -1,5 +1,3 @@
-"use client";
-
 import { createContext, useContext } from "react";
 
 export type TabsContextValue = {

--- a/lib/actions/saveJobApplication.ts
+++ b/lib/actions/saveJobApplication.ts
@@ -14,10 +14,10 @@ import {
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 
 const ERROR_MESSAGES = {
-  AUTH_REQUIRED: "Authentication required.",
-  INVALID_RPC_RESPONSE: "Failed to parse save_job_application response.",
-  UNKNOWN_ERROR: "Unknown error",
-  VALIDATION_ERROR: "Invalid saveJobApplication input.",
+  AUTH_REQUIRED: "로그인이 필요합니다.",
+  INVALID_RPC_RESPONSE: "지원 저장 응답을 해석하지 못했습니다.",
+  UNKNOWN_ERROR: "알 수 없는 오류가 발생했습니다.",
+  VALIDATION_ERROR: "유효하지 않은 지원 입력입니다.",
 } as const;
 
 export async function saveJobApplication(

--- a/lib/types/application.ts
+++ b/lib/types/application.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { nullableTextSchema } from "@/lib/types/common";
 import {
   type JobPlatform,
   jobPlatformSchema,
@@ -8,17 +9,7 @@ import {
 } from "@/lib/types/job";
 
 export const applicationIdSchema = z.uuid("applicationId must be a valid UUID");
-const applicationNotesSchema = z
-  .string()
-  .trim()
-  .nullable()
-  .transform((value) => {
-    if (value === null || value.length === 0) {
-      return null;
-    }
-
-    return value;
-  });
+const applicationNotesSchema = nullableTextSchema;
 
 export const updateApplicationStatusInputSchema = z
   .object({
@@ -136,17 +127,7 @@ export type UpdateApplicationNotesResult =
       ok: true;
     };
 
-const jobDescriptionSchema = z
-  .string()
-  .trim()
-  .nullable()
-  .transform((value) => {
-    if (value === null || value.length === 0) {
-      return null;
-    }
-
-    return value;
-  });
+const jobDescriptionSchema = nullableTextSchema;
 
 export const updateJobDescriptionInputSchema = z
   .object({

--- a/lib/types/common.ts
+++ b/lib/types/common.ts
@@ -1,1 +1,18 @@
+import { z } from "zod";
+
 export type Brand<K, T> = K & { readonly __brand: T };
+
+/**
+ * 빈 문자열과 null을 모두 null로 정규화하는 공용 스키마입니다.
+ * applicationNotesSchema, jobDescriptionSchema, interviewLocationSchema 등에서 공유합니다.
+ */
+export const nullableTextSchema = z
+  .string()
+  .trim()
+  .nullable()
+  .transform((value) => {
+    if (value === null || value.length === 0) {
+      return null;
+    }
+    return value;
+  });

--- a/lib/types/interview.ts
+++ b/lib/types/interview.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { applicationIdSchema } from "@/lib/types/application";
+import { nullableTextSchema } from "@/lib/types/common";
 import { Constants, Enums } from "@/lib/types/supabase";
 
 export type InterviewType = Enums<"interview_type">;
@@ -23,27 +24,8 @@ export type InterviewDetail = {
   updatedAt: string;
 };
 
-const interviewLocationSchema = z
-  .string()
-  .trim()
-  .nullable()
-  .transform((value) => {
-    if (value === null || value.length === 0) {
-      return null;
-    }
-    return value;
-  });
-
-const interviewScratchpadSchema = z
-  .string()
-  .trim()
-  .nullable()
-  .transform((value) => {
-    if (value === null || value.length === 0) {
-      return null;
-    }
-    return value;
-  });
+const interviewLocationSchema = nullableTextSchema;
+const interviewScratchpadSchema = nullableTextSchema;
 
 export const upsertInterviewInputSchema = z
   .object({

--- a/lib/utils/cn.ts
+++ b/lib/utils/cn.ts
@@ -1,4 +1,4 @@
-import { ClassValue, clsx } from "clsx";
+import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 export const cn = (...inputs: ClassValue[]) => {


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #150

## 📌 작업 내용

- InterviewFormSheet: scheduledAt 빈 문자열 및 Invalid Date 사전 검증
- useBottomSheetState: closing 애니메이션 effect cleanup 추가
- saveJobApplication: 에러 메시지 한국어 통일
- nullableTextSchema 공용화로 Zod 패턴 중복 제거
- TabsContext: "use client" 경계 제거
- cn.ts: ClassValue type import 수정


