### PR TITLE
perf: 번들 최적화 및 LCP 개선(#221)

### DIFF
--- a/app/_components/landing/HeroSection.tsx
+++ b/app/_components/landing/HeroSection.tsx
@@ -1,14 +1,14 @@
 export function HeroSection() {
   return (
     <section className="flex flex-col px-6 pt-20 pb-12">
-      <div className="animate-fade-up">
+      <div className="animate-slide-up">
         <span className="inline-flex items-center gap-1.5 rounded-full bg-primary/10 px-3.5 py-1.5 text-[11px] font-bold tracking-wider text-primary uppercase">
           채용 공고 관리 대시보드
         </span>
       </div>
 
       <h1
-        className="mt-6 animate-fade-up text-[40px] leading-[1.1] font-extrabold tracking-tight text-foreground sm:text-5xl"
+        className="mt-6 animate-slide-up text-[40px] leading-[1.1] font-extrabold tracking-tight text-foreground sm:text-5xl"
         style={{ animationDelay: "80ms" }}
       >
         취업 준비,
@@ -17,7 +17,7 @@ export function HeroSection() {
       </h1>
 
       <p
-        className="mt-6 animate-fade-up text-lg leading-relaxed font-medium text-muted-foreground/80"
+        className="mt-6 animate-slide-up text-lg leading-relaxed font-medium text-muted-foreground/80"
         style={{ animationDelay: "160ms" }}
       >
         지원 현황부터 일정 관리까지,

--- a/app/globals.css
+++ b/app/globals.css
@@ -41,6 +41,16 @@
   /* Animations */
   --animate-fade-up: fade-up 0.5s ease-out both;
   --animate-fade-in: fade-in 0.4s ease-out both;
+  --animate-slide-up: slide-up 0.5s ease-out both;
+}
+
+@keyframes slide-up {
+  from {
+    transform: translateY(16px);
+  }
+  to {
+    transform: translateY(0);
+  }
 }
 
 @keyframes fade-up {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 
 import GoogleIcon from "@/assets/google.svg";
-import { createClient } from "@/lib/supabase/client";
 
 import { PublicHeader } from "../_components/PublicHeader";
 
@@ -15,21 +14,27 @@ export default function LoginPage() {
     setIsLoading(true);
     setErrorMessage(null);
 
-    const supabase = createClient();
+    try {
+      const { createClient } = await import("@/lib/supabase/client");
+      const supabase = createClient();
 
-    const url = new URL("/auth/callback", window.location.origin);
-    url.searchParams.set("next", "/");
+      const url = new URL("/auth/callback", window.location.origin);
+      url.searchParams.set("next", "/");
 
-    const { error } = await supabase.auth.signInWithOAuth({
-      options: {
-        redirectTo: url.toString(),
-      },
-      provider: "google",
-    });
+      const { error } = await supabase.auth.signInWithOAuth({
+        options: {
+          redirectTo: url.toString(),
+        },
+        provider: "google",
+      });
 
-    if (error) {
+      if (error) {
+        setErrorMessage(error.message);
+      }
+    } catch {
+      setErrorMessage("로그인을 시작할 수 없습니다. 다시 시도해 주세요.");
+    } finally {
       setIsLoading(false);
-      setErrorMessage(error.message);
     }
   };
 


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #221

## 📌 작업 내용

- login: Supabase 클라이언트를 dynamic import로 전환하여 초기 번들에서 제거
  - 로그인 페이지 unused JS 77 KiB → 26 KiB 감소
  - 버튼 클릭 시점에 lazy load되며 loading state로 지연 노출 없음
  - dynamic import 실패 포함 전체 에러를 try/catch/finally로 통합 처리

- HeroSection: animate-fade-up → animate-slide-up으로 교체
  - opacity: 0으로 시작하는 기존 애니메이션이 LCP 요소를 브라우저가 인식하지 못하게 막는 문제 수정
  - slide-up은 transform만 animate하여 요소가 즉시 LCP 후보로 인식됨
  - globals.css에 slide-up keyframe 및 --animate-slide-up 변수 추가

