### PR TITLE
feat: 에러 바운더리 계층화(#207)

### DIFF
--- a/app/(protected)/applications/[applicationId]/_components/InterviewSection.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/InterviewSection.tsx
@@ -25,6 +25,10 @@ export async function InterviewSection({
 }: InterviewSectionProps) {
   const result = await getInterviews(applicationId);
 
+  if (!result.ok) {
+    throw new Error(result.reason);
+  }
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
@@ -39,20 +43,14 @@ export async function InterviewSection({
         <div className="ml-auto">
           <InterviewFormSheet
             applicationId={applicationId}
-            defaultRound={result.ok ? result.data.length + 1 : 1}
+            defaultRound={result.data.length + 1}
             mode="add"
             upsertAction={upsertInterview}
           />
         </div>
       </div>
 
-      {!result.ok ? (
-        <p className="text-[15px] text-muted-foreground/60 italic">
-          면접 일정을 불러오지 못했습니다.
-        </p>
-      ) : (
-        <InterviewList applicationId={applicationId} interviews={result.data} />
-      )}
+      <InterviewList applicationId={applicationId} interviews={result.data} />
     </div>
   );
 }

--- a/app/(protected)/applications/[applicationId]/_components/SectionErrorBoundary.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/SectionErrorBoundary.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { ErrorBoundary } from "@suspensive/react";
+
+import { Button } from "@/components/ui/button/Button";
+
+type SectionErrorBoundaryProps = {
+  children: ReactNode;
+};
+
+type SectionErrorFallbackProps = {
+  reset: () => void;
+};
+
+export function SectionErrorBoundary({ children }: SectionErrorBoundaryProps) {
+  return (
+    <ErrorBoundary
+      fallback={({ reset }) => <SectionErrorFallback reset={reset} />}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}
+
+function SectionErrorFallback({ reset }: SectionErrorFallbackProps) {
+  return (
+    <div className="flex flex-col items-center gap-3 py-6 text-center">
+      <p className="text-sm text-muted-foreground">
+        이 섹션을 불러오지 못했습니다.
+      </p>
+      <Button onClick={reset} size="sm" variant="link">
+        다시 시도
+      </Button>
+    </div>
+  );
+}

--- a/app/(protected)/applications/[applicationId]/error.tsx
+++ b/app/(protected)/applications/[applicationId]/error.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { ErrorPageFallback } from "@/app/_components/ErrorPageFallback";
+
+export default function ApplicationDetailError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main className="min-h-screen bg-muted/30">
+      <ErrorPageFallback
+        description="일시적인 오류가 발생했습니다. 다시 시도하거나 대시보드로 돌아가 주세요."
+        error={error}
+        navHref="/dashboard"
+        navLabel="지원 현황으로 돌아가기"
+        resetAction={reset}
+        title="상세 페이지를 불러오지 못했습니다"
+      />
+    </main>
+  );
+}

--- a/app/(protected)/applications/[applicationId]/page.tsx
+++ b/app/(protected)/applications/[applicationId]/page.tsx
@@ -4,8 +4,10 @@ import {
   ListChecksIcon,
   LockKeyholeIcon,
 } from "lucide-react";
+import { Suspense } from "react";
 
 import { ApplicationStatusSelector } from "@/app/(protected)/_components/ApplicationStatusSelector";
+import { Skeleton } from "@/components/ui";
 import { Button } from "@/components/ui/button/Button";
 import { deleteApplication, getApplicationDetail } from "@/lib/actions";
 import { updateApplicationNotes } from "@/lib/actions/updateApplicationNotes";
@@ -20,6 +22,7 @@ import { ErrorState } from "./_components/ErrorState";
 import { InterviewSection } from "./_components/InterviewSection";
 import { JobDescriptionEditor } from "./_components/JobDescriptionEditor";
 import { MemoEditor } from "./_components/MemoEditor";
+import { SectionErrorBoundary } from "./_components/SectionErrorBoundary";
 
 type ApplicationDetailPageProps = {
   params: Promise<{
@@ -162,7 +165,11 @@ export default async function ApplicationDetailPage({
 
         <div className="grid gap-6">
           <div className="rounded-2xl border border-border/50 bg-background p-5 shadow-sm">
-            <InterviewSection applicationId={detail.id} />
+            <SectionErrorBoundary>
+              <Suspense fallback={<InterviewSectionSkeleton />}>
+                <InterviewSection applicationId={detail.id} />
+              </Suspense>
+            </SectionErrorBoundary>
           </div>
 
           <div className="rounded-2xl border border-border/50 bg-background p-5 shadow-sm">
@@ -183,5 +190,25 @@ export default async function ApplicationDetailPage({
         </div>
       </div>
     </main>
+  );
+}
+
+function InterviewSectionSkeleton() {
+  return (
+    <div
+      aria-busy="true"
+      aria-label="면접 일정을 불러오는 중입니다"
+      className="space-y-4"
+      role="status"
+    >
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-5 w-20" />
+        <Skeleton className="h-8 w-16" />
+      </div>
+      <div className="space-y-3">
+        <Skeleton className="h-16 w-full rounded-xl" />
+        <Skeleton className="h-16 w-full rounded-xl" />
+      </div>
+    </div>
   );
 }

--- a/app/(protected)/dashboard/_components/dashboard-view/components/DashboardApplicationsPanel.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/components/DashboardApplicationsPanel.tsx
@@ -3,7 +3,10 @@
 import type { InfiniteData } from "@tanstack/react-query";
 import type { Route } from "next";
 
-import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useQueryClient,
+  useSuspenseInfiniteQuery,
+} from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useRef, useState } from "react";
 
@@ -36,7 +39,7 @@ export function DashboardApplicationsPanel() {
   const [isListScrolled, setIsListScrolled] = useState(false);
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useInfiniteQuery({
+    useSuspenseInfiniteQuery({
       getNextPageParam: getApplicationsNextPageParam,
       initialPageParam: 0,
       queryFn: async ({ pageParam }: { pageParam: number }) => {
@@ -52,8 +55,9 @@ export function DashboardApplicationsPanel() {
       queryKey: APPLICATIONS_QUERY_KEY,
     });
 
-  const applications: ApplicationListItem[] =
-    data?.pages.flatMap((page) => page.items) ?? [];
+  const applications: ApplicationListItem[] = data.pages.flatMap(
+    (page) => page.items,
+  );
 
   const selectedApplicationId = searchParams.get(PREVIEW_PARAM);
   const isPreviewOpen = selectedApplicationId !== null;

--- a/app/(protected)/dashboard/error.tsx
+++ b/app/(protected)/dashboard/error.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { ErrorPageFallback } from "@/app/_components/ErrorPageFallback";
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main className="min-h-screen bg-muted/30">
+      <ErrorPageFallback
+        description="목록 로딩 중 오류가 발생했습니다. 다시 시도하거나 잠시 후 돌아와 주세요."
+        error={error}
+        navHref="/"
+        navLabel="홈으로 이동"
+        resetAction={reset}
+        title="지원 현황을 불러오지 못했습니다"
+      />
+    </main>
+  );
+}

--- a/app/_components/ErrorPageFallback.tsx
+++ b/app/_components/ErrorPageFallback.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import type { Route } from "next";
+
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button/Button";
+
+type ErrorPageFallbackProps = {
+  description: string;
+  error: Error & { digest?: string };
+  navHref: Route;
+  navLabel: string;
+  resetAction: () => void;
+  title: string;
+};
+
+export function ErrorPageFallback({
+  description,
+  error,
+  navHref,
+  navLabel,
+  resetAction,
+  title,
+}: ErrorPageFallbackProps) {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 p-4 text-center">
+      <div className="space-y-3">
+        <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
+        <p className="text-sm text-muted-foreground">
+          {description}
+          {error.digest && (
+            <span className="mt-1 block text-xs text-muted-foreground/60">
+              오류 코드: {error.digest}
+            </span>
+          )}
+        </p>
+      </div>
+      <div className="flex gap-3">
+        <Button onClick={resetAction} variant="outline">
+          다시 시도
+        </Button>
+        <Button asChild>
+          <Link href={navHref}>{navLabel}</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { ErrorPageFallback } from "./_components/ErrorPageFallback";
+
+export default function RootError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ErrorPageFallback
+      description="일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."
+      error={error}
+      navHref="/dashboard"
+      navLabel="대시보드로 이동"
+      resetAction={reset}
+      title="페이지를 불러오지 못했습니다"
+    />
+  );
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.95.0",
+    "@suspensive/react": "^3.20.2",
     "@tanstack/react-query": "^5.95.2",
     "cheerio": "^1.2.0",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.95.0
         version: 2.95.0
+      '@suspensive/react':
+        specifier: ^3.20.2
+        version: 3.20.2(react@19.2.3)
       '@tanstack/react-query':
         specifier: ^5.95.2
         version: 5.95.2(react@19.2.3)
@@ -1820,6 +1823,11 @@ packages:
   '@supabase/supabase-js@2.95.0':
     resolution: {integrity: sha512-fO5O650mkPIgUOZ/s86RZ19ZZhvxTBbatQmECGUtB5/sUb6DtIyoR7rFBBMV9oLbtyDCi1UU4wv3Jd6EY3d03Q==}
     engines: {node: '>=20.0.0'}
+
+  '@suspensive/react@3.20.2':
+    resolution: {integrity: sha512-BSh7PidCZlfpW8aXgldNf9n70PTTFw4yo4Zzev+yYSWya6SbR3v8DXsQnA7lJILNztnw22iYnjV6Nmumhhn9rA==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
@@ -6314,6 +6322,10 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@suspensive/react@3.20.2(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.28.6)':
     dependencies:


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #207

## 📌 작업 내용

- ErrorPageFallback 공통 컴포넌트 추가
- app, dashboard, applicationDetail 레벨에 Next.js error.tsx 추가
- SectionErrorBoundary 컴포넌트 추가(@suspensive/react 활용)
- InterviewSection을 에러 throw 방식으로 전환하고 SectionErrorBoundary + Suspense로 감쌈
- DashboardApplicationsPanel을 useSuspenseInfiniteQuery로 전환


