### PR TITLE
feat: useMutation으로 비동기 상태 관리 교체(#209)

### DIFF
--- a/app/(protected)/_components/ApplicationStatusSelector.tsx
+++ b/app/(protected)/_components/ApplicationStatusSelector.tsx
@@ -2,8 +2,9 @@
 
 import type { ReactNode } from "react";
 
+import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import type {
   UpdateApplicationStatusInput,
@@ -50,15 +51,51 @@ export function ApplicationStatusSelector({
 }: ApplicationStatusSelectorProps) {
   const router = useRouter();
   const [currentStatus, setCurrentStatus] = useState(status);
-  const [errorMessage, setErrorMessage] = useState<null | string>(null);
-  const [isSaving, setIsSaving] = useState(false);
+  // status prop 기준으로 에러를 추적 — prop이 바뀌면 이전 에러는 무효
+  const [errorState, setErrorState] = useState<null | {
+    message: string;
+    status: JobStatus;
+  }>(null);
 
-  useEffect(() => {
-    setErrorMessage(null);
-  }, [applicationId, status]);
+  const errorMessage =
+    errorState?.status === status ? errorState.message : null;
 
-  async function handleValueChange(nextStatus: string) {
-    if (isSaving || nextStatus === currentStatus) {
+  const mutation = useMutation<
+    void,
+    Error,
+    JobStatus,
+    { previousStatus: JobStatus }
+  >({
+    mutationFn: async (nextStatus) => {
+      const result = await updateStatusAction({
+        applicationId,
+        status: nextStatus,
+      });
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+    },
+    onError: (error, _, context) => {
+      if (context) {
+        setCurrentStatus(context.previousStatus);
+        onStatusChangeAction?.(context.previousStatus);
+      }
+      setErrorState({ message: error.message, status });
+    },
+    onMutate: (nextStatus) => {
+      const previousStatus = currentStatus;
+      setCurrentStatus(nextStatus);
+      setErrorState(null);
+      onStatusChangeAction?.(nextStatus);
+      return { previousStatus };
+    },
+    onSuccess: () => {
+      router.refresh();
+    },
+  });
+
+  function handleValueChange(nextStatus: string) {
+    if (mutation.isPending || nextStatus === currentStatus) {
       return;
     }
 
@@ -66,28 +103,7 @@ export function ApplicationStatusSelector({
       return;
     }
 
-    const parsedStatus = nextStatus as JobStatus;
-
-    setIsSaving(true);
-    setErrorMessage(null);
-
-    try {
-      const result = await updateStatusAction({
-        applicationId,
-        status: parsedStatus,
-      });
-
-      if (!result.ok) {
-        setErrorMessage(result.reason);
-        return;
-      }
-
-      setCurrentStatus(parsedStatus);
-      onStatusChangeAction?.(parsedStatus);
-      router.refresh();
-    } finally {
-      setIsSaving(false);
-    }
+    mutation.mutate(nextStatus as JobStatus);
   }
 
   return (
@@ -97,10 +113,10 @@ export function ApplicationStatusSelector({
           {icon && <span className="text-muted-foreground">{icon}</span>}
           {label && <h3 className="text-sm font-semibold">{label}</h3>}
           <div aria-live="polite" className="min-h-5">
-            {isSaving && (
+            {mutation.isPending && (
               <p className="text-sm text-muted-foreground">저장하는 중...</p>
             )}
-            {!isSaving && errorMessage && (
+            {!mutation.isPending && errorMessage && (
               <p className="text-sm text-red-600">{errorMessage}</p>
             )}
           </div>
@@ -109,7 +125,7 @@ export function ApplicationStatusSelector({
       <TabSelector
         activeItemClassName="border-primary bg-primary text-primary-foreground shadow-md"
         aria-label={ariaLabel}
-        disabled={isSaving}
+        disabled={mutation.isPending}
         inactiveItemClassName="border-border/50 bg-background text-muted-foreground hover:border-primary/20 hover:text-primary/70"
         itemClassName="min-h-11 flex-none rounded-full border px-4 py-2 font-bold shadow-none"
         items={STATUS_ITEMS}

--- a/app/(protected)/applications/[applicationId]/_components/DeleteApplicationButton.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/DeleteApplicationButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMutation } from "@tanstack/react-query";
 import { Trash2Icon } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -32,8 +33,25 @@ export function DeleteApplicationButton({
 }: DeleteApplicationButtonProps) {
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<null | string>(null);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const result = await deleteAction({ applicationId });
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+    },
+    onError: (error) => {
+      setErrorMessage(error.message);
+    },
+    onMutate: () => {
+      setErrorMessage(null);
+    },
+    onSuccess: () => {
+      router.push("/dashboard");
+    },
+  });
 
   function handleOpen() {
     setErrorMessage(null);
@@ -41,32 +59,17 @@ export function DeleteApplicationButton({
   }
 
   function handleClose() {
-    if (isDeleting) {
+    if (mutation.isPending) {
       return;
     }
     setIsOpen(false);
   }
 
-  async function handleConfirm() {
-    if (isDeleting) {
+  function handleConfirm() {
+    if (mutation.isPending) {
       return;
     }
-
-    setIsDeleting(true);
-    setErrorMessage(null);
-
-    try {
-      const result = await deleteAction({ applicationId });
-
-      if (!result.ok) {
-        setErrorMessage(result.reason);
-        return;
-      }
-
-      router.push("/dashboard");
-    } finally {
-      setIsDeleting(false);
-    }
+    mutation.mutate();
   }
 
   return (
@@ -85,7 +88,7 @@ export function DeleteApplicationButton({
       <BottomSheet isOpen={isOpen} onClose={handleClose}>
         <BottomSheet.Overlay
           onClick={(e) => {
-            if (isDeleting) {
+            if (mutation.isPending) {
               e.preventDefault();
             }
           }}
@@ -114,7 +117,7 @@ export function DeleteApplicationButton({
 
             <div className="flex justify-end gap-2">
               <Button
-                disabled={isDeleting}
+                disabled={mutation.isPending}
                 onClick={handleClose}
                 type="button"
                 variant="outline"
@@ -122,12 +125,12 @@ export function DeleteApplicationButton({
                 취소
               </Button>
               <Button
-                disabled={isDeleting}
+                disabled={mutation.isPending}
                 onClick={handleConfirm}
                 type="button"
                 variant="destructive"
               >
-                {isDeleting ? "삭제하는 중..." : "삭제"}
+                {mutation.isPending ? "삭제하는 중..." : "삭제"}
               </Button>
             </div>
           </BottomSheet.Body>

--- a/app/(protected)/applications/[applicationId]/_components/JobDescriptionEditor.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/JobDescriptionEditor.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMutation } from "@tanstack/react-query";
 import { FileTextIcon, PencilIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
@@ -29,22 +30,66 @@ export function JobDescriptionEditor({
   const [currentDescription, setCurrentDescription] = useState(description);
   const [draftText, setDraftText] = useState("");
   const [isEditing, setIsEditing] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState<null | string>(null);
 
   const editButtonRef = useRef<HTMLButtonElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  useEffect(() => {
+  // prop이 바뀌면 렌더 중에 바로 동기화 — effect 없이 이전 값 추적으로 처리
+  const [syncedProps, setSyncedProps] = useState({
+    applicationId,
+    description,
+  });
+  if (
+    syncedProps.applicationId !== applicationId ||
+    syncedProps.description !== description
+  ) {
+    setSyncedProps({ applicationId, description });
     setCurrentDescription(description);
     setErrorMessage(null);
-  }, [applicationId, description]);
+  }
 
   useEffect(() => {
     if (isEditing) {
       textareaRef.current?.focus();
     }
   }, [isEditing]);
+
+  const mutation = useMutation<
+    { description: null | string },
+    Error,
+    null | string,
+    { previousDescription: null | string }
+  >({
+    mutationFn: async (nextDescription) => {
+      const result = await updateDescriptionAction({
+        applicationId,
+        description: nextDescription,
+      });
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      return result.data;
+    },
+    onError: (error, variables, context) => {
+      if (context) {
+        setCurrentDescription(context.previousDescription);
+      }
+      setDraftText(variables ?? "");
+      setIsEditing(true);
+      setErrorMessage(error.message);
+    },
+    onMutate: (nextDescription) => {
+      const previousDescription = currentDescription;
+      setCurrentDescription(nextDescription);
+      setErrorMessage(null);
+      setIsEditing(false);
+      return { previousDescription };
+    },
+    onSuccess: () => {
+      router.refresh();
+    },
+  });
 
   function handleEditStart() {
     setDraftText(currentDescription ?? "");
@@ -53,35 +98,16 @@ export function JobDescriptionEditor({
   }
 
   function handleCancel() {
+    setErrorMessage(null);
     setIsEditing(false);
     editButtonRef.current?.focus();
   }
 
-  async function handleSave() {
-    if (isSaving) {
+  function handleSave() {
+    if (mutation.isPending) {
       return;
     }
-
-    setIsSaving(true);
-    setErrorMessage(null);
-
-    try {
-      const result = await updateDescriptionAction({
-        applicationId,
-        description: draftText.trim() === "" ? null : draftText,
-      });
-
-      if (!result.ok) {
-        setErrorMessage(result.reason);
-        return;
-      }
-
-      setCurrentDescription(result.data.description);
-      setIsEditing(false);
-      router.refresh();
-    } finally {
-      setIsSaving(false);
-    }
+    mutation.mutate(draftText.trim() === "" ? null : draftText);
   }
 
   return (
@@ -103,6 +129,7 @@ export function JobDescriptionEditor({
             <Button
               aria-label="편집"
               className="size-8 rounded-full"
+              disabled={mutation.isPending}
               onClick={handleEditStart}
               ref={editButtonRef}
               variant="ghost"
@@ -114,10 +141,7 @@ export function JobDescriptionEditor({
       </div>
 
       <div aria-atomic="true" aria-live="polite" className="min-h-0">
-        {isEditing && isSaving && (
-          <p className="mb-2 text-xs text-muted-foreground">저장하는 중...</p>
-        )}
-        {isEditing && !isSaving && errorMessage && (
+        {isEditing && errorMessage && (
           <p className="mb-2 text-xs font-medium text-red-600">
             {errorMessage}
           </p>
@@ -128,8 +152,8 @@ export function JobDescriptionEditor({
         <div className="space-y-3">
           <textarea
             aria-labelledby={`job-description-label-${applicationId}`}
-            className="min-h-[200px] w-full resize-none rounded-xl border border-input bg-muted/50 px-4 py-3 text-sm leading-relaxed text-foreground transition-colors placeholder:text-muted-foreground focus:bg-background focus:ring-2 focus:ring-ring focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={isSaving}
+            className="min-h-50 w-full resize-none rounded-xl border border-input bg-muted/50 px-4 py-3 text-sm leading-relaxed text-foreground transition-colors placeholder:text-muted-foreground focus:bg-background focus:ring-2 focus:ring-ring focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={mutation.isPending}
             onChange={(e) => setDraftText(e.target.value)}
             placeholder="공고 설명을 입력하세요"
             ref={textareaRef}
@@ -138,7 +162,7 @@ export function JobDescriptionEditor({
           <div className="flex justify-end gap-2">
             <Button
               className="h-9 rounded-full px-4 text-sm font-medium"
-              disabled={isSaving}
+              disabled={mutation.isPending}
               onClick={handleCancel}
               variant="ghost"
             >
@@ -146,7 +170,7 @@ export function JobDescriptionEditor({
             </Button>
             <Button
               className="h-9 rounded-full px-5 text-sm font-semibold"
-              disabled={isSaving}
+              disabled={mutation.isPending}
               onClick={handleSave}
             >
               저장
@@ -155,7 +179,7 @@ export function JobDescriptionEditor({
         </div>
       ) : (
         <div className="rounded-xl bg-muted/30 p-4">
-          <p className="text-[15px] leading-relaxed break-words whitespace-pre-wrap text-foreground/90">
+          <p className="text-[15px] leading-relaxed wrap-break-word whitespace-pre-wrap text-foreground/90">
             {currentDescription ?? (
               <span className="text-muted-foreground/60 italic">
                 공고 설명이 없습니다

--- a/app/(protected)/applications/[applicationId]/_components/MemoEditor.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/MemoEditor.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMutation } from "@tanstack/react-query";
 import { NotebookPenIcon, PencilIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
@@ -29,22 +30,63 @@ export function MemoEditor({
   const [currentNotes, setCurrentNotes] = useState(notes);
   const [draftText, setDraftText] = useState("");
   const [isEditing, setIsEditing] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState<null | string>(null);
 
   const editButtonRef = useRef<HTMLButtonElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  useEffect(() => {
+  // prop이 바뀌면 렌더 중에 바로 동기화 — effect 없이 이전 값 추적으로 처리
+  const [syncedProps, setSyncedProps] = useState({ applicationId, notes });
+  if (
+    syncedProps.applicationId !== applicationId ||
+    syncedProps.notes !== notes
+  ) {
+    setSyncedProps({ applicationId, notes });
     setCurrentNotes(notes);
     setErrorMessage(null);
-  }, [applicationId, notes]);
+  }
 
   useEffect(() => {
     if (isEditing) {
       textareaRef.current?.focus();
     }
   }, [isEditing]);
+
+  const mutation = useMutation<
+    { notes: null | string },
+    Error,
+    null | string,
+    { previousNotes: null | string }
+  >({
+    mutationFn: async (nextNotes) => {
+      const result = await updateNotesAction({
+        applicationId,
+        notes: nextNotes,
+      });
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      return result.data;
+    },
+    onError: (error, variables, context) => {
+      if (context) {
+        setCurrentNotes(context.previousNotes);
+      }
+      setDraftText(variables ?? "");
+      setIsEditing(true);
+      setErrorMessage(error.message);
+    },
+    onMutate: (nextNotes) => {
+      const previousNotes = currentNotes;
+      setCurrentNotes(nextNotes);
+      setErrorMessage(null);
+      setIsEditing(false);
+      return { previousNotes };
+    },
+    onSuccess: () => {
+      router.refresh();
+    },
+  });
 
   function handleEditStart() {
     setDraftText(currentNotes ?? "");
@@ -53,35 +95,16 @@ export function MemoEditor({
   }
 
   function handleCancel() {
+    setErrorMessage(null);
     setIsEditing(false);
     editButtonRef.current?.focus();
   }
 
-  async function handleSave() {
-    if (isSaving) {
+  function handleSave() {
+    if (mutation.isPending) {
       return;
     }
-
-    setIsSaving(true);
-    setErrorMessage(null);
-
-    try {
-      const result = await updateNotesAction({
-        applicationId,
-        notes: draftText.trim() === "" ? null : draftText,
-      });
-
-      if (!result.ok) {
-        setErrorMessage(result.reason);
-        return;
-      }
-
-      setCurrentNotes(result.data.notes);
-      setIsEditing(false);
-      router.refresh();
-    } finally {
-      setIsSaving(false);
-    }
+    mutation.mutate(draftText.trim() === "" ? null : draftText);
   }
 
   return (
@@ -103,6 +126,7 @@ export function MemoEditor({
             <Button
               aria-label="편집"
               className="size-8 rounded-full"
+              disabled={mutation.isPending}
               onClick={handleEditStart}
               ref={editButtonRef}
               variant="ghost"
@@ -114,10 +138,7 @@ export function MemoEditor({
       </div>
 
       <div aria-atomic="true" aria-live="polite" className="min-h-0">
-        {isEditing && isSaving && (
-          <p className="mb-2 text-xs text-muted-foreground">저장하는 중...</p>
-        )}
-        {isEditing && !isSaving && errorMessage && (
+        {isEditing && errorMessage && (
           <p className="mb-2 text-xs font-medium text-red-600">
             {errorMessage}
           </p>
@@ -128,8 +149,8 @@ export function MemoEditor({
         <div className="space-y-3">
           <textarea
             aria-labelledby={`memo-label-${applicationId}`}
-            className="min-h-[120px] w-full resize-none rounded-xl border border-input bg-muted/50 px-4 py-3 text-sm leading-relaxed text-foreground transition-colors placeholder:text-muted-foreground focus:bg-background focus:ring-2 focus:ring-ring focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={isSaving}
+            className="min-h-30 w-full resize-none rounded-xl border border-input bg-muted/50 px-4 py-3 text-sm leading-relaxed text-foreground transition-colors placeholder:text-muted-foreground focus:bg-background focus:ring-2 focus:ring-ring focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={mutation.isPending}
             onChange={(e) => setDraftText(e.target.value)}
             placeholder="메모를 입력하세요"
             ref={textareaRef}
@@ -138,7 +159,7 @@ export function MemoEditor({
           <div className="flex justify-end gap-2">
             <Button
               className="h-9 rounded-full px-4 text-sm font-medium"
-              disabled={isSaving}
+              disabled={mutation.isPending}
               onClick={handleCancel}
               variant="ghost"
             >
@@ -146,7 +167,7 @@ export function MemoEditor({
             </Button>
             <Button
               className="h-9 rounded-full px-5 text-sm font-semibold"
-              disabled={isSaving}
+              disabled={mutation.isPending}
               onClick={handleSave}
             >
               저장
@@ -155,7 +176,7 @@ export function MemoEditor({
         </div>
       ) : (
         <div className="rounded-xl bg-muted/30 p-4">
-          <p className="text-[15px] leading-relaxed break-words whitespace-pre-wrap text-foreground/90">
+          <p className="text-[15px] leading-relaxed wrap-break-word whitespace-pre-wrap text-foreground/90">
             {currentNotes ?? (
               <span className="text-muted-foreground/60 italic">
                 메모가 없습니다


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #209

## 📌 작업 내용

- ApplicationStatusSelector: 상태 변경 시 낙관적 업데이트 및 실패 시 이전 상태 복원, onStatusChangeAction 콜백 롤백 지원
- DeleteApplicationButton: 삭제 뮤테이션으로 교체, 진행 중 다이얼로그 닫기 방지 유지
- JobDescriptionEditor: 저장 시 편집 모드 즉시 종료 후 실패 시 draft 복원 및 편집 모드 재진입
- MemoEditor: JobDescriptionEditor와 동일한 낙관적 업데이트 패턴 적용


