### PR TITLE
feat: 지원 목록 무한 스크롤 적용(#162)

### DIFF
--- a/app/(protected)/dashboard/_components/dashboard-view/DashboardView.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DashboardView.tsx
@@ -1,37 +1,58 @@
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from "@tanstack/react-query";
 import { Suspense } from "react";
 
 import { Skeleton } from "@/components/ui";
-import { getApplications } from "@/lib/actions";
+import { getApplications, getApplicationsStats } from "@/lib/actions";
 import { cn, formatKoreanDate } from "@/lib/utils";
 
 import { AddJobTrigger } from "../add-job";
 import { DashboardApplicationsPanel } from "./components/DashboardApplicationsPanel";
-import { DOCS_STATUSES } from "./constants";
+import {
+  APPLICATIONS_QUERY_KEY,
+  getApplicationsNextPageParam,
+  PAGE_SIZE,
+} from "./constants";
 
 export async function DashboardView() {
-  const applicationsResult = await getApplications();
+  const queryClient = new QueryClient();
 
-  if (!applicationsResult.ok) {
-    throw new Error(applicationsResult.reason);
+  const [, statsResult] = await Promise.all([
+    queryClient.prefetchInfiniteQuery({
+      getNextPageParam: getApplicationsNextPageParam,
+      initialPageParam: 0,
+      pages: 1,
+      queryFn: async ({ pageParam }: { pageParam: number }) => {
+        const result = await getApplications({
+          limit: PAGE_SIZE,
+          offset: pageParam,
+        });
+
+        if (!result.ok) {
+          throw new Error(result.reason);
+        }
+
+        return result.data;
+      },
+      queryKey: APPLICATIONS_QUERY_KEY,
+    }),
+    getApplicationsStats(),
+  ]);
+
+  if (!statsResult.ok) {
+    throw new Error(statsResult.reason);
   }
 
-  const applications = applicationsResult.data;
+  const { docs, interviewing, offered, total } = statsResult.data;
 
   const stats = [
-    { label: "전체", value: applications.length },
-    {
-      label: "서류",
-      value: applications.filter((a) => DOCS_STATUSES.includes(a.status))
-        .length,
-    },
-    {
-      label: "면접",
-      value: applications.filter((a) => a.status === "INTERVIEWING").length,
-    },
-    {
-      label: "합격",
-      value: applications.filter((a) => a.status === "OFFERED").length,
-    },
+    { label: "전체", value: total },
+    { label: "서류", value: docs },
+    { label: "면접", value: interviewing },
+    { label: "합격", value: offered },
   ];
 
   return (
@@ -59,16 +80,18 @@ export async function DashboardView() {
       </div>
 
       <div className="min-h-0 flex-1 overflow-hidden">
-        <Suspense fallback={<DashboardApplicationsPanelSkeleton />}>
-          <DashboardApplicationsPanel applications={applications} />
-        </Suspense>
+        <HydrationBoundary state={dehydrate(queryClient)}>
+          <Suspense fallback={<DashboardViewSkeleton />}>
+            <DashboardApplicationsPanel />
+          </Suspense>
+        </HydrationBoundary>
       </div>
       <AddJobTrigger />
     </main>
   );
 }
 
-function DashboardApplicationsPanelSkeleton() {
+function DashboardViewSkeleton() {
   return (
     <div
       aria-busy="true"

--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationList.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationList.tsx
@@ -2,6 +2,7 @@ import { InboxIcon } from "lucide-react";
 
 import type { VirtualListHandle } from "@/components/ui/virtual-list";
 
+import { Skeleton } from "@/components/ui";
 import { VirtualList } from "@/components/ui/virtual-list";
 
 import type { ApplicationListItem } from "../types";
@@ -11,9 +12,14 @@ import { ApplicationRow } from "./ApplicationRow";
 // ApplicationRow의 실측 전 초기 높이 추정값(px).
 const ESTIMATED_ROW_HEIGHT = 88;
 
+// 끝에서 몇 개 전에 다음 페이지를 미리 로드할지.
+const NEAR_END_THRESHOLD = 5;
+
 type ApplicationListProps = {
   applications: ApplicationListItem[];
   emptyMessage?: string;
+  isFetchingNextPage?: boolean;
+  onNearEnd?: () => void;
   onRangeChange?: (startIndex: number, endIndex: number) => void;
   onSelectApplication: (application: ApplicationListItem) => void;
   ref?: React.Ref<VirtualListHandle>;
@@ -22,10 +28,19 @@ type ApplicationListProps = {
 export function ApplicationList({
   applications,
   emptyMessage = "해당하는 지원 내역이 없습니다",
+  isFetchingNextPage,
+  onNearEnd,
   onRangeChange,
   onSelectApplication,
   ref,
 }: ApplicationListProps) {
+  const handleRangeChange = (startIndex: number, endIndex: number) => {
+    onRangeChange?.(startIndex, endIndex);
+    if (onNearEnd && endIndex >= applications.length - NEAR_END_THRESHOLD) {
+      onNearEnd();
+    }
+  };
+
   const emptyState = (
     <div className="flex flex-col items-center gap-3 py-16 text-muted-foreground">
       <InboxIcon className="size-8 stroke-[1.5]" />
@@ -34,18 +49,52 @@ export function ApplicationList({
   );
 
   return (
-    <VirtualList
-      aria-label="지원서 목록"
-      className="h-full"
-      emptyState={emptyState}
-      estimatedItemHeight={ESTIMATED_ROW_HEIGHT}
-      items={applications}
-      keyExtractor={(item) => item.id}
-      onRangeChange={onRangeChange}
-      ref={ref}
-      renderItem={(item) => (
-        <ApplicationRow application={item} onSelect={onSelectApplication} />
+    <div className="flex h-full flex-col">
+      <VirtualList
+        aria-label="지원서 목록"
+        className="flex-1"
+        emptyState={emptyState}
+        estimatedItemHeight={ESTIMATED_ROW_HEIGHT}
+        items={applications}
+        keyExtractor={(item) => item.id}
+        onRangeChange={handleRangeChange}
+        ref={ref}
+        renderItem={(item) => (
+          <ApplicationRow application={item} onSelect={onSelectApplication} />
+        )}
+      />
+      {isFetchingNextPage && (
+        <div
+          aria-label="추가 항목을 불러오는 중입니다"
+          aria-live="polite"
+          role="status"
+        >
+          {Array.from({ length: 3 }).map((_, i) => (
+            <ApplicationRowSkeleton key={i} />
+          ))}
+        </div>
       )}
-    />
+    </div>
+  );
+}
+
+function ApplicationRowSkeleton() {
+  return (
+    <div className="flex w-full items-start justify-between gap-4 border-b border-border py-4">
+      <div className="flex min-w-0 flex-1 flex-col gap-2">
+        <div className="flex flex-col gap-1">
+          <Skeleton className="h-4.5 w-24" />
+          <Skeleton className="h-4 w-40" />
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Skeleton className="h-4 w-10" />
+          <Skeleton className="h-4 w-16" />
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <Skeleton className="h-4 w-12" />
+        <Skeleton className="size-4" />
+      </div>
+    </div>
   );
 }

--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationTabs.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationTabs.tsx
@@ -3,6 +3,7 @@ import { useImperativeHandle, useRef } from "react";
 import type { VirtualListHandle } from "@/components/ui/virtual-list";
 
 import { Tabs } from "@/components/ui";
+import { cn } from "@/lib/utils";
 
 import type { ApplicationListItem } from "../types";
 
@@ -18,6 +19,9 @@ export type ApplicationTabsHandle = {
 
 type ApplicationTabsProps = {
   applications: ApplicationListItem[];
+  className?: string;
+  isFetchingNextPage?: boolean;
+  onNearEnd?: () => void;
   onRangeChange?: (startIndex: number, endIndex: number) => void;
   onSelectApplication: (application: ApplicationListItem) => void;
   ref?: React.Ref<ApplicationTabsHandle>;
@@ -25,6 +29,9 @@ type ApplicationTabsProps = {
 
 export function ApplicationTabs({
   applications,
+  className,
+  isFetchingNextPage,
+  onNearEnd,
   onRangeChange,
   onSelectApplication,
   ref,
@@ -48,7 +55,7 @@ export function ApplicationTabs({
 
   return (
     <Tabs
-      className="flex h-full flex-col"
+      className={cn("flex flex-col", className ?? "h-full")}
       defaultValue="all"
       onValueChange={() => {
         // 탭 전환 시 GoToTopFAB 상태를 즉시 초기화합니다.
@@ -72,6 +79,8 @@ export function ApplicationTabs({
         <ApplicationList
           applications={applications}
           emptyMessage="아직 지원한 곳이 없습니다"
+          isFetchingNextPage={isFetchingNextPage}
+          onNearEnd={onNearEnd}
           onRangeChange={onRangeChange}
           onSelectApplication={onSelectApplication}
           ref={listRef}
@@ -81,6 +90,8 @@ export function ApplicationTabs({
         <ApplicationList
           applications={inProgressApplications}
           emptyMessage="진행 중인 지원이 없습니다"
+          isFetchingNextPage={isFetchingNextPage}
+          onNearEnd={onNearEnd}
           onRangeChange={onRangeChange}
           onSelectApplication={onSelectApplication}
           ref={listRef}
@@ -90,6 +101,8 @@ export function ApplicationTabs({
         <ApplicationList
           applications={doneApplications}
           emptyMessage="완료된 지원이 없습니다"
+          isFetchingNextPage={isFetchingNextPage}
+          onNearEnd={onNearEnd}
           onRangeChange={onRangeChange}
           onSelectApplication={onSelectApplication}
           ref={listRef}

--- a/app/(protected)/dashboard/_components/dashboard-view/components/DashboardApplicationsPanel.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/DashboardApplicationsPanel.tsx
@@ -1,42 +1,65 @@
 "use client";
 
+import type { InfiniteData } from "@tanstack/react-query";
 import type { Route } from "next";
 
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
+import type { GetApplicationsPage } from "@/lib/types/application";
 import type { JobStatus } from "@/lib/types/job";
+
+import { getApplications } from "@/lib/actions";
 
 import type { ApplicationListItem } from "../types";
 import type { ApplicationTabsHandle } from "./ApplicationTabs";
 
 import { GoToTopFAB } from "../../go-to-top";
+import {
+  APPLICATIONS_QUERY_KEY,
+  getApplicationsNextPageParam,
+  PAGE_SIZE,
+} from "../constants";
 import { ApplicationPreviewSheet } from "./ApplicationPreviewSheet";
 import { ApplicationTabs } from "./ApplicationTabs";
 
 const PREVIEW_PARAM = "preview";
 
-type DashboardApplicationsPanelProps = {
-  applications: ApplicationListItem[];
-};
-
-export function DashboardApplicationsPanel({
-  applications,
-}: DashboardApplicationsPanelProps) {
+export function DashboardApplicationsPanel() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const queryClient = useQueryClient();
 
   const tabsRef = useRef<ApplicationTabsHandle>(null);
   const [isListScrolled, setIsListScrolled] = useState(false);
-  const [applicationItems, setApplicationItems] = useState(applications);
 
-  useEffect(() => {
-    setApplicationItems(applications);
-  }, [applications]);
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery({
+      getNextPageParam: getApplicationsNextPageParam,
+      initialPageParam: 0,
+      queryFn: async ({ pageParam }: { pageParam: number }) => {
+        const result = await getApplications({
+          limit: PAGE_SIZE,
+          offset: pageParam,
+        });
+        if (!result.ok) {
+          throw new Error(result.reason);
+        }
+        return result.data;
+      },
+      queryKey: APPLICATIONS_QUERY_KEY,
+    });
+
+  const applications: ApplicationListItem[] =
+    data?.pages.flatMap((page) => page.items) ?? [];
 
   const selectedApplicationId = searchParams.get(PREVIEW_PARAM);
   const isPreviewOpen = selectedApplicationId !== null;
+
+  const selectedApplication =
+    applications.find((a) => a.id === selectedApplicationId) ?? null;
 
   const handleSelectApplication = (application: ApplicationListItem) => {
     router.replace(
@@ -49,29 +72,40 @@ export function DashboardApplicationsPanel({
   };
 
   const handleStatusChange = (applicationId: string, nextStatus: JobStatus) => {
-    setApplicationItems((currentApplications) =>
-      currentApplications.map((application) => {
-        if (application.id !== applicationId) {
-          return application;
+    queryClient.setQueryData<InfiniteData<GetApplicationsPage>>(
+      APPLICATIONS_QUERY_KEY,
+      (old) => {
+        if (!old) {
+          return old;
         }
-
         return {
-          ...application,
-          status: nextStatus,
+          ...old,
+          pages: old.pages.map((page) => ({
+            ...page,
+            items: page.items.map((item) =>
+              item.id === applicationId
+                ? { ...item, status: nextStatus }
+                : item,
+            ),
+          })),
         };
-      }),
+      },
     );
   };
 
-  const selectedApplication =
-    applicationItems.find(
-      (application) => application.id === selectedApplicationId,
-    ) ?? null;
+  const handleNearEnd = () => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  };
 
   return (
-    <div className="h-full">
+    <div className="flex h-full flex-col">
       <ApplicationTabs
-        applications={applicationItems}
+        applications={applications}
+        className="min-h-0 flex-1"
+        isFetchingNextPage={isFetchingNextPage}
+        onNearEnd={handleNearEnd}
         onRangeChange={(startIndex) => setIsListScrolled(startIndex > 0)}
         onSelectApplication={handleSelectApplication}
         ref={tabsRef}

--- a/app/(protected)/dashboard/_components/dashboard-view/constants.ts
+++ b/app/(protected)/dashboard/_components/dashboard-view/constants.ts
@@ -1,3 +1,5 @@
+import type { GetApplicationsPage } from "@/lib/types/application";
+
 import { APPLICATION_STATUS_META } from "@/lib/constants/application-status";
 import { PLATFORM_LABEL } from "@/lib/constants/job-platform";
 import { JobStatus } from "@/lib/types/job";
@@ -6,7 +8,8 @@ export const STATUS_META = APPLICATION_STATUS_META;
 
 export { PLATFORM_LABEL };
 
-export const DOCS_STATUSES: JobStatus[] = ["APPLIED", "DOCS_PASSED"];
+export { DOCS_STATUSES } from "@/lib/constants/application-status";
+
 export const IN_PROGRESS_STATUSES: JobStatus[] = [
   "SAVED",
   "APPLIED",
@@ -14,3 +17,25 @@ export const IN_PROGRESS_STATUSES: JobStatus[] = [
   "INTERVIEWING",
 ];
 export const DONE_STATUSES: JobStatus[] = ["OFFERED", "REJECTED"];
+
+/**
+ * 한 페이지에 로드할 지원서 수
+ */
+export const PAGE_SIZE = 30;
+
+/**
+ * useInfiniteQuery / prefetchInfiniteQuery 공통 query key
+ */
+export const APPLICATIONS_QUERY_KEY = ["applications"] as const;
+
+/**
+ * useInfiniteQuery / prefetchInfiniteQuery 공통 getNextPageParam.
+ * lastPageParam + 현재 페이지 아이템 수로 다음 오프셋을 O(1)에 계산합니다.
+ */
+export function getApplicationsNextPageParam(
+  lastPage: GetApplicationsPage,
+  _allPages: GetApplicationsPage[],
+  lastPageParam: number,
+): number | undefined {
+  return lastPage.hasMore ? lastPageParam + lastPage.items.length : undefined;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "sonner";
 
 import { PORTAL_ROOT_ID } from "@/lib/constants/dom";
 
+import { Providers } from "./providers";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -26,9 +27,11 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className={`${pretendard.className} antialiased`}>
-        {children}
-        <div id={PORTAL_ROOT_ID} />
-        <Toaster position="bottom-center" richColors />
+        <Providers>
+          {children}
+          <div id={PORTAL_ROOT_ID} />
+          <Toaster position="bottom-center" richColors />
+        </Providers>
       </body>
     </html>
   );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 60 * 1000,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/lib/actions/getApplications.ts
+++ b/lib/actions/getApplications.ts
@@ -12,7 +12,13 @@ const ERROR_MESSAGES = {
   AUTH_REQUIRED: "로그인이 필요합니다.",
 } as const;
 
-export async function getApplications(): Promise<GetApplicationsResult> {
+export async function getApplications({
+  limit,
+  offset,
+}: {
+  limit: number;
+  offset: number;
+}): Promise<GetApplicationsResult> {
   const supabase = await createClient();
   const { data: authData, error: authError } = await supabase.auth.getUser();
 
@@ -39,7 +45,8 @@ export async function getApplications(): Promise<GetApplicationsResult> {
     `,
     )
     .eq("user_id", authData.user.id)
-    .order("applied_at", { ascending: false });
+    .order("applied_at", { ascending: false })
+    .range(offset, offset + limit);
 
   if (error) {
     return {
@@ -68,5 +75,9 @@ export async function getApplications(): Promise<GetApplicationsResult> {
     })
     .filter((item) => item !== null);
 
-  return { data: items, ok: true };
+  // limit + 1개를 요청해 실제로 limit개만 반환하고, 초과분이 있으면 hasMore = true
+  const hasMore = items.length > limit;
+  const pageItems = hasMore ? items.slice(0, limit) : items;
+
+  return { data: { hasMore, items: pageItems }, ok: true };
 }

--- a/lib/actions/getApplicationsStats.ts
+++ b/lib/actions/getApplicationsStats.ts
@@ -1,0 +1,53 @@
+"use server";
+
+import type { GetApplicationsStatsResult } from "@/lib/types/application";
+
+import { DOCS_STATUSES } from "@/lib/constants/application-status";
+
+import { createClient } from "../supabase/server";
+import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
+
+const ERROR_MESSAGES = {
+  AUTH_REQUIRED: "로그인이 필요합니다.",
+} as const;
+
+/**
+ * 사용자의 지원 현황 통계를 반환합니다.
+ * 페이지네이션과 무관하게 전체 데이터 기준으로 집계합니다.
+ */
+export async function getApplicationsStats(): Promise<GetApplicationsStatsResult> {
+  const supabase = await createClient();
+  const { data: authData, error: authError } = await supabase.auth.getUser();
+
+  if (authError || !authData.user) {
+    return {
+      code: "AUTH_REQUIRED",
+      ok: false,
+      reason: ERROR_MESSAGES.AUTH_REQUIRED,
+    };
+  }
+
+  const userId = authData.user.id;
+
+  const { data, error } = await supabase
+    .from("applications")
+    .select("status")
+    .eq("user_id", userId);
+
+  if (error) {
+    return {
+      code: error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR",
+      ok: false,
+      reason: normalizeQueryError(error),
+    };
+  }
+
+  const total = data.length;
+  const docs = data.filter((r) =>
+    (DOCS_STATUSES as readonly string[]).includes(r.status),
+  ).length;
+  const interviewing = data.filter((r) => r.status === "INTERVIEWING").length;
+  const offered = data.filter((r) => r.status === "OFFERED").length;
+
+  return { data: { docs, interviewing, offered, total }, ok: true };
+}

--- a/lib/actions/index.ts
+++ b/lib/actions/index.ts
@@ -2,6 +2,7 @@ export { deleteApplication } from "./deleteApplication";
 export { extractJobData } from "./extractJobData";
 export { getApplicationDetail } from "./getApplicationDetail";
 export { getApplications } from "./getApplications";
+export { getApplicationsStats } from "./getApplicationsStats";
 export { getInterviews } from "./getInterviews";
 export { saveJobApplication } from "./saveJobApplication";
 export { updateApplicationNotes } from "./updateApplicationNotes";

--- a/lib/constants/application-status.ts
+++ b/lib/constants/application-status.ts
@@ -9,6 +9,11 @@ export const APPLICATION_STATUS_ORDER = [
   "REJECTED",
 ] as const satisfies readonly JobStatus[];
 
+export const DOCS_STATUSES = [
+  "APPLIED",
+  "DOCS_PASSED",
+] as const satisfies readonly JobStatus[];
+
 export const APPLICATION_STATUS_META: Record<
   JobStatus,
   { color: string; label: string }

--- a/lib/types/application.ts
+++ b/lib/types/application.ts
@@ -66,6 +66,13 @@ export const deleteApplicationInputSchema = z
   })
   .strict();
 
+export type ApplicationsStats = {
+  docs: number;
+  interviewing: number;
+  offered: number;
+  total: number;
+};
+
 export type DeleteApplicationErrorCode =
   | "AUTH_REQUIRED"
   | "NOT_FOUND"
@@ -100,9 +107,20 @@ export type GetApplicationDetailResult =
 
 export type GetApplicationsErrorCode = "AUTH_REQUIRED" | "QUERY_ERROR";
 
+export type GetApplicationsPage = {
+  hasMore: boolean;
+  items: ApplicationListItem[];
+};
+
 export type GetApplicationsResult =
   | { code: GetApplicationsErrorCode; ok: false; reason: string }
-  | { data: ApplicationListItem[]; ok: true };
+  | { data: GetApplicationsPage; ok: true };
+
+export type GetApplicationsStatsErrorCode = "AUTH_REQUIRED" | "QUERY_ERROR";
+
+export type GetApplicationsStatsResult =
+  | { code: GetApplicationsStatsErrorCode; ok: false; reason: string }
+  | { data: ApplicationsStats; ok: true };
 
 export type UpdateApplicationNotesErrorCode =
   | "AUTH_REQUIRED"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.95.0",
+    "@tanstack/react-query": "^5.95.2",
     "cheerio": "^1.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       "@supabase/supabase-js":
         specifier: ^2.95.0
         version: 2.95.0
+      "@tanstack/react-query":
+        specifier: ^5.95.2
+        version: 5.95.2(react@19.2.3)
       cheerio:
         specifier: ^1.2.0
         version: 1.2.0
@@ -1660,6 +1663,20 @@ packages:
       {
         integrity: sha512-Ce0GFnzAOuPyfV5SxjXGn0CubwGcuDB0zcdaPuCSzAa/2vII24JTkH+I6jcbXLb1ctjZMZZI6OjDaLPJQL1S0g==,
       }
+
+  "@tanstack/query-core@5.95.2":
+    resolution:
+      {
+        integrity: sha512-o4T8vZHZET4Bib3jZ/tCW9/7080urD4c+0/AUaYVpIqOsr7y0reBc1oX3ttNaSW5mYyvZHctiQ/UOP2PfdmFEQ==,
+      }
+
+  "@tanstack/react-query@5.95.2":
+    resolution:
+      {
+        integrity: sha512-/wGkvLj/st5Ud1Q76KF1uFxScV7WeqN1slQx5280ycwAyYkIPGaRZAEgHxe3bjirSd5Zpwkj6zNcR4cqYni/ZA==,
+      }
+    peerDependencies:
+      react: ^18 || ^19
 
   "@testing-library/dom@10.4.1":
     resolution:
@@ -6526,6 +6543,13 @@ snapshots:
       "@tailwindcss/oxide": 4.1.18
       postcss: 8.5.6
       tailwindcss: 4.1.18
+
+  "@tanstack/query-core@5.95.2": {}
+
+  "@tanstack/react-query@5.95.2(react@19.2.3)":
+    dependencies:
+      "@tanstack/query-core": 5.95.2
+      react: 19.2.3
 
   "@testing-library/dom@10.4.1":
     dependencies:


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #162

## 📌 작업 내용

- @tanstack/react-query 도입 및 QueryClientProvider 설정(app/providers.tsx)
- getApplications에 limit/offset 페이지네이션 파라미터 추가
    - limit+1 요청 후 hasMore 판별하는 패턴 적용
- getApplicationsStats 서버 액션 신규 추가
    - 통계(전체/서류/면접/합격)를 페이지네이션과 무관하게 전체 집계
- DashboardView에서 prefetchInfiniteQuery + HydrationBoundary로 SSR prefetch
- DashboardApplicationsPanel을 useInfiniteQuery 기반으로 전환

