### PR TITLE
feat: Sentry 사용자 컨텍스트 연동 및 Server Action QUERY_ERROR 구조화 리포트(#231)

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "react";
 
 import { TooltipProvider } from "@/components/ui/tooltip/Tooltip";
+import { SentryUserSync } from "@/lib/sentry/SentryUserSync";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -19,6 +20,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
 
   return (
     <QueryClientProvider client={queryClient}>
+      <SentryUserSync />
       <TooltipProvider>{children}</TooltipProvider>
     </QueryClientProvider>
   );

--- a/lib/actions/_reportQueryError.ts
+++ b/lib/actions/_reportQueryError.ts
@@ -1,0 +1,11 @@
+import * as Sentry from "@sentry/nextjs";
+
+export function reportQueryError(actionName: string, reason: string): void {
+  const error = new Error(`[${actionName}] QUERY_ERROR: ${reason}`);
+  error.name = "QueryError";
+  Sentry.withScope((scope) => {
+    scope.setTag("action", actionName);
+    scope.setExtra("reason", reason);
+    Sentry.captureException(error);
+  });
+}

--- a/lib/actions/deleteApplication.ts
+++ b/lib/actions/deleteApplication.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/types/application";
 
 import { normalizeQueryError } from "./_queryError";
+import { reportQueryError } from "./_reportQueryError";
 import { verifyApplicationOwnership } from "./_verifyApplicationOwnership";
 
 export async function deleteApplication(
@@ -45,11 +46,9 @@ export async function deleteApplication(
     .eq("id", parsedInput.data.applicationId);
 
   if (error) {
-    return {
-      code: "QUERY_ERROR",
-      ok: false,
-      reason: normalizeQueryError(error),
-    };
+    const reason = normalizeQueryError(error);
+    reportQueryError("deleteApplication", reason);
+    return { code: "QUERY_ERROR", ok: false, reason };
   }
 
   return { ok: true };

--- a/lib/actions/deleteInterview.ts
+++ b/lib/actions/deleteInterview.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/types/interview";
 
 import { normalizeQueryError } from "./_queryError";
+import { reportQueryError } from "./_reportQueryError";
 import { verifyApplicationOwnership } from "./_verifyApplicationOwnership";
 
 export async function deleteInterview(
@@ -46,11 +47,9 @@ export async function deleteInterview(
     .eq("application_id", parsedInput.data.applicationId);
 
   if (error) {
-    return {
-      code: "QUERY_ERROR",
-      ok: false,
-      reason: normalizeQueryError(error),
-    };
+    const reason = normalizeQueryError(error);
+    reportQueryError("deleteInterview", reason);
+    return { code: "QUERY_ERROR", ok: false, reason };
   }
 
   return { ok: true };

--- a/lib/actions/getApplicationDetail.ts
+++ b/lib/actions/getApplicationDetail.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/types/application";
 
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
+import { reportQueryError } from "./_reportQueryError";
 
 const ERROR_MESSAGES = {
   AUTH_REQUIRED: "로그인이 필요합니다.",
@@ -64,11 +65,13 @@ export async function getApplicationDetail(
     .maybeSingle();
 
   if (error) {
-    return {
-      code: error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR",
-      ok: false,
-      reason: normalizeQueryError(error),
-    };
+    const code =
+      error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
+    const reason = normalizeQueryError(error);
+    if (code === "QUERY_ERROR") {
+      reportQueryError("getApplicationDetail", reason);
+    }
+    return { code, ok: false, reason };
   }
 
   if (!data) {

--- a/lib/actions/getApplications.ts
+++ b/lib/actions/getApplications.ts
@@ -7,6 +7,7 @@ import type {
 
 import { createClient } from "../supabase/server";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
+import { reportQueryError } from "./_reportQueryError";
 
 const ERROR_MESSAGES = {
   AUTH_REQUIRED: "로그인이 필요합니다.",
@@ -49,11 +50,13 @@ export async function getApplications({
     .range(offset, offset + limit);
 
   if (error) {
-    return {
-      code: error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR",
-      ok: false,
-      reason: normalizeQueryError(error),
-    };
+    const code =
+      error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
+    const reason = normalizeQueryError(error);
+    if (code === "QUERY_ERROR") {
+      reportQueryError("getApplications", reason);
+    }
+    return { code, ok: false, reason };
   }
 
   const items: ApplicationListItem[] = data

--- a/lib/actions/getApplicationsStats.ts
+++ b/lib/actions/getApplicationsStats.ts
@@ -6,6 +6,7 @@ import { DOCS_STATUSES } from "@/lib/constants/application-status";
 
 import { createClient } from "../supabase/server";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
+import { reportQueryError } from "./_reportQueryError";
 
 const ERROR_MESSAGES = {
   AUTH_REQUIRED: "로그인이 필요합니다.",
@@ -35,11 +36,13 @@ export async function getApplicationsStats(): Promise<GetApplicationsStatsResult
     .eq("user_id", userId);
 
   if (error) {
-    return {
-      code: error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR",
-      ok: false,
-      reason: normalizeQueryError(error),
-    };
+    const code =
+      error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
+    const reason = normalizeQueryError(error);
+    if (code === "QUERY_ERROR") {
+      reportQueryError("getApplicationsStats", reason);
+    }
+    return { code, ok: false, reason };
   }
 
   const total = data.length;

--- a/lib/actions/getInterviews.ts
+++ b/lib/actions/getInterviews.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/types/interview";
 
 import { normalizeQueryError } from "./_queryError";
+import { reportQueryError } from "./_reportQueryError";
 import { verifyApplicationOwnership } from "./_verifyApplicationOwnership";
 
 export async function getInterviews(
@@ -46,11 +47,9 @@ export async function getInterviews(
     .order("round", { ascending: true });
 
   if (error) {
-    return {
-      code: "QUERY_ERROR",
-      ok: false,
-      reason: normalizeQueryError(error),
-    };
+    const reason = normalizeQueryError(error);
+    reportQueryError("getInterviews", reason);
+    return { code: "QUERY_ERROR", ok: false, reason };
   }
 
   return {

--- a/lib/actions/saveJobApplication.ts
+++ b/lib/actions/saveJobApplication.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/types/jobApplication";
 
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
+import { reportQueryError } from "./_reportQueryError";
 
 const ERROR_MESSAGES = {
   AUTH_REQUIRED: "로그인이 필요합니다.",
@@ -63,11 +64,12 @@ export async function saveJobApplication(
   });
 
   if (error) {
-    return {
-      code: error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "RPC_ERROR",
-      ok: false,
-      reason: normalizeQueryError(error),
-    };
+    const code = error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "RPC_ERROR";
+    const reason = normalizeQueryError(error);
+    if (code === "RPC_ERROR") {
+      reportQueryError("saveJobApplication", reason);
+    }
+    return { code, ok: false, reason };
   }
 
   const payload = Array.isArray(data) ? data[0] : data;

--- a/lib/actions/updateApplicationNotes.ts
+++ b/lib/actions/updateApplicationNotes.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/types/application";
 
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
+import { reportQueryError } from "./_reportQueryError";
 
 const ERROR_MESSAGES = {
   AUTH_REQUIRED: "로그인이 필요합니다.",
@@ -57,11 +58,13 @@ export async function updateApplicationNotes(
     .maybeSingle();
 
   if (error) {
-    return {
-      code: error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR",
-      ok: false,
-      reason: normalizeQueryError(error),
-    };
+    const code =
+      error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
+    const reason = normalizeQueryError(error);
+    if (code === "QUERY_ERROR") {
+      reportQueryError("updateApplicationNotes", reason);
+    }
+    return { code, ok: false, reason };
   }
 
   if (!data) {

--- a/lib/actions/updateApplicationStatus.ts
+++ b/lib/actions/updateApplicationStatus.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/types/application";
 
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
+import { reportQueryError } from "./_reportQueryError";
 
 const ERROR_MESSAGES = {
   AUTH_REQUIRED: "로그인이 필요합니다.",
@@ -57,11 +58,13 @@ export async function updateApplicationStatus(
     .maybeSingle();
 
   if (error) {
-    return {
-      code: error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR",
-      ok: false,
-      reason: normalizeQueryError(error),
-    };
+    const code =
+      error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
+    const reason = normalizeQueryError(error);
+    if (code === "QUERY_ERROR") {
+      reportQueryError("updateApplicationStatus", reason);
+    }
+    return { code, ok: false, reason };
   }
 
   if (!data) {

--- a/lib/actions/updateJobDescription.ts
+++ b/lib/actions/updateJobDescription.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/types/application";
 
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
+import { reportQueryError } from "./_reportQueryError";
 
 const ERROR_MESSAGES = {
   AUTH_REQUIRED: "로그인이 필요합니다.",
@@ -55,14 +56,15 @@ export async function updateJobDescription(
     .maybeSingle();
 
   if (applicationError) {
-    return {
-      code:
-        applicationError.code === AUTH_ERROR_CODE
-          ? "AUTH_REQUIRED"
-          : "QUERY_ERROR",
-      ok: false,
-      reason: normalizeQueryError(applicationError),
-    };
+    const code =
+      applicationError.code === AUTH_ERROR_CODE
+        ? "AUTH_REQUIRED"
+        : "QUERY_ERROR";
+    const reason = normalizeQueryError(applicationError);
+    if (code === "QUERY_ERROR") {
+      reportQueryError("updateJobDescription/fetchApplication", reason);
+    }
+    return { code, ok: false, reason };
   }
 
   if (!applicationData) {
@@ -81,11 +83,13 @@ export async function updateJobDescription(
     .maybeSingle();
 
   if (error) {
-    return {
-      code: error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR",
-      ok: false,
-      reason: normalizeQueryError(error),
-    };
+    const code =
+      error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
+    const reason = normalizeQueryError(error);
+    if (code === "QUERY_ERROR") {
+      reportQueryError("updateJobDescription/updateJob", reason);
+    }
+    return { code, ok: false, reason };
   }
 
   if (!data) {

--- a/lib/actions/upsertInterview.ts
+++ b/lib/actions/upsertInterview.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/types/interview";
 
 import { normalizeQueryError } from "./_queryError";
+import { reportQueryError } from "./_reportQueryError";
 import { verifyApplicationOwnership } from "./_verifyApplicationOwnership";
 
 export async function upsertInterview(
@@ -69,11 +70,9 @@ export async function upsertInterview(
     .maybeSingle();
 
   if (error) {
-    return {
-      code: "QUERY_ERROR",
-      ok: false,
-      reason: normalizeQueryError(error),
-    };
+    const reason = normalizeQueryError(error);
+    reportQueryError("upsertInterview", reason);
+    return { code: "QUERY_ERROR", ok: false, reason };
   }
 
   if (!data) {

--- a/lib/sentry/SentryUserSync.tsx
+++ b/lib/sentry/SentryUserSync.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import { useEffect } from "react";
+
+import { createClient } from "@/lib/supabase/client";
+
+export function SentryUserSync() {
+  useEffect(() => {
+    const supabase = createClient();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (session?.user) {
+        Sentry.setUser({ id: session.user.id });
+      } else {
+        Sentry.setUser(null);
+      }
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #231

## 📌 작업 내용

- SentryUserSync 컴포넌트 추가: onAuthStateChange로 로그인/로그아웃 감지 후 Sentry.setUser({ id }) / Sentry.setUser(null) 호출 (이메일 제외)
- reportQueryError 헬퍼 추가: captureException + withScope로 action 이름과 reason을 context로 첨부해 QueryError를 구조화된 형태로 Sentry에 리포트
- 10개 Server Action에서 QUERY_ERROR(및 RPC_ERROR) 반환 직전에 reportQueryError 명시적 호출 추가 (AUTH_REQUIRED 분기는 제외)


