### PR TITLE
fix: 가상 스크롤 높이 측정·범위 계산 버그 수정(#169)

### DIFF
--- a/components/ui/virtual-list/VirtualList.tsx
+++ b/components/ui/virtual-list/VirtualList.tsx
@@ -81,6 +81,11 @@ type VirtualListProps<T> = {
  * 부모에 반드시 고정 높이가 있어야 합니다 (className에 h-full 등 지정).
  *
  * 주의: 키보드 탭 포커스는 렌더링된 아이템(overscan 범위)까지만 이동합니다.
+ *
+ * 데이터셋 교체 시 높이 캐시 초기화:
+ * - 아이템 수가 줄어드는 경우(필터링 등): 자동으로 범위 밖 측정값을 정리합니다.
+ * - 같은 개수의 완전히 다른 데이터로 교체하는 경우: `key` prop으로 컴포넌트를 리셋하세요.
+ *   예) `<VirtualList key={activeTabId} ... />`
  */
 export function VirtualList<T>({
   "aria-label": ariaLabel,
@@ -164,7 +169,11 @@ function VirtualItemMeasurer({
     onMeasure(index, el.getBoundingClientRect().height);
 
     const observer = new ResizeObserver(([entry]) => {
-      onMeasure(index, entry.contentRect.height);
+      // getBoundingClientRect와 일치하도록 border box 기준으로 측정합니다.
+      const height =
+        entry.borderBoxSize?.[0]?.blockSize ??
+        (entry.target as HTMLElement).getBoundingClientRect().height;
+      onMeasure(index, height);
     });
     observer.observe(el);
 

--- a/components/ui/virtual-list/hooks/useVirtualList.ts
+++ b/components/ui/virtual-list/hooks/useVirtualList.ts
@@ -65,9 +65,15 @@ export function useVirtualList({
     }
 
     setContainerHeight(el.getBoundingClientRect().height);
+    // emptyState에서 아이템으로 복귀할 때 컨테이너가 재마운트되면
+    // 실제 scrollTop(보통 0)과 state가 어긋날 수 있으므로 동기적으로 맞춥니다.
+    setScrollTop(el.scrollTop);
 
     const observer = new ResizeObserver(([entry]) => {
-      setContainerHeight(entry.contentRect.height);
+      const height =
+        entry.borderBoxSize?.[0]?.blockSize ??
+        (entry.target as HTMLElement).getBoundingClientRect().height;
+      setContainerHeight(height);
     });
     observer.observe(el);
 
@@ -133,6 +139,14 @@ export function useVirtualList({
     [estimatedItemHeight, itemCount, paddingTop],
   );
 
+  // itemCount가 줄어든 경우 범위 밖 인덱스의 측정값을 정리합니다.
+  // 필터링 등으로 아이템 수가 줄었을 때 이전 인덱스의 높이가 새 아이템에 잘못 적용되는 것을 막습니다.
+  for (const key of measuredHeights.current.keys()) {
+    if (key >= itemCount) {
+      measuredHeights.current.delete(key);
+    }
+  }
+
   // 누적 오프셋 계산 — O(n)
   // 실측값이 있으면 사용하고, 없으면 estimatedItemHeight로 대체합니다.
   const offsets = new Array<number>(itemCount);
@@ -149,7 +163,7 @@ export function useVirtualList({
   let rawEnd = rawStart;
   while (
     rawEnd + 1 < itemCount &&
-    offsets[rawEnd + 1] < scrollTop + containerHeight
+    offsets[rawEnd + 1] <= scrollTop + containerHeight
   ) {
     rawEnd++;
   }


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #169

## 📌 작업 내용

- ResizeObserver contentRect(border 제외) → borderBoxSize(border 포함)로 통일해 초기 측정(getBoundingClientRect)과의 1px 불일치로 인한 불필요한 리렌더 제거
- itemCount 감소 시 범위 밖 measuredHeights 항목을 렌더 전에 정리해 필터링 등으로 교체된 아이템에 이전 높이가 적용되는 오류 수정
- emptyState에서 아이템 복귀 시 컨테이너 재마운트 직후 el.scrollTop 동기화해 stale scrollTop state로 인한 잘못된 가시 범위 계산 방지
- rawEnd while 조건을 < 에서 <=로 수정해 top이 뷰포트 하단과 정확히 일치하는 아이템이 가시 범위에서 누락되는 경계 케이스 수정


