### PR TITLE
fix: storybook 테스트 중 Vite optimizeDeps 미설정으로 인한 모듈 fetch 실패 수정(#199)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -39,6 +39,9 @@ export default defineConfig({
       },
       {
         extends: true,
+        optimizeDeps: {
+          include: ["react", "react-dom", "next/navigation"],
+        },
         plugins: [
           // The plugin will run tests for the stories defined in your Storybook config
           // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #199

## 📌 작업 내용

-  vitest.config.ts의 storybook 프로젝트에 optimizeDeps.include를 추가해 react, react-dom, next/navigation을 사전 번들링하도록 설정


