### PR TITLE
fix: 지원 목록 첫 렌더 및 탭 전환 시 레이아웃 점프/깜빡임 제거(#164)

### DIFF
--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationList.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationList.tsx
@@ -10,7 +10,8 @@ import type { ApplicationListItem } from "../types";
 import { ApplicationRow } from "./ApplicationRow";
 
 // ApplicationRow의 실측 전 초기 높이 추정값(px).
-const ESTIMATED_ROW_HEIGHT = 88;
+// py-4(32) + 회사명(22.5) + 직군명(21) + gap-2(8) + 상태행(21) ≈ 105
+const ESTIMATED_ROW_HEIGHT = 105;
 
 // 끝에서 몇 개 전에 다음 페이지를 미리 로드할지.
 const NEAR_END_THRESHOLD = 5;

--- a/components/ui/virtual-list/VirtualList.tsx
+++ b/components/ui/virtual-list/VirtualList.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import { useEffect, useImperativeHandle, useRef } from "react";
+import { useImperativeHandle, useLayoutEffect, useRef } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -154,11 +154,14 @@ function VirtualItemMeasurer({
 }: VirtualItemMeasurerProps) {
   const ref = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const el = ref.current;
     if (!el) {
       return;
     }
+
+    // 첫 페인트 전에 실제 높이를 동기적으로 측정해 레이아웃 점프를 제거합니다.
+    onMeasure(index, el.getBoundingClientRect().height);
 
     const observer = new ResizeObserver(([entry]) => {
       onMeasure(index, entry.contentRect.height);

--- a/components/ui/virtual-list/hooks/useVirtualList.ts
+++ b/components/ui/virtual-list/hooks/useVirtualList.ts
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 
 export type ScrollToIndexOptions = {
   align?: "center" | "end" | "start";
@@ -49,11 +55,16 @@ export function useVirtualList({
   // 측정값 변경 시 리렌더를 트리거하는 용도로만 사용합니다.
   const [, setVersion] = useState(0);
 
-  useEffect(() => {
+  // 컨테이너 높이를 페인트 전에 동기적으로 읽어, 첫 렌더에서 올바른 visible range를 계산합니다.
+  // useEffect를 쓰면 containerHeight=0으로 첫 페인트가 일어나 overscan 범위(4개)만 먼저 보이고
+  // 이후 ResizeObserver 콜백에서 나머지 아이템이 깜빡이며 나타납니다.
+  useLayoutEffect(() => {
     const el = containerRef.current;
     if (!el) {
       return;
     }
+
+    setContainerHeight(el.getBoundingClientRect().height);
 
     const observer = new ResizeObserver(([entry]) => {
       setContainerHeight(entry.contentRect.height);


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #164

## 📌 작업 내용

- VirtualItemMeasurer: 아이템 높이를 페인트 전에 측정해 추정값 -> 실제값으로 바뀌는 레이아웃 시프트 제거
- useVirtualList: 컨테이너 높이를 페인트 전에 측정해 탭 전환 시 overscan 범위(4개)만 먼저 보이다가 나머지가 깜빡이며 나타나는 문제 제거
- ESTIMATED_ROW_HEIGHT를 88 → 105로 수정해 화면 밖 아이템의 위치 추정 오차 감소

