### PR TITLE
fix: 로그인 후 리다이렉트 경로 및 auth 콜백 안정화(#227)

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,3 +1,5 @@
+export const runtime = "edge";
+
 import { NextResponse } from "next/server";
 
 import { createClient } from "@/lib/supabase/server";
@@ -11,16 +13,13 @@ export async function GET(request: Request) {
     const supabase = await createClient();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
-      const forwardedHost = request.headers.get("x-forwarded-host"); // original origin before load balancer
-      const isLocalEnv = process.env.NODE_ENV === "development";
-      if (isLocalEnv) {
-        // we can be sure that there is no load balancer in between, so no need to watch for X-Forwarded-Host
-        return NextResponse.redirect(`${origin}${next}`);
-      } else if (forwardedHost) {
-        return NextResponse.redirect(`https://${forwardedHost}${next}`);
-      } else {
-        return NextResponse.redirect(`${origin}${next}`);
-      }
+      const forwardedHost = request.headers.get("x-forwarded-host");
+      const host = forwardedHost ?? new URL(request.url).hostname;
+      const isLocalhost = host.split(":")[0] === "localhost";
+      const redirectOrigin = isLocalhost
+        ? `http://localhost:3000`
+        : `https://${host}`;
+      return NextResponse.redirect(`${redirectOrigin}${next}`);
     }
   }
 

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -19,7 +19,7 @@ export default function LoginPage() {
       const supabase = createClient();
 
       const url = new URL("/auth/callback", window.location.origin);
-      url.searchParams.set("next", "/");
+      url.searchParams.set("next", "/dashboard");
 
       const { error } = await supabase.auth.signInWithOAuth({
         options: {


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #227

## 📌 작업 내용

- next=/를 next=/dashboard로 변경해 로그인 후 랜딩페이지 경유 제거
- auth/callback을 Edge Runtime으로 전환해 콜드 스타트 개선
- NODE_ENV 대신 hostname 기반으로 리다이렉트 origin 결정

