### PR TITLE
feat: 파싱 비활성화 시 수동 입력 폼 제공 및 뷰 컴포넌트 분리(#155)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 **https://201-escape.vercel.app**
 
-원티드, 사람인 공고 URL을 붙여넣으면 자동으로 정보를 파싱해 저장하고, 지원 상태를 추적할 수 있습니다.
+지원 상태를 한 곳에서 추적합니다. 회사명과 포지션을 직접 입력하거나, 로컬 환경에서는 원티드·사람인 URL을 붙여넣어 자동 파싱할 수 있습니다.
 
 ## 주요 기능
 
-- **공고 자동 파싱**: 원티드, 사람인 URL에서 회사명, 직책, 공고 내용을 자동으로 추출
-- **직접 입력**: 파싱이 지원되지 않는 플랫폼의 공고도 수동 입력 가능
+- **직접 입력**: 회사명, 포지션, URL을 직접 입력해 공고 추가
+- **공고 자동 파싱** _(로컬 전용)_: 원티드, 사람인 URL에서 회사명, 직책, 공고 내용을 자동으로 추출
 - **지원 상태 관리**: 관심 → 서류 제출 → 서류 통과 → 면접 중 → 최종 합격 / 불합격
 - **바텀 시트 프리뷰**: 목록에서 공고를 탭하면 상세 정보를 빠르게 확인
 - **탭 기반 필터링**: 지원 상태별로 목록 필터링
@@ -37,12 +37,15 @@
 cp .env.example .env.local
 ```
 
-| 변수                                   | 설명                     |
-| -------------------------------------- | ------------------------ |
-| `NEXT_PUBLIC_SUPABASE_URL`             | Supabase 프로젝트 URL    |
-| `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | Supabase Publishable Key |
+| 변수                                   | 설명                                                                |
+| -------------------------------------- | ------------------------------------------------------------------- |
+| `NEXT_PUBLIC_SUPABASE_URL`             | Supabase 프로젝트 URL                                               |
+| `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | Supabase Publishable Key                                            |
+| `NEXT_PUBLIC_ENABLE_PARSING`           | `true`로 설정 시 URL 자동 파싱 활성화 (로컬 전용, 기본값: 비활성화) |
 
-두 값 모두 Supabase 대시보드의 **Project Settings → API** 페이지에서 확인할 수 있습니다.
+`NEXT_PUBLIC_SUPABASE_URL`과 `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`는 Supabase 대시보드의 **Project Settings → API** 페이지에서 확인할 수 있습니다.
+
+> **참고**: `NEXT_PUBLIC_ENABLE_PARSING=true`는 로컬 개발 환경에서만 사용하세요. 배포 환경에서는 이 변수를 설정하지 않거나 `false`로 유지합니다.
 
 ### 설치 및 실행
 
@@ -73,9 +76,9 @@ SAVED → APPLIED → DOCS_PASSED → INTERVIEWING → OFFERED
 
 ### 지원 플랫폼
 
-- `WANTED`: 원티드 (자동 파싱)
-- `SARAMIN`: 사람인 (자동 파싱)
-- `LINKEDIN`: LinkedIn (파싱 미지원, 수동 입력)
+- `WANTED`: 원티드 (자동 파싱, 로컬 전용)
+- `SARAMIN`: 사람인 (자동 파싱, 로컬 전용)
+- `LINKEDIN`: LinkedIn (수동 입력)
 - `MANUAL`: 직접 입력
 
 ## 스크립트

--- a/app/(protected)/dashboard/_components/add-job/AddJobTrigger.tsx
+++ b/app/(protected)/dashboard/_components/add-job/AddJobTrigger.tsx
@@ -3,41 +3,28 @@
 import { Plus as PlusIcon } from "lucide-react";
 import { useState } from "react";
 
-import type { JobPlatform, JobPost } from "@/lib/types/job";
-
 import { BottomSheet, Button } from "@/components/ui";
-import { cn } from "@/lib/utils";
 
-import { PLATFORM_LABEL } from "../dashboard-view/constants";
+import { ManualFormView } from "./components/ManualFormView";
+import { ReviewView } from "./components/ReviewView";
+import { UrlInputView } from "./components/UrlInputView";
 import { useAddJob } from "./hooks/useAddJob";
 
-type ReviewFieldProps = {
-  label: string;
-  value: string;
-};
-
-type ReviewViewProps = {
-  error: null | string;
-  isSaving: boolean;
-  jobData: JobPost;
-  onReset: () => void;
-  onSave: () => void;
-};
-
-type UrlInputViewProps = {
-  error: null | string;
-  isLoading: boolean;
-  onExtract: () => void;
-  onUrlChange: (url: string) => void;
-  url: string;
-};
+const PARSING_ENABLED = process.env.NEXT_PUBLIC_ENABLE_PARSING === "true";
 
 export function AddJobTrigger() {
   const [isOpen, setIsOpen] = useState(false);
-  const { handleExtract, handleReset, handleSave, reset, setUrl, state } =
-    useAddJob({
-      onSuccess: () => setIsOpen(false),
-    });
+  const {
+    handleExtract,
+    handleManualSubmit,
+    handleReset,
+    handleSave,
+    reset,
+    setUrl,
+    state,
+  } = useAddJob({
+    onSuccess: () => setIsOpen(false),
+  });
 
   function handleClose() {
     setIsOpen(false);
@@ -63,13 +50,22 @@ export function AddJobTrigger() {
             <BottomSheet.Title className="mb-4">공고 추가</BottomSheet.Title>
             {(() => {
               if (state.step === "idle" || state.step === "extracting") {
+                if (PARSING_ENABLED) {
+                  return (
+                    <UrlInputView
+                      error={state.step === "idle" ? state.error : null}
+                      isLoading={state.step === "extracting"}
+                      onExtract={handleExtract}
+                      onUrlChange={setUrl}
+                      url={state.url}
+                    />
+                  );
+                }
+
                 return (
-                  <UrlInputView
+                  <ManualFormView
                     error={state.step === "idle" ? state.error : null}
-                    isLoading={state.step === "extracting"}
-                    onExtract={handleExtract}
-                    onUrlChange={setUrl}
-                    url={state.url}
+                    onSubmit={handleManualSubmit}
                   />
                 );
               }
@@ -88,97 +84,5 @@ export function AddJobTrigger() {
         </BottomSheet.Content>
       </BottomSheet>
     </>
-  );
-}
-
-function ReviewField({ label, value }: ReviewFieldProps) {
-  return (
-    <div className="flex flex-col gap-0.5">
-      <span className="text-xs text-muted-foreground">{label}</span>
-      <span className="text-sm font-semibold text-foreground">{value}</span>
-    </div>
-  );
-}
-
-function ReviewView({
-  error,
-  isSaving,
-  jobData,
-  onReset,
-  onSave,
-}: ReviewViewProps) {
-  return (
-    <div className="flex flex-col gap-4">
-      <div className="flex flex-col gap-3 rounded-lg bg-muted p-4">
-        <ReviewField label="회사" value={jobData.companyName} />
-        <ReviewField label="포지션" value={jobData.title} />
-        <ReviewField
-          label="플랫폼"
-          value={PLATFORM_LABEL[jobData.platform as JobPlatform]}
-        />
-      </div>
-      {error && <p className="text-sm text-destructive">{error}</p>}
-      <div className="flex gap-2">
-        <Button
-          className="flex-1"
-          disabled={isSaving}
-          onClick={onReset}
-          variant="outline"
-        >
-          다시 입력
-        </Button>
-        <Button className="flex-1" disabled={isSaving} onClick={onSave}>
-          {isSaving ? "저장 중..." : "저장"}
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-function UrlInputView({
-  error,
-  isLoading,
-  onExtract,
-  onUrlChange,
-  url,
-}: UrlInputViewProps) {
-  return (
-    <div className="flex flex-col gap-4">
-      <div className="flex flex-col gap-1.5">
-        <label
-          className="text-sm font-medium text-foreground"
-          htmlFor="job-url"
-        >
-          공고 URL
-        </label>
-        <input
-          className={cn(
-            "h-10 w-full rounded-md border border-input bg-background px-3 text-sm",
-            "placeholder:text-muted-foreground",
-            "focus:ring-1 focus:ring-ring focus:outline-none",
-            error && "border-destructive",
-          )}
-          disabled={isLoading}
-          id="job-url"
-          onChange={(e) => onUrlChange(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              onExtract();
-            }
-          }}
-          placeholder="https://www.wanted.co.kr/..."
-          type="url"
-          value={url}
-        />
-        {error && <p className="text-sm text-destructive">{error}</p>}
-      </div>
-      <Button
-        className="w-full"
-        disabled={!url.trim() || isLoading}
-        onClick={onExtract}
-      >
-        {isLoading ? "공고 정보 가져오는 중..." : "공고 정보 가져오기"}
-      </Button>
-    </div>
   );
 }

--- a/app/(protected)/dashboard/_components/add-job/components/ManualFormView.tsx
+++ b/app/(protected)/dashboard/_components/add-job/components/ManualFormView.tsx
@@ -1,0 +1,132 @@
+import { useState } from "react";
+
+import { Button } from "@/components/ui";
+import { cn } from "@/lib/utils";
+
+type ManualFormViewProps = {
+  error: null | string;
+  onSubmit: (fields: {
+    companyName: string;
+    title: string;
+    url: string;
+  }) => void;
+};
+
+export function ManualFormView({ error, onSubmit }: ManualFormViewProps) {
+  const [companyName, setCompanyName] = useState("");
+  const [title, setTitle] = useState("");
+  const [url, setUrl] = useState("");
+  const [fieldError, setFieldError] = useState<null | string>(null);
+
+  function handleSubmit() {
+    if (!companyName.trim() || !title.trim()) {
+      setFieldError("회사명과 포지션은 필수입니다.");
+      return;
+    }
+    setFieldError(null);
+    onSubmit({ companyName, title, url });
+  }
+
+  const displayError = fieldError ?? error;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1.5">
+          <label
+            className="flex items-center gap-1 text-sm font-medium text-foreground"
+            htmlFor="manual-company"
+          >
+            회사명
+            <span aria-hidden="true" className="text-destructive">
+              *
+            </span>
+          </label>
+          <input
+            className={cn(
+              "h-10 w-full rounded-md border border-input bg-background px-3 text-sm",
+              "placeholder:text-muted-foreground",
+              "focus:ring-1 focus:ring-ring focus:outline-none",
+            )}
+            id="manual-company"
+            onChange={(e) => setCompanyName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                handleSubmit();
+              }
+            }}
+            placeholder="(주)회사명"
+            required
+            type="text"
+            value={companyName}
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <label
+            className="flex items-center gap-1 text-sm font-medium text-foreground"
+            htmlFor="manual-title"
+          >
+            포지션
+            <span aria-hidden="true" className="text-destructive">
+              *
+            </span>
+          </label>
+          <input
+            className={cn(
+              "h-10 w-full rounded-md border border-input bg-background px-3 text-sm",
+              "placeholder:text-muted-foreground",
+              "focus:ring-1 focus:ring-ring focus:outline-none",
+            )}
+            id="manual-title"
+            onChange={(e) => setTitle(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                handleSubmit();
+              }
+            }}
+            placeholder="프론트엔드 엔지니어"
+            required
+            type="text"
+            value={title}
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <label
+            className="flex items-center gap-1 text-sm font-medium text-foreground"
+            htmlFor="manual-url"
+          >
+            공고 URL
+            <span className="text-xs text-muted-foreground">(선택)</span>
+          </label>
+          <input
+            className={cn(
+              "h-10 w-full rounded-md border border-input bg-background px-3 text-sm",
+              "placeholder:text-muted-foreground",
+              "focus:ring-1 focus:ring-ring focus:outline-none",
+            )}
+            id="manual-url"
+            onChange={(e) => setUrl(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                handleSubmit();
+              }
+            }}
+            placeholder="https://..."
+            type="url"
+            value={url}
+          />
+        </div>
+      </div>
+      {displayError && (
+        <p className="text-sm text-destructive">{displayError}</p>
+      )}
+      <Button
+        className="w-full"
+        disabled={!companyName.trim() || !title.trim()}
+        onClick={handleSubmit}
+      >
+        공고 추가
+      </Button>
+    </div>
+  );
+}

--- a/app/(protected)/dashboard/_components/add-job/components/ReviewView.tsx
+++ b/app/(protected)/dashboard/_components/add-job/components/ReviewView.tsx
@@ -1,0 +1,62 @@
+import type { JobPlatform, JobPost } from "@/lib/types/job";
+
+import { Button } from "@/components/ui";
+
+import { PLATFORM_LABEL } from "../../dashboard-view/constants";
+
+type ReviewFieldProps = {
+  label: string;
+  value: string;
+};
+
+type ReviewViewProps = {
+  error: null | string;
+  isSaving: boolean;
+  jobData: JobPost;
+  onReset: () => void;
+  onSave: () => void;
+};
+
+export function ReviewView({
+  error,
+  isSaving,
+  jobData,
+  onReset,
+  onSave,
+}: ReviewViewProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-3 rounded-lg bg-muted p-4">
+        <ReviewField label="회사" value={jobData.companyName} />
+        <ReviewField label="포지션" value={jobData.title} />
+        <ReviewField
+          label="플랫폼"
+          value={PLATFORM_LABEL[jobData.platform as JobPlatform]}
+        />
+      </div>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      <div className="flex gap-2">
+        <Button
+          className="flex-1"
+          disabled={isSaving}
+          onClick={onReset}
+          variant="outline"
+        >
+          다시 입력
+        </Button>
+        <Button className="flex-1" disabled={isSaving} onClick={onSave}>
+          {isSaving ? "저장 중..." : "저장"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ReviewField({ label, value }: ReviewFieldProps) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className="text-sm font-semibold text-foreground">{value}</span>
+    </div>
+  );
+}

--- a/app/(protected)/dashboard/_components/add-job/components/UrlInputView.tsx
+++ b/app/(protected)/dashboard/_components/add-job/components/UrlInputView.tsx
@@ -1,0 +1,58 @@
+import { Button } from "@/components/ui";
+import { cn } from "@/lib/utils";
+
+type UrlInputViewProps = {
+  error: null | string;
+  isLoading: boolean;
+  onExtract: () => void;
+  onUrlChange: (url: string) => void;
+  url: string;
+};
+
+export function UrlInputView({
+  error,
+  isLoading,
+  onExtract,
+  onUrlChange,
+  url,
+}: UrlInputViewProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1.5">
+        <label
+          className="text-sm font-medium text-foreground"
+          htmlFor="job-url"
+        >
+          공고 URL
+        </label>
+        <input
+          className={cn(
+            "h-10 w-full rounded-md border border-input bg-background px-3 text-sm",
+            "placeholder:text-muted-foreground",
+            "focus:ring-1 focus:ring-ring focus:outline-none",
+            error && "border-destructive",
+          )}
+          disabled={isLoading}
+          id="job-url"
+          onChange={(e) => onUrlChange(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              onExtract();
+            }
+          }}
+          placeholder="https://www.wanted.co.kr/..."
+          type="url"
+          value={url}
+        />
+        {error && <p className="text-sm text-destructive">{error}</p>}
+      </div>
+      <Button
+        className="w-full"
+        disabled={!url.trim() || isLoading}
+        onClick={onExtract}
+      >
+        {isLoading ? "공고 정보 가져오는 중..." : "공고 정보 가져오기"}
+      </Button>
+    </div>
+  );
+}

--- a/app/(protected)/dashboard/_components/add-job/hooks/useAddJob.ts
+++ b/app/(protected)/dashboard/_components/add-job/hooks/useAddJob.ts
@@ -1,10 +1,9 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
-import type { JobPost } from "@/lib/types/job";
-
 import { extractJobData } from "@/lib/actions/extractJobData";
 import { saveJobApplication } from "@/lib/actions/saveJobApplication";
+import { JobId, type JobPost, MANUAL_JOB_DEFAULTS } from "@/lib/types/job";
 
 export type AddJobState =
   | ExtractingState
@@ -52,6 +51,29 @@ export function useAddJob({ onSuccess }: UseAddJobProps) {
     if (state.step === "idle" && state.url !== url) {
       setState({ ...state, url });
     }
+  }
+
+  function handleManualSubmit(fields: {
+    companyName: string;
+    title: string;
+    url: string;
+  }) {
+    if (state.step !== "idle") {
+      return;
+    }
+
+    const jobData: JobPost = {
+      companyName: fields.companyName.trim() || MANUAL_JOB_DEFAULTS.companyName,
+      id: crypto.randomUUID() as JobId,
+      platform: MANUAL_JOB_DEFAULTS.platform,
+      status: MANUAL_JOB_DEFAULTS.status,
+      title: fields.title.trim() || MANUAL_JOB_DEFAULTS.title,
+      // URL 미입력 시 DB의 NOT NULL + UNIQUE (platform, origin_url) 제약을 충족하기 위해
+      // 고유 식별자를 생성합니다. Zod v4의 z.url()은 manual: 스킴을 허용합니다.
+      url: fields.url.trim() || `manual:${crypto.randomUUID()}`,
+    };
+
+    setState({ error: null, jobData, step: "review", url: fields.url.trim() });
   }
 
   async function handleExtract() {
@@ -104,5 +126,13 @@ export function useAddJob({ onSuccess }: UseAddJobProps) {
     setState({ error: null, step: "idle", url: "" });
   }
 
-  return { handleExtract, handleReset, handleSave, reset, setUrl, state };
+  return {
+    handleExtract,
+    handleManualSubmit,
+    handleReset,
+    handleSave,
+    reset,
+    setUrl,
+    state,
+  };
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #155

## 📌 작업 내용

- NEXT_PUBLIC_ENABLE_PARSING에 따라 UrlInputView/ManualFormView 분기
- ManualFormView 추가 — 회사명·포지션·URL 직접 입력
- useAddJob에 handleManualSubmit 추가 — 추출 없이 review 상태로 전환
- AddJobTrigger 내부 뷰(ReviewView, UrlInputView)를 components/로 분리
- README에 파싱 기능 로컬 전용 안내 반영


