### PR TITLE
fix: 모바일 UX 및 데이터 표시 오류 수정(#178)

### DIFF
--- a/app/(protected)/_components/Header.tsx
+++ b/app/(protected)/_components/Header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { LogOutIcon } from "lucide-react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -37,7 +38,13 @@ export function Header() {
 
   return (
     <header className="sticky top-0 z-10 flex items-center justify-between border-b border-border bg-background/80 px-6 py-3 backdrop-blur-sm">
-      <span className="text-lg font-bold">201</span>
+      <Button
+        asChild
+        className="text-lg font-bold hover:bg-transparent"
+        variant="ghost"
+      >
+        <Link href="/dashboard">201</Link>
+      </Button>
       <Tooltip label={isLoggingOut ? "로그아웃 중..." : "로그아웃"}>
         <Button
           aria-label={isLoggingOut ? "로그아웃 중..." : "로그아웃"}

--- a/app/(protected)/applications/[applicationId]/_components/BackLink.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/BackLink.tsx
@@ -2,18 +2,21 @@ import { ArrowLeftIcon } from "lucide-react";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button/Button";
+import { Tooltip } from "@/components/ui/tooltip/Tooltip";
 
 export function BackLink() {
   return (
-    <Button
-      asChild
-      className="h-auto w-fit px-0 text-sm font-medium text-muted-foreground hover:bg-transparent hover:text-foreground"
-      variant="ghost"
-    >
-      <Link href="/dashboard">
-        <ArrowLeftIcon aria-hidden="true" />
-        대시보드로 돌아가기
-      </Link>
-    </Button>
+    <Tooltip label="대시보드로 돌아가기" side="bottom">
+      <Button
+        asChild
+        className="-ml-2 text-muted-foreground hover:text-foreground"
+        size="sm"
+        variant="ghost"
+      >
+        <Link aria-label="대시보드로 돌아가기" href="/dashboard">
+          <ArrowLeftIcon aria-hidden="true" />
+        </Link>
+      </Button>
+    </Tooltip>
   );
 }

--- a/app/(protected)/applications/[applicationId]/_components/DeleteApplicationButton.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/DeleteApplicationButton.tsx
@@ -11,6 +11,7 @@ import type {
 
 import { Button } from "@/components/ui";
 import { BottomSheet } from "@/components/ui/bottom-sheet/BottomSheet";
+import { Tooltip } from "@/components/ui/tooltip/Tooltip";
 
 type DeleteApplicationAction = (
   input: DeleteApplicationInput,
@@ -70,10 +71,16 @@ export function DeleteApplicationButton({
 
   return (
     <>
-      <Button onClick={handleOpen} size="sm" variant="ghost">
-        <Trash2Icon aria-hidden="true" className="size-4" />
-        지원 삭제
-      </Button>
+      <Tooltip label="지원 삭제" side="bottom">
+        <Button
+          aria-label="지원 삭제"
+          onClick={handleOpen}
+          size="sm"
+          variant="ghost"
+        >
+          <Trash2Icon aria-hidden="true" className="size-4" />
+        </Button>
+      </Tooltip>
 
       <BottomSheet isOpen={isOpen} onClose={handleClose}>
         <BottomSheet.Overlay

--- a/app/(protected)/applications/[applicationId]/_components/ErrorState.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/ErrorState.tsx
@@ -7,14 +7,12 @@ import { Button } from "@/components/ui/button/Button";
 export type ErrorStateProps = {
   description: string;
   icon: LucideIcon;
-  reason: string;
   title: string;
 };
 
 export function ErrorState({
   description,
   icon: Icon,
-  reason,
   title,
 }: ErrorStateProps) {
   return (
@@ -30,7 +28,6 @@ export function ErrorState({
           <p className="text-sm leading-6 text-muted-foreground">
             {description}
           </p>
-          <p className="text-sm leading-6 text-foreground">{reason}</p>
         </div>
         <Button asChild className="h-10 px-4 text-sm">
           <Link href="/dashboard">지원 현황으로 돌아가기</Link>

--- a/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
@@ -19,7 +19,7 @@ import { toDatetimeLocalValue } from "@/lib/utils";
 const INTERVIEW_TYPES = Constants.public.Enums.interview_type;
 
 const INPUT_CLASS =
-  "w-full rounded-md border border-input bg-background px-3 py-2 text-[15px] text-foreground placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50";
+  "w-full rounded-md border border-input bg-background px-3 py-2 text-base text-foreground placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50";
 
 export type InterviewFormSheetProps = AddModeProps | EditModeProps;
 

--- a/app/(protected)/applications/[applicationId]/_components/JobDescriptionEditor.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/JobDescriptionEditor.tsx
@@ -121,7 +121,7 @@ export function JobDescriptionEditor({
         <>
           <textarea
             aria-labelledby={`job-description-label-${applicationId}`}
-            className="w-full resize-y rounded-md border border-input bg-background px-3 py-2 text-[15px] leading-8 text-foreground placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            className="w-full resize-y rounded-md border border-input bg-background px-3 py-2 text-base leading-8 text-foreground placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
             disabled={isSaving}
             onChange={(e) => setDraftText(e.target.value)}
             placeholder="공고 설명을 입력하세요"

--- a/app/(protected)/applications/[applicationId]/_components/MemoEditor.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/MemoEditor.tsx
@@ -121,7 +121,7 @@ export function MemoEditor({
         <>
           <textarea
             aria-labelledby={`memo-label-${applicationId}`}
-            className="w-full resize-y rounded-md border border-input bg-background px-3 py-2 text-[15px] leading-8 text-foreground placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            className="w-full resize-y rounded-md border border-input bg-background px-3 py-2 text-base leading-8 text-foreground placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
             disabled={isSaving}
             onChange={(e) => setDraftText(e.target.value)}
             placeholder="메모를 입력하세요"

--- a/app/(protected)/applications/[applicationId]/page.tsx
+++ b/app/(protected)/applications/[applicationId]/page.tsx
@@ -71,7 +71,6 @@ export default async function ApplicationDetailPage({
           <ErrorState
             description={errorMeta.description}
             icon={errorMeta.icon}
-            reason={result.reason}
             title={errorMeta.title}
           />
         </div>
@@ -80,7 +79,10 @@ export default async function ApplicationDetailPage({
   }
 
   const detail = result.data;
-  const hasOriginUrl = detail.originUrl.trim() !== "";
+  const hasOriginUrl =
+    detail.originUrl !== null &&
+    detail.originUrl.trim() !== "" &&
+    !detail.originUrl.startsWith("manual:");
 
   return (
     <main className="px-5 py-6 sm:px-6 lg:px-8">
@@ -98,14 +100,19 @@ export default async function ApplicationDetailPage({
         <section className="space-y-5">
           <div className="space-y-4">
             <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-              <span className="text-sm font-medium tracking-[0.08em] text-muted-foreground uppercase">
-                {PLATFORM_LABEL[detail.platform]}
-              </span>
-              <span aria-hidden="true" className="text-muted-foreground">
-                /
-              </span>
-              <span className="text-sm text-muted-foreground">
-                지원일 {formatAppliedAt(detail.appliedAt)}
+              {detail.platform !== "MANUAL" && (
+                <>
+                  <span className="text-sm font-medium tracking-[0.08em] text-muted-foreground uppercase">
+                    {PLATFORM_LABEL[detail.platform]}
+                  </span>
+                  <span aria-hidden="true" className="text-muted-foreground">
+                    /
+                  </span>
+                </>
+              )}
+              <span className="flex gap-1 text-sm text-muted-foreground">
+                <span>{detail.status === "SAVED" ? "저장일" : "지원일"}</span>
+                <span>{formatAppliedAt(detail.appliedAt)}</span>
               </span>
             </div>
 
@@ -125,7 +132,7 @@ export default async function ApplicationDetailPage({
                   >
                     <a
                       aria-label="원문 공고 보러가기"
-                      href={detail.originUrl}
+                      href={detail.originUrl!}
                       rel="noreferrer noopener"
                       target="_blank"
                     >

--- a/app/(protected)/dashboard/_components/add-job/components/ManualFormView.tsx
+++ b/app/(protected)/dashboard/_components/add-job/components/ManualFormView.tsx
@@ -44,7 +44,7 @@ export function ManualFormView({ error, onSubmit }: ManualFormViewProps) {
           </label>
           <input
             className={cn(
-              "h-10 w-full rounded-md border border-input bg-background px-3 text-sm",
+              "h-10 w-full rounded-md border border-input bg-background px-3 text-base",
               "placeholder:text-muted-foreground",
               "focus:ring-1 focus:ring-ring focus:outline-none",
             )}
@@ -73,7 +73,7 @@ export function ManualFormView({ error, onSubmit }: ManualFormViewProps) {
           </label>
           <input
             className={cn(
-              "h-10 w-full rounded-md border border-input bg-background px-3 text-sm",
+              "h-10 w-full rounded-md border border-input bg-background px-3 text-base",
               "placeholder:text-muted-foreground",
               "focus:ring-1 focus:ring-ring focus:outline-none",
             )}
@@ -100,7 +100,7 @@ export function ManualFormView({ error, onSubmit }: ManualFormViewProps) {
           </label>
           <input
             className={cn(
-              "h-10 w-full rounded-md border border-input bg-background px-3 text-sm",
+              "h-10 w-full rounded-md border border-input bg-background px-3 text-base",
               "placeholder:text-muted-foreground",
               "focus:ring-1 focus:ring-ring focus:outline-none",
             )}

--- a/app/(protected)/dashboard/_components/add-job/components/UrlInputView.tsx
+++ b/app/(protected)/dashboard/_components/add-job/components/UrlInputView.tsx
@@ -27,7 +27,7 @@ export function UrlInputView({
         </label>
         <input
           className={cn(
-            "h-10 w-full rounded-md border border-input bg-background px-3 text-sm",
+            "h-10 w-full rounded-md border border-input bg-background px-3 text-base",
             "placeholder:text-muted-foreground",
             "focus:ring-1 focus:ring-ring focus:outline-none",
             error && "border-destructive",

--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationPreviewSheet.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationPreviewSheet.tsx
@@ -117,6 +117,7 @@ export function ApplicationPreviewSheet({
   const companyName = detail?.companyName ?? application?.companyName ?? "";
   const platform = detail?.platform ?? application?.platform;
   const appliedAt = detail?.appliedAt ?? application?.appliedAt;
+  const status = detail?.status ?? application?.status;
   const descriptionMeta = getDescriptionMeta(detail);
   const notesMeta = getNotesMeta(detail);
 
@@ -135,17 +136,18 @@ export function ApplicationPreviewSheet({
         <div className="px-6 pb-4">
           {(platform || appliedAt) && (
             <div className="mb-2 flex flex-wrap items-center gap-0">
-              {platform && (
+              {platform && platform !== "MANUAL" && (
                 <span className="text-xs font-medium text-muted-foreground">
                   {PLATFORM_LABEL[platform]}
                 </span>
               )}
-              {platform && appliedAt && (
+              {platform && platform !== "MANUAL" && appliedAt && (
                 <span className="mx-2 text-xs text-muted-foreground/40">|</span>
               )}
               {appliedAt && (
-                <span className="text-xs font-medium text-muted-foreground">
-                  지원일 {formatAppliedAt(appliedAt)}
+                <span className="flex gap-1 text-xs font-medium text-muted-foreground">
+                  <span>{status === "SAVED" ? "저장일" : "지원일"}</span>
+                  <span>{formatAppliedAt(appliedAt)}</span>
                 </span>
               )}
             </div>

--- a/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationRow.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/ApplicationRow.tsx
@@ -1,10 +1,11 @@
 import { ChevronRightIcon } from "lucide-react";
 
-import { cn, getTimeAgo } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 
 import type { ApplicationListItem } from "../types";
 
 import { PLATFORM_LABEL, STATUS_META } from "../constants";
+import { TimeAgo } from "./TimeAgo";
 
 type ApplicationRowProps = {
   application: ApplicationListItem;
@@ -40,14 +41,20 @@ export function ApplicationRow({ application, onSelect }: ApplicationRowProps) {
         </div>
         <div className="flex items-center gap-1.5">
           <span className={cn("text-sm font-medium", color)}>{label}</span>
-          <span className="text-sm text-muted-foreground">·</span>
-          <span className="text-sm text-muted-foreground">
-            {PLATFORM_LABEL[application.platform]}
-          </span>
+          {application.platform !== "MANUAL" && (
+            <>
+              <span className="text-sm text-muted-foreground">·</span>
+              <span className="text-sm text-muted-foreground">
+                {PLATFORM_LABEL[application.platform]}
+              </span>
+            </>
+          )}
         </div>
       </div>
       <div className="flex shrink-0 items-center gap-2 text-muted-foreground">
-        <span className="text-sm">{getTimeAgo(application.appliedAt)}</span>
+        <span className="text-sm">
+          <TimeAgo dateString={application.appliedAt} />
+        </span>
         <ChevronRightIcon aria-hidden="true" className="mt-0.5 size-4" />
       </div>
     </button>

--- a/app/(protected)/dashboard/_components/dashboard-view/components/TimeAgo.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/TimeAgo.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getTimeAgo } from "@/lib/utils";
+
+type TimeAgoProps = {
+  dateString: string;
+};
+
+export function TimeAgo({ dateString }: TimeAgoProps) {
+  const [, forceUpdate] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => forceUpdate((n) => n + 1), 60_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return <>{getTimeAgo(dateString)}</>;
+}

--- a/lib/types/application.ts
+++ b/lib/types/application.ts
@@ -41,7 +41,7 @@ export const applicationDetailSchema = z
     description: z.string().nullable(),
     id: z.uuid(),
     notes: z.string().nullable(),
-    originUrl: z.string(),
+    originUrl: z.string().nullable(),
     platform: jobPlatformSchema,
     positionTitle: z.string(),
     status: jobStatusSchema,
@@ -54,7 +54,7 @@ export type ApplicationDetail = {
   description: null | string;
   id: string;
   notes: null | string;
-  originUrl: string;
+  originUrl: null | string;
   platform: JobPlatform;
   positionTitle: string;
   status: JobStatus;


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #178

## 📌 작업 내용

- iOS 자동 확대 방지: input/textarea font-size를 16px(text-base)로 변경
- 수동 입력 공고에서 원본 링크 버튼이 노출되던 문제 수정(manual: 스킴 필터링)
- originUrl nullable 처리(DB에서 null 반환 시 상세 페이지 에러 상태로 빠지던 문제 수정)
- 관심 공고(SAVED) 상태일 때 지원일 → 저장일로 표시(상세 페이지, 프리뷰 시트)
- 직접 입력(MANUAL) 플랫폼 레이블 숨김(목록, 상세 페이지, 프리뷰 시트)
- ErrorState에서 내부 오류 메시지(reason)를 사용자에게 노출하던 문제 수정
- getTimeAgo 표시값이 페이지 오픈 중 갱신되지 않던 문제 수정 (1분 인터벌)
- 상세 페이지 헤더의 뒤로가기, 지원 삭제 버튼을 아이콘 전용으로 변경 및 툴팁 추가
- 헤더 로고에 /dashboard 링크 추가

