### PR TITLE
feat: 지원 목록에 가상화 리스트 적용(#160)

### DIFF
--- a/app/(protected)/dashboard/_components/dashboard-view/DashboardView.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DashboardView.tsx
@@ -5,7 +5,6 @@ import { getApplications } from "@/lib/actions";
 import { cn, formatKoreanDate } from "@/lib/utils";
 
 import { AddJobTrigger } from "../add-job";
-import { GoToTopFAB } from "../go-to-top";
 import { DashboardApplicationsPanel } from "./components/DashboardApplicationsPanel";
 import { DOCS_STATUSES } from "./constants";
 
@@ -36,13 +35,13 @@ export async function DashboardView() {
   ];
 
   return (
-    <main className="flex flex-col">
-      <div className="px-5 pt-6 pb-5">
+    <main className="flex h-dvh flex-col">
+      <div className="shrink-0 px-5 pt-6 pb-5">
         <p className="text-muted-foreground">{formatKoreanDate(new Date())}</p>
         <h1 className="mt-0.5 text-3xl text-foreground">지원 현황</h1>
       </div>
 
-      <div className="grid grid-cols-4 border-y border-border">
+      <div className="grid shrink-0 grid-cols-4 border-y border-border">
         {stats.map((stat, i) => (
           <div
             className={cn(
@@ -59,10 +58,11 @@ export async function DashboardView() {
         ))}
       </div>
 
-      <Suspense fallback={<DashboardApplicationsPanelSkeleton />}>
-        <DashboardApplicationsPanel applications={applications} />
-      </Suspense>
-      <GoToTopFAB />
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <Suspense fallback={<DashboardApplicationsPanelSkeleton />}>
+          <DashboardApplicationsPanel applications={applications} />
+        </Suspense>
+      </div>
       <AddJobTrigger />
     </main>
   );

--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationList.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationList.tsx
@@ -1,38 +1,51 @@
 import { InboxIcon } from "lucide-react";
 
+import type { VirtualListHandle } from "@/components/ui/virtual-list";
+
+import { VirtualList } from "@/components/ui/virtual-list";
+
 import type { ApplicationListItem } from "../types";
 
 import { ApplicationRow } from "./ApplicationRow";
 
+// ApplicationRow의 실측 전 초기 높이 추정값(px).
+const ESTIMATED_ROW_HEIGHT = 88;
+
 type ApplicationListProps = {
   applications: ApplicationListItem[];
   emptyMessage?: string;
+  onRangeChange?: (startIndex: number, endIndex: number) => void;
   onSelectApplication: (application: ApplicationListItem) => void;
+  ref?: React.Ref<VirtualListHandle>;
 };
 
 export function ApplicationList({
   applications,
   emptyMessage = "해당하는 지원 내역이 없습니다",
+  onRangeChange,
   onSelectApplication,
+  ref,
 }: ApplicationListProps) {
-  if (applications.length === 0) {
-    return (
-      <div className="flex flex-col items-center gap-3 py-16 text-muted-foreground">
-        <InboxIcon className="size-8 stroke-[1.5]" />
-        <p className="text-sm">{emptyMessage}</p>
-      </div>
-    );
-  }
+  const emptyState = (
+    <div className="flex flex-col items-center gap-3 py-16 text-muted-foreground">
+      <InboxIcon className="size-8 stroke-[1.5]" />
+      <p className="text-sm">{emptyMessage}</p>
+    </div>
+  );
 
   return (
-    <>
-      {applications.map((application) => (
-        <ApplicationRow
-          application={application}
-          key={application.id}
-          onSelect={onSelectApplication}
-        />
-      ))}
-    </>
+    <VirtualList
+      aria-label="지원서 목록"
+      className="h-full"
+      emptyState={emptyState}
+      estimatedItemHeight={ESTIMATED_ROW_HEIGHT}
+      items={applications}
+      keyExtractor={(item) => item.id}
+      onRangeChange={onRangeChange}
+      ref={ref}
+      renderItem={(item) => (
+        <ApplicationRow application={item} onSelect={onSelectApplication} />
+      )}
+    />
   );
 }

--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationTabs.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationTabs.tsx
@@ -1,4 +1,6 @@
-"use client";
+import { useImperativeHandle, useRef } from "react";
+
+import type { VirtualListHandle } from "@/components/ui/virtual-list";
 
 import { Tabs } from "@/components/ui";
 
@@ -7,18 +9,32 @@ import type { ApplicationListItem } from "../types";
 import { DONE_STATUSES, IN_PROGRESS_STATUSES } from "../constants";
 import { ApplicationList } from "./ApplicationList";
 
-type ApplicationTabsProps = {
-  applications: ApplicationListItem[];
-  onSelectApplication: (application: ApplicationListItem) => void;
-};
-
 const TAB_TRIGGER_CLASS =
   "h-12 flex-1 rounded-none border-b-2 border-transparent px-0 text-muted-foreground data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none";
 
+export type ApplicationTabsHandle = {
+  scrollToTop: () => void;
+};
+
+type ApplicationTabsProps = {
+  applications: ApplicationListItem[];
+  onRangeChange?: (startIndex: number, endIndex: number) => void;
+  onSelectApplication: (application: ApplicationListItem) => void;
+  ref?: React.Ref<ApplicationTabsHandle>;
+};
+
 export function ApplicationTabs({
   applications,
+  onRangeChange,
   onSelectApplication,
+  ref,
 }: ApplicationTabsProps) {
+  /**
+   * TabsContent의 forceMount 기본값이 false이므로 활성 탭 하나만 렌더링됩니다.
+   * 따라서 listRef 하나로 현재 활성 탭의 VirtualList를 참조할 수 있습니다.
+   */
+  const listRef = useRef<VirtualListHandle>(null);
+
   const inProgressApplications = applications.filter((a) =>
     IN_PROGRESS_STATUSES.includes(a.status),
   );
@@ -26,9 +42,21 @@ export function ApplicationTabs({
     DONE_STATUSES.includes(a.status),
   );
 
+  useImperativeHandle(ref, () => ({
+    scrollToTop: () => listRef.current?.scrollToIndex(0),
+  }));
+
   return (
-    <Tabs defaultValue="all">
-      <Tabs.List className="h-auto w-full rounded-none border-b border-border bg-transparent p-0">
+    <Tabs
+      className="flex h-full flex-col"
+      defaultValue="all"
+      onValueChange={() => {
+        // 탭 전환 시 GoToTopFAB 상태를 즉시 초기화합니다.
+        // 새 탭의 VirtualList가 마운트되면 onRangeChange(0, N)이 다시 호출됩니다.
+        onRangeChange?.(0, 0);
+      }}
+    >
+      <Tabs.List className="h-auto w-full shrink-0 rounded-none border-b border-border bg-transparent p-0">
         <Tabs.Trigger className={TAB_TRIGGER_CLASS} value="all">
           전체
         </Tabs.Trigger>
@@ -40,25 +68,31 @@ export function ApplicationTabs({
         </Tabs.Trigger>
       </Tabs.List>
 
-      <Tabs.Content className="mt-0 px-5" value="all">
+      <Tabs.Content className="mt-0 min-h-0 flex-1 px-5" value="all">
         <ApplicationList
           applications={applications}
           emptyMessage="아직 지원한 곳이 없습니다"
+          onRangeChange={onRangeChange}
           onSelectApplication={onSelectApplication}
+          ref={listRef}
         />
       </Tabs.Content>
-      <Tabs.Content className="mt-0 px-5" value="active">
+      <Tabs.Content className="mt-0 min-h-0 flex-1 px-5" value="active">
         <ApplicationList
           applications={inProgressApplications}
           emptyMessage="진행 중인 지원이 없습니다"
+          onRangeChange={onRangeChange}
           onSelectApplication={onSelectApplication}
+          ref={listRef}
         />
       </Tabs.Content>
-      <Tabs.Content className="mt-0 px-5" value="done">
+      <Tabs.Content className="mt-0 min-h-0 flex-1 px-5" value="done">
         <ApplicationList
           applications={doneApplications}
           emptyMessage="완료된 지원이 없습니다"
+          onRangeChange={onRangeChange}
           onSelectApplication={onSelectApplication}
+          ref={listRef}
         />
       </Tabs.Content>
     </Tabs>

--- a/app/(protected)/dashboard/_components/dashboard-view/components/DashboardApplicationsPanel.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/DashboardApplicationsPanel.tsx
@@ -3,12 +3,14 @@
 import type { Route } from "next";
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import type { JobStatus } from "@/lib/types/job";
 
 import type { ApplicationListItem } from "../types";
+import type { ApplicationTabsHandle } from "./ApplicationTabs";
 
+import { GoToTopFAB } from "../../go-to-top";
 import { ApplicationPreviewSheet } from "./ApplicationPreviewSheet";
 import { ApplicationTabs } from "./ApplicationTabs";
 
@@ -25,6 +27,8 @@ export function DashboardApplicationsPanel({
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
+  const tabsRef = useRef<ApplicationTabsHandle>(null);
+  const [isListScrolled, setIsListScrolled] = useState(false);
   const [applicationItems, setApplicationItems] = useState(applications);
 
   useEffect(() => {
@@ -65,10 +69,12 @@ export function DashboardApplicationsPanel({
     ) ?? null;
 
   return (
-    <>
+    <div className="h-full">
       <ApplicationTabs
         applications={applicationItems}
+        onRangeChange={(startIndex) => setIsListScrolled(startIndex > 0)}
         onSelectApplication={handleSelectApplication}
+        ref={tabsRef}
       />
       <ApplicationPreviewSheet
         application={selectedApplication}
@@ -76,6 +82,10 @@ export function DashboardApplicationsPanel({
         onCloseAction={handleClosePreview}
         onStatusChangeAction={handleStatusChange}
       />
-    </>
+      <GoToTopFAB
+        isVisible={isListScrolled}
+        onScrollToTop={() => tabsRef.current?.scrollToTop()}
+      />
+    </div>
   );
 }

--- a/app/(protected)/dashboard/_components/go-to-top/GoToTopFAB.tsx
+++ b/app/(protected)/dashboard/_components/go-to-top/GoToTopFAB.tsx
@@ -1,60 +1,29 @@
-"use client";
-
 import { ArrowUp as ArrowUpIcon } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui";
 import { cn } from "@/lib/utils";
 
-export function GoToTopFAB() {
-  const [isVisible, setIsVisible] = useState(false);
-  const sentinelRef = useRef<HTMLDivElement>(null);
+type GoToTopFABProps = {
+  isVisible: boolean;
+  onScrollToTop: () => void;
+};
 
-  useEffect(() => {
-    const sentinel = sentinelRef.current;
-    if (!sentinel) {
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        setIsVisible(!entry.isIntersecting);
-      },
-      { threshold: 0 },
-    );
-
-    observer.observe(sentinel);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, []);
-
-  function handleClick() {
-    window.scrollTo({ behavior: "smooth", top: 0 });
-  }
-
+export function GoToTopFAB({ isVisible, onScrollToTop }: GoToTopFABProps) {
   return (
-    <>
-      <div
-        aria-hidden
-        className="absolute top-0 h-px w-full"
-        ref={sentinelRef}
-      />
-      <Button
-        aria-label="맨 위로 이동"
-        className={cn(
-          "fixed right-5 bottom-[calc(env(safe-area-inset-bottom)+6.5rem)] z-40 shadow-lg transition-all duration-300 active:scale-95",
-          isVisible
-            ? "scale-100 opacity-100"
-            : "pointer-events-none scale-75 opacity-0",
-        )}
-        onClick={handleClick}
-        size="fab"
-        variant="outline"
-      >
-        <ArrowUpIcon />
-      </Button>
-    </>
+    <Button
+      aria-hidden={!isVisible}
+      aria-label="맨 위로 이동"
+      className={cn(
+        "fixed right-5 bottom-[calc(env(safe-area-inset-bottom)+6.5rem)] z-40 shadow-lg transition-all duration-300 active:scale-95",
+        isVisible
+          ? "scale-100 opacity-100"
+          : "pointer-events-none scale-75 opacity-0",
+      )}
+      onClick={onScrollToTop}
+      size="fab"
+      variant="outline"
+    >
+      <ArrowUpIcon />
+    </Button>
   );
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #160

## 📌 작업 내용

- VirtualList에 onScrollTopChange prop 추가
- ApplicationList를 map() 렌더링에서 VirtualList로 교체
- DashboardView 레이아웃을 h-dvh flex-col로 변경해 VirtualList 고정 높이 확보
- GoToTopFAB을 DashboardApplicationsPanel로 이동, VirtualList scrollToIndex(0)와 연결


