### PR TITLE
ci: Lighthouse 결과 PR 코멘트 게시 및 Node24 강제 적용(#215)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ jobs:
     name: Type Check / Lint / Test
     runs-on: ubuntu-latest
 
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -4,12 +4,16 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  pull-requests: write
+
 jobs:
   lighthouse:
     name: Lighthouse Audit
     runs-on: ubuntu-latest
 
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       NEXT_PUBLIC_SUPABASE_URL: https://${{ secrets.SUPABASE_PROJECT_REF }}.supabase.co
       NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_PUBLISHABLE_KEY }}
 
@@ -55,3 +59,107 @@ jobs:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
           LHCI_TEST_EMAIL: ${{ secrets.LHCI_TEST_EMAIL }}
           LHCI_TEST_PASSWORD: ${{ secrets.LHCI_TEST_PASSWORD }}
+
+      - name: Post Lighthouse results as PR comment
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const nodePath = require('path');
+
+            const lhciDir = nodePath.join(process.env.GITHUB_WORKSPACE, '.lighthouseci');
+
+            if (!fs.existsSync(lhciDir)) {
+              core.warning(`${lhciDir} not found — Lighthouse CI may have failed before producing results.`);
+              return;
+            }
+
+            const lhrFiles = fs.readdirSync(lhciDir).filter(f => f.startsWith('lhr-') && f.endsWith('.json'));
+
+            if (lhrFiles.length === 0) {
+              core.warning('No lhr-*.json files found — Lighthouse CI may have failed before producing results.');
+              return;
+            }
+
+            // URL별로 실행 결과를 그룹화한 뒤 성능 점수 중앙값 run을 대표로 선택
+            const byUrl = {};
+            for (const file of lhrFiles) {
+              const lhr = JSON.parse(fs.readFileSync(nodePath.join(lhciDir, file), 'utf8'));
+              const url = lhr.finalUrl || lhr.requestedUrl;
+              if (!byUrl[url]) byUrl[url] = [];
+              byUrl[url].push(lhr);
+            }
+
+            const representativeRuns = Object.entries(byUrl).map(([url, runs]) => {
+              const sorted = [...runs].sort((a, b) => a.categories.performance.score - b.categories.performance.score);
+              return { url, lhr: sorted[Math.floor(sorted.length / 2)] };
+            });
+
+            const linksPath = nodePath.join(lhciDir, 'links.json');
+            const links = fs.existsSync(linksPath)
+              ? JSON.parse(fs.readFileSync(linksPath, 'utf8'))
+              : {};
+
+            const emoji = (v) => v >= 0.9 ? '🟢' : v >= 0.8 ? '🟡' : '🔴';
+            const score = (v) => Math.round(v * 100);
+            const pagePath = (url) => url.replace('http://localhost:3000', '') || '/';
+            const pageCell = (url) => {
+              const p = pagePath(url);
+              return links[url] ? `[\`${p}\`](${links[url]})` : `\`${p}\``;
+            };
+            const metric = (audit) => audit?.displayValue ?? '-';
+
+            const perfRows = representativeRuns.map(({ url, lhr }) => {
+              const c = lhr.categories;
+              const a = lhr.audits;
+              return `| ${pageCell(url)} | ${emoji(c.performance.score)}${score(c.performance.score)} | ${metric(a['first-contentful-paint'])} | ${metric(a['largest-contentful-paint'])} | ${metric(a['total-blocking-time'])} | ${metric(a['cumulative-layout-shift'])} | ${metric(a['speed-index'])} |`;
+            }).join('\n');
+
+            const categoryRows = representativeRuns.map(({ url, lhr }) => {
+              const c = lhr.categories;
+              return `| ${pageCell(url)} | ${emoji(c.accessibility.score)}${score(c.accessibility.score)} | ${emoji(c['best-practices'].score)}${score(c['best-practices'].score)} | ${emoji(c.seo.score)}${score(c.seo.score)} |`;
+            }).join('\n');
+
+            const body = [
+              '## Lighthouse CI 결과',
+              '',
+              '### Performance',
+              '| 페이지 | Score | First Contentful Paint | Largest Contentful Paint | Total Blocking Time | Cumulative Layout Shift | Speed Index |',
+              '|---|:---:|:---:|:---:|:---:|:---:|:---:|',
+              perfRows,
+              '',
+              '### Categories',
+              '| 페이지 | Accessibility | Best Practices | SEO |',
+              '|---|:---:|:---:|:---:|',
+              categoryRows,
+              '',
+              '> 카테고리 점수 기준: 🟢 90점 이상 · 🟡 80점 이상 · 🔴 80점 미만',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.startsWith('## Lighthouse CI 결과')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -12,6 +12,9 @@ module.exports = {
     collect: {
       chromePath: process.env.CHROMIUM_PATH,
       numberOfRuns: 3,
+      outputDir: process.env.GITHUB_WORKSPACE
+        ? `${process.env.GITHUB_WORKSPACE}/.lighthouseci`
+        : ".lighthouseci",
       puppeteerLaunchOptions: {
         args: ["--no-sandbox", "--disable-setuid-sandbox"],
       },

--- a/lighthouse-auth.js
+++ b/lighthouse-auth.js
@@ -2,8 +2,15 @@
 // @supabase/ssr은 세션을 localStorage가 아닌 쿠키에 저장하기 때문에
 // setCookie로 주입해야 서버 컴포넌트에서 인증 상태를 읽을 수 있습니다.
 
-/** @param {import('puppeteer').Browser} browser */
-module.exports = async (browser) => {
+/**
+ * @param {import('puppeteer').Browser} browser
+ * @param {{ url: string }} context
+ */
+module.exports = async (browser, context) => {
+  // 랜딩 페이지는 비인증 상태로 측정합니다.
+  if (context.url === "http://localhost:3000") {
+    return;
+  }
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const publishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
   const projectRef = new URL(supabaseUrl).hostname.split(".")[0];


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #215

## 📌 작업 내용

- lighthouse.yml에 Lighthouse CI 결과를 PR 코멘트로 upsert하는 step 추가
- pull-requests: write 권한 추가
- ci.yml, lighthouse.yml에 FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 환경 변수 추가
- lighthouse-auth.js: 랜딩 페이지(/)는 비인증 상태로 측정하도록 context 분기 추가


