### PR TITLE
style: 홈, 로그인, 인증오류 페이지 디자인 대시보드 스타일로 통일(#173)

### DIFF
--- a/app/_components/PublicHeader.tsx
+++ b/app/_components/PublicHeader.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button/Button";
+
+export function PublicHeader() {
+  return (
+    <header className="border-b border-border px-6 py-3">
+      <Button
+        asChild
+        className="text-lg font-bold hover:bg-transparent"
+        variant="ghost"
+      >
+        <Link href="/">201</Link>
+      </Button>
+    </header>
+  );
+}

--- a/app/auth/auth-code-error/page.tsx
+++ b/app/auth/auth-code-error/page.tsx
@@ -1,26 +1,28 @@
 import Link from "next/link";
 
+import { Button } from "@/components/ui/button/Button";
+
+import { PublicHeader } from "../../_components/PublicHeader";
+
 export default function AuthCodeErrorPage() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center p-4">
-      <div className="w-full max-w-md space-y-4 text-center">
-        <h1 className="text-2xl font-bold">인증 오류</h1>
-        <p className="flex flex-col text-gray-600">
-          <span>인증 코드가 유효하지 않거나 만료되었습니다.</span>
-          <span>다시 로그인을 시도해 주세요.</span>
+    <div className="flex h-dvh flex-col">
+      <PublicHeader />
+      <div className="flex flex-1 flex-col justify-center px-5 pb-8">
+        <p className="text-sm text-muted-foreground">오류</p>
+        <h1 className="mt-0.5 text-3xl text-foreground">인증 오류</h1>
+        <p className="mt-2 text-muted-foreground">
+          인증 코드가 유효하지 않거나 만료되었습니다.
+          <br />
+          다시 로그인을 시도해 주세요.
         </p>
-        <div className="pt-4">
-          <Link
-            className="inline-block rounded-lg bg-black px-6 py-2 text-white transition-colors hover:bg-gray-800"
-            href="/login"
-          >
-            로그인 페이지로 돌아가기
-          </Link>
-        </div>
-        <div>
-          <Link className="text-sm text-gray-500 hover:underline" href="/">
-            메인 화면으로
-          </Link>
+        <div className="mt-8 flex flex-col gap-3">
+          <Button asChild size="lg">
+            <Link href="/login">로그인 페이지로 돌아가기</Link>
+          </Button>
+          <Button asChild size="sm" variant="ghost">
+            <Link href="/">메인 화면으로</Link>
+          </Button>
         </div>
       </div>
     </div>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -5,6 +5,8 @@ import { useState } from "react";
 import { GoogleIcon } from "@/components/icons/GoogleIcon";
 import { createClient } from "@/lib/supabase/client";
 
+import { PublicHeader } from "../_components/PublicHeader";
+
 export default function LoginPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<null | string>(null);
@@ -32,20 +34,17 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50">
-      <div className="w-full max-w-sm space-y-8 rounded-2xl bg-white p-8 shadow-lg">
-        <div className="text-center">
-          <h2 className="text-2xl font-bold tracking-tight text-gray-900">
-            반가워요!
-          </h2>
-          <p className="mt-2 text-sm text-gray-600">
-            201 escape에 오신 것을 환영합니다.
-          </p>
-        </div>
-
+    <div className="flex h-dvh flex-col">
+      <PublicHeader />
+      <div className="flex flex-1 flex-col justify-center px-5 pb-8">
+        <p className="text-sm text-muted-foreground">반가워요!</p>
+        <h1 className="mt-0.5 text-3xl text-foreground">로그인</h1>
+        <p className="mt-2 text-muted-foreground">
+          201 escape에 오신 것을 환영합니다.
+        </p>
         <div className="mt-8">
           <button
-            className="group relative flex w-full items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm font-semibold text-gray-700 transition-all hover:bg-gray-50 hover:shadow-md disabled:opacity-50"
+            className="group relative flex w-full cursor-pointer items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm font-semibold text-gray-700 transition-colors hover:bg-accent focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
             disabled={isLoading}
             onClick={handleGoogleLogin}
             type="button"
@@ -54,11 +53,8 @@ export default function LoginPage() {
             <span>{isLoading ? "로그인 중..." : "Google로 계속하기"}</span>
           </button>
         </div>
-
         {errorMessage && (
-          <p className="mt-4 text-center text-sm text-red-600">
-            {errorMessage}
-          </p>
+          <p className="mt-4 text-sm text-destructive">{errorMessage}</p>
         )}
       </div>
     </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,17 +2,24 @@ import Link from "next/link";
 
 import { Button } from "@/components/ui/button/Button";
 
+import { PublicHeader } from "./_components/PublicHeader";
+
 export default function Home() {
   return (
-    <div className="flex h-full flex-col justify-center gap-2 p-4">
-      <h1 className="flex flex-col text-4xl font-light">
-        <span>201</span>
-        <span>Escape</span>
-      </h1>
-      <p>개인 채용 공고 관리 대시보드</p>
-      <Button asChild size={"lg"}>
-        <Link href="/login">로그인</Link>
-      </Button>
+    <div className="flex h-dvh flex-col">
+      <PublicHeader />
+      <div className="flex flex-1 flex-col justify-center px-5 pb-8">
+        <p className="text-sm text-muted-foreground">채용 공고 관리</p>
+        <h1 className="mt-0.5 text-3xl text-foreground">201 Escape</h1>
+        <p className="mt-2 text-muted-foreground">
+          개인 채용 공고 관리 대시보드
+        </p>
+        <div className="mt-8">
+          <Button asChild size="lg">
+            <Link href="/login">로그인</Link>
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #173

## 📌 작업 내용

- h-dvh flex-col 레이아웃 + border-b 헤더 구조 적용
- 하드코딩 색상을 CSS 변수(foreground, muted-foreground, destructive)로 교체
- 카드/shadow 제거, 플랫 디자인으로 변경
- Google 로그인 버튼 hover·focus 이펙트 디자인 시스템에 맞게 통일

