### PR TITLE
feat: 지원 목록 검색/기간/정렬/탭 필터 URL 상태 관리 추가(#239)

### DIFF
--- a/app/(protected)/applications/_components/ApplicationsView.tsx
+++ b/app/(protected)/applications/_components/ApplicationsView.tsx
@@ -11,12 +11,31 @@ import { getApplications } from "@/lib/actions";
 import { AddJobTrigger } from "./add-job";
 import { ApplicationsPanel } from "./components/ApplicationsPanel";
 import {
-  APPLICATIONS_QUERY_KEY,
+  buildApplicationsQueryKey,
   getApplicationsNextPageParam,
+  getPeriodDateRange,
   PAGE_SIZE,
+  parsePeriodParam,
+  parseSortParam,
+  PERIOD_PARAM,
+  SEARCH_PARAM,
+  SORT_PARAM,
 } from "./constants";
 
-export async function ApplicationsView() {
+type SearchParams = Record<string, string | string[] | undefined>;
+
+export async function ApplicationsView({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const search = getString(searchParams[SEARCH_PARAM]);
+  const period = parsePeriodParam(
+    getString(searchParams[PERIOD_PARAM]) || null,
+  );
+  const sort = parseSortParam(getString(searchParams[SORT_PARAM]) || null);
+  const dateRange = getPeriodDateRange(period);
+
   const queryClient = new QueryClient();
 
   await queryClient.prefetchInfiniteQuery({
@@ -27,6 +46,10 @@ export async function ApplicationsView() {
       const result = await getApplications({
         limit: PAGE_SIZE,
         offset: pageParam,
+        periodEnd: dateRange?.end,
+        periodStart: dateRange?.start,
+        search: search || undefined,
+        sort,
       });
 
       if (!result.ok) {
@@ -35,7 +58,7 @@ export async function ApplicationsView() {
 
       return result.data;
     },
-    queryKey: APPLICATIONS_QUERY_KEY,
+    queryKey: buildApplicationsQueryKey({ period, search, sort }),
   });
 
   return (
@@ -47,7 +70,7 @@ export async function ApplicationsView() {
           </h1>
         </header>
 
-        <div className="h-150 overflow-hidden rounded-3xl border border-border/50 bg-background shadow-sm">
+        <div className="h-200 overflow-hidden rounded-3xl border border-border/50 bg-background shadow-sm">
           <HydrationBoundary state={dehydrate(queryClient)}>
             <Suspense fallback={<ApplicationsViewSkeleton />}>
               <ApplicationsPanel />
@@ -73,4 +96,8 @@ function ApplicationsViewSkeleton() {
       ))}
     </div>
   );
+}
+
+function getString(value: string | string[] | undefined): string {
+  return typeof value === "string" ? value : "";
 }

--- a/app/(protected)/applications/_components/components/ApplicationFilters.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationFilters.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { ChevronDownIcon, SearchIcon, XIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+import type { PeriodPreset, SortValue } from "../constants";
+
+import {
+  PERIOD_PRESET_LABELS,
+  PERIOD_PRESETS,
+  SORT_LABELS,
+  SORT_VALUES,
+} from "../constants";
+
+type ApplicationFiltersProps = {
+  onPeriodChangeAction: (period: PeriodPreset) => void;
+  onSearchSubmitAction: (search: string) => void;
+  onSortChangeAction: (sort: SortValue) => void;
+  period: PeriodPreset;
+  resultCount: number;
+  search: string;
+  sort: SortValue;
+};
+
+export function ApplicationFilters({
+  onPeriodChangeAction,
+  onSearchSubmitAction,
+  onSortChangeAction,
+  period,
+  resultCount,
+  search,
+  sort,
+}: ApplicationFiltersProps) {
+  const [inputValue, setInputValue] = useState(search);
+
+  // URL 상태(뒤로가기 등)로 search prop이 외부에서 바뀔 때 입력창을 동기화
+  useEffect(() => {
+    setInputValue(search);
+  }, [search]);
+
+  const isFiltered = search !== "" || period !== "all";
+
+  function handleSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
+    e.preventDefault();
+    onSearchSubmitAction(inputValue.trim());
+  }
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const value = e.target.value;
+    setInputValue(value);
+    if (value === "") {
+      onSearchSubmitAction("");
+    }
+  }
+
+  function handleClear() {
+    setInputValue("");
+    onSearchSubmitAction("");
+  }
+
+  return (
+    <div className="flex flex-col gap-3 px-5 pt-4 pb-2">
+      {/* 1행: 검색 */}
+      <form onSubmit={handleSubmit} role="search">
+        <div className="relative">
+          <SearchIcon
+            aria-hidden="true"
+            className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground"
+          />
+          <input
+            aria-label="회사명 검색"
+            className="w-full rounded-xl border border-border bg-muted/50 py-2 pr-9 pl-9 text-sm placeholder:text-muted-foreground focus:border-primary/50 focus:ring-2 focus:ring-primary/10 focus:outline-none"
+            onChange={handleChange}
+            placeholder="회사명 검색"
+            type="text"
+            value={inputValue}
+          />
+          {inputValue !== "" && (
+            <button
+              aria-label="검색어 지우기"
+              className="absolute top-1/2 right-3 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              onClick={handleClear}
+              type="button"
+            >
+              <XIcon aria-hidden="true" className="size-4" />
+            </button>
+          )}
+        </div>
+      </form>
+
+      {/* 2행: 기간 필터 + 정렬 */}
+      <div className="flex items-center justify-between gap-2">
+        <div aria-label="기간 필터" className="flex gap-2" role="group">
+          {PERIOD_PRESETS.map((preset) => (
+            <button
+              aria-pressed={period === preset}
+              className={cn(
+                "rounded-full px-3 py-1 text-xs font-semibold transition-colors",
+                period === preset
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground",
+              )}
+              key={preset}
+              onClick={() => onPeriodChangeAction(preset)}
+              type="button"
+            >
+              {PERIOD_PRESET_LABELS[preset]}
+            </button>
+          ))}
+        </div>
+
+        <div className="relative shrink-0">
+          <select
+            aria-label="정렬"
+            className="appearance-none bg-transparent py-1 pr-6 pl-0 text-sm font-semibold text-muted-foreground focus:outline-none"
+            onChange={(e) => onSortChangeAction(e.target.value as SortValue)}
+            value={sort}
+          >
+            {SORT_VALUES.map((value) => (
+              <option key={value} value={value}>
+                {SORT_LABELS[value]}
+              </option>
+            ))}
+          </select>
+          <ChevronDownIcon
+            aria-hidden="true"
+            className="pointer-events-none absolute top-1/2 right-2.5 size-3.5 -translate-y-1/2 text-muted-foreground"
+          />
+        </div>
+      </div>
+
+      {isFiltered && (
+        <p aria-atomic="true" aria-live="polite" className="sr-only">
+          {resultCount}개의 지원 내역이 있습니다
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/(protected)/applications/_components/components/ApplicationList.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationList.tsx
@@ -61,7 +61,10 @@ export function ApplicationList({
         onRangeChange={handleRangeChange}
         ref={ref}
         renderItem={(item) => (
-          <ApplicationRow application={item} onSelect={onSelectApplication} />
+          <ApplicationRow
+            application={item}
+            onSelectAction={onSelectApplication}
+          />
         )}
       />
       {!isFetchingNextPage && <div className="h-12 shrink-0" />}

--- a/app/(protected)/applications/_components/components/ApplicationRow.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationRow.tsx
@@ -13,10 +13,13 @@ import { TimeAgo } from "./TimeAgo";
 
 type ApplicationRowProps = {
   application: ApplicationListItem;
-  onSelect: (application: ApplicationListItem) => void;
+  onSelectAction: (application: ApplicationListItem) => void;
 };
 
-export function ApplicationRow({ application, onSelect }: ApplicationRowProps) {
+export function ApplicationRow({
+  application,
+  onSelectAction,
+}: ApplicationRowProps) {
   const posthog = usePostHog();
   const { badgeClassName, label } = STATUS_META[application.status];
 
@@ -31,7 +34,7 @@ export function ApplicationRow({ application, onSelect }: ApplicationRowProps) {
         )}
         onClick={() => {
           posthog.capture(POSTHOG_EVENTS.APPLICATION_PREVIEW_OPENED);
-          onSelect(application);
+          onSelectAction(application);
         }}
         type="button"
       >

--- a/app/(protected)/applications/_components/components/ApplicationTabs.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationTabs.tsx
@@ -9,13 +9,17 @@ import { Tabs } from "@/components/ui";
 import { POSTHOG_EVENTS } from "@/lib/posthog/events";
 import { cn } from "@/lib/utils";
 
+import type { TabValue } from "../constants";
 import type { ApplicationListItem } from "../types";
 
 import { DONE_STATUSES, IN_PROGRESS_STATUSES } from "../constants";
 import { ApplicationList } from "./ApplicationList";
 
 const TAB_TRIGGER_CLASS =
-  "h-9 flex-1 rounded-full px-3 text-sm font-semibold transition-all data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-md text-muted-foreground hover:text-foreground";
+  "group relative flex items-center gap-1.5 rounded-none px-1 pb-3 text-sm font-semibold transition-colors text-muted-foreground hover:text-foreground data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:rounded-full after:bg-transparent data-[state=active]:after:bg-primary";
+
+const BADGE_CLASS =
+  "rounded-full px-1.5 py-0.5 text-[10px] font-bold tabular-nums text-muted-foreground transition-colors group-data-[state=active]:bg-primary/10 group-data-[state=active]:text-primary";
 
 export type ApplicationTabsHandle = {
   scrollToTop: () => void;
@@ -25,20 +29,24 @@ type ApplicationTabsProps = {
   applications: ApplicationListItem[];
   className?: string;
   isFetchingNextPage?: boolean;
-  onNearEnd?: () => void;
-  onRangeChange?: (startIndex: number, endIndex: number) => void;
-  onSelectApplication: (application: ApplicationListItem) => void;
+  onNearEndAction?: () => void;
+  onRangeChangeAction?: (startIndex: number, endIndex: number) => void;
+  onSelectApplicationAction: (application: ApplicationListItem) => void;
+  onTabChangeAction: (tab: TabValue) => void;
   ref?: React.Ref<ApplicationTabsHandle>;
+  tab: TabValue;
 };
 
 export function ApplicationTabs({
   applications,
   className,
   isFetchingNextPage,
-  onNearEnd,
-  onRangeChange,
-  onSelectApplication,
+  onNearEndAction,
+  onRangeChangeAction,
+  onSelectApplicationAction,
+  onTabChangeAction,
   ref,
+  tab,
 }: ApplicationTabsProps) {
   const posthog = usePostHog();
 
@@ -62,26 +70,30 @@ export function ApplicationTabs({
   return (
     <Tabs
       className={cn("flex flex-col", className ?? "h-full")}
-      defaultValue="all"
       onValueChange={(value) => {
         posthog.capture(POSTHOG_EVENTS.APPLICATIONS_TAB_CHANGED, {
           tab: value,
         });
         // 탭 전환 시 GoToTopFAB 상태를 즉시 초기화합니다.
-        // 새 탭의 VirtualList가 마운트되면 onRangeChange(0, N)이 다시 호출됩니다.
-        onRangeChange?.(0, 0);
+        // 새 탭의 VirtualList가 마운트되면 onRangeChangeAction(0, N)이 다시 호출됩니다.
+        onRangeChangeAction?.(0, 0);
+        onTabChangeAction(value as TabValue);
       }}
+      value={tab}
     >
-      <div className="px-5 py-4">
-        <Tabs.List className="flex h-11 w-full items-center gap-1 rounded-2xl bg-muted/50 p-1 shadow-inner">
+      <div className="border-b border-border px-5">
+        <Tabs.List className="flex h-auto items-end gap-5 rounded-none bg-transparent p-0">
           <Tabs.Trigger className={TAB_TRIGGER_CLASS} value="all">
             전체
+            <span className={BADGE_CLASS}>{applications.length}</span>
           </Tabs.Trigger>
           <Tabs.Trigger className={TAB_TRIGGER_CLASS} value="active">
             진행중
+            <span className={BADGE_CLASS}>{inProgressApplications.length}</span>
           </Tabs.Trigger>
           <Tabs.Trigger className={TAB_TRIGGER_CLASS} value="done">
             완료
+            <span className={BADGE_CLASS}>{doneApplications.length}</span>
           </Tabs.Trigger>
         </Tabs.List>
       </div>
@@ -91,9 +103,9 @@ export function ApplicationTabs({
           applications={applications}
           emptyMessage="아직 지원한 곳이 없습니다"
           isFetchingNextPage={isFetchingNextPage}
-          onNearEnd={onNearEnd}
-          onRangeChange={onRangeChange}
-          onSelectApplication={onSelectApplication}
+          onNearEnd={onNearEndAction}
+          onRangeChange={onRangeChangeAction}
+          onSelectApplication={onSelectApplicationAction}
           ref={listRef}
         />
       </Tabs.Content>
@@ -102,9 +114,9 @@ export function ApplicationTabs({
           applications={inProgressApplications}
           emptyMessage="진행 중인 지원이 없습니다"
           isFetchingNextPage={isFetchingNextPage}
-          onNearEnd={onNearEnd}
-          onRangeChange={onRangeChange}
-          onSelectApplication={onSelectApplication}
+          onNearEnd={onNearEndAction}
+          onRangeChange={onRangeChangeAction}
+          onSelectApplication={onSelectApplicationAction}
           ref={listRef}
         />
       </Tabs.Content>
@@ -113,9 +125,9 @@ export function ApplicationTabs({
           applications={doneApplications}
           emptyMessage="완료된 지원이 없습니다"
           isFetchingNextPage={isFetchingNextPage}
-          onNearEnd={onNearEnd}
-          onRangeChange={onRangeChange}
-          onSelectApplication={onSelectApplication}
+          onNearEnd={onNearEndAction}
+          onRangeChange={onRangeChangeAction}
+          onSelectApplication={onSelectApplicationAction}
           ref={listRef}
         />
       </Tabs.Content>

--- a/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
@@ -8,26 +8,35 @@ import {
   useSuspenseInfiniteQuery,
 } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 
 import type { GetApplicationsPage } from "@/lib/types/application";
 import type { JobStatus } from "@/lib/types/job";
 
 import { getApplications } from "@/lib/actions";
 
+import type { PeriodPreset, SortValue, TabValue } from "../constants";
 import type { ApplicationListItem } from "../types";
 import type { ApplicationTabsHandle } from "./ApplicationTabs";
 
 import {
-  APPLICATIONS_QUERY_KEY,
+  buildApplicationsQueryKey,
   getApplicationsNextPageParam,
+  getPeriodDateRange,
   PAGE_SIZE,
+  parsePeriodParam,
+  parseSortParam,
+  parseTabParam,
+  PERIOD_PARAM,
+  PREVIEW_PARAM,
+  SEARCH_PARAM,
+  SORT_PARAM,
+  TAB_PARAM,
 } from "../constants";
 import { GoToTopFAB } from "../go-to-top";
+import { ApplicationFilters } from "./ApplicationFilters";
 import { ApplicationPreviewSheet } from "./ApplicationPreviewSheet";
 import { ApplicationTabs } from "./ApplicationTabs";
-
-const PREVIEW_PARAM = "preview";
 
 export function ApplicationsPanel() {
   const router = useRouter();
@@ -38,6 +47,14 @@ export function ApplicationsPanel() {
   const tabsRef = useRef<ApplicationTabsHandle>(null);
   const [isListScrolled, setIsListScrolled] = useState(false);
 
+  const search = searchParams.get(SEARCH_PARAM) ?? "";
+  const period = parsePeriodParam(searchParams.get(PERIOD_PARAM));
+  const sort = parseSortParam(searchParams.get(SORT_PARAM));
+  const tab = parseTabParam(searchParams.get(TAB_PARAM));
+
+  const queryKey = buildApplicationsQueryKey({ period, search, sort });
+  const dateRange = useMemo(() => getPeriodDateRange(period), [period]);
+
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useSuspenseInfiniteQuery({
       getNextPageParam: getApplicationsNextPageParam,
@@ -46,13 +63,17 @@ export function ApplicationsPanel() {
         const result = await getApplications({
           limit: PAGE_SIZE,
           offset: pageParam,
+          periodEnd: dateRange?.end,
+          periodStart: dateRange?.start,
+          search: search || undefined,
+          sort,
         });
         if (!result.ok) {
           throw new Error(result.reason);
         }
         return result.data;
       },
-      queryKey: APPLICATIONS_QUERY_KEY,
+      queryKey,
     });
 
   const applications: ApplicationListItem[] = data.pages.flatMap(
@@ -61,23 +82,59 @@ export function ApplicationsPanel() {
 
   const selectedApplicationId = searchParams.get(PREVIEW_PARAM);
   const isPreviewOpen = selectedApplicationId !== null;
-
   const selectedApplication =
     applications.find((a) => a.id === selectedApplicationId) ?? null;
 
-  const handleSelectApplication = (application: ApplicationListItem) => {
+  const updateParams = (updates: Record<string, string>) => {
+    const params = new URLSearchParams(searchParams.toString());
+    for (const [key, value] of Object.entries(updates)) {
+      if (value) {
+        params.set(key, value);
+      } else {
+        params.delete(key);
+      }
+    }
+    const query = params.toString();
     router.replace(
-      `${pathname}?${PREVIEW_PARAM}=${application.id}` as unknown as Route,
+      `${pathname}${query ? `?${query}` : ""}` as unknown as Route,
     );
   };
 
+  const handleSearchSubmit = (nextSearch: string) => {
+    updateParams({ [PREVIEW_PARAM]: "", [SEARCH_PARAM]: nextSearch });
+  };
+
+  const handlePeriodChange = (nextPeriod: PeriodPreset) => {
+    updateParams({
+      [PERIOD_PARAM]: nextPeriod === "all" ? "" : nextPeriod,
+      [PREVIEW_PARAM]: "",
+    });
+  };
+
+  const handleSortChange = (nextSort: SortValue) => {
+    updateParams({
+      [SORT_PARAM]: nextSort === "applied_at_desc" ? "" : nextSort,
+    });
+  };
+
+  const handleTabChange = (nextTab: TabValue) => {
+    updateParams({
+      [PREVIEW_PARAM]: "",
+      [TAB_PARAM]: nextTab === "all" ? "" : nextTab,
+    });
+  };
+
+  const handleSelectApplication = (application: ApplicationListItem) => {
+    updateParams({ [PREVIEW_PARAM]: application.id });
+  };
+
   const handleClosePreview = () => {
-    router.replace(pathname as unknown as Route);
+    updateParams({ [PREVIEW_PARAM]: "" });
   };
 
   const handleStatusChange = (applicationId: string, nextStatus: JobStatus) => {
     queryClient.setQueryData<InfiniteData<GetApplicationsPage>>(
-      APPLICATIONS_QUERY_KEY,
+      queryKey,
       (old) => {
         if (!old) {
           return old;
@@ -105,14 +162,27 @@ export function ApplicationsPanel() {
 
   return (
     <div className="flex h-full flex-col">
+      <ApplicationFilters
+        onPeriodChangeAction={handlePeriodChange}
+        onSearchSubmitAction={handleSearchSubmit}
+        onSortChangeAction={handleSortChange}
+        period={period}
+        resultCount={applications.length}
+        search={search}
+        sort={sort}
+      />
       <ApplicationTabs
         applications={applications}
         className="min-h-0 flex-1"
         isFetchingNextPage={isFetchingNextPage}
-        onNearEnd={handleNearEnd}
-        onRangeChange={(startIndex) => setIsListScrolled(startIndex > 0)}
-        onSelectApplication={handleSelectApplication}
+        onNearEndAction={handleNearEnd}
+        onRangeChangeAction={(startIndex: number) =>
+          setIsListScrolled(startIndex > 0)
+        }
+        onSelectApplicationAction={handleSelectApplication}
+        onTabChangeAction={handleTabChange}
         ref={tabsRef}
+        tab={tab}
       />
       <ApplicationPreviewSheet
         application={selectedApplication}

--- a/app/(protected)/applications/_components/constants.ts
+++ b/app/(protected)/applications/_components/constants.ts
@@ -24,9 +24,120 @@ export const DONE_STATUSES: JobStatus[] = ["OFFERED", "REJECTED"];
 export const PAGE_SIZE = 30;
 
 /**
- * useInfiniteQuery / prefetchInfiniteQuery 공통 query key
+ * URL query string 파라미터 키
+ */
+export const SEARCH_PARAM = "q";
+export const PERIOD_PARAM = "period";
+export const TAB_PARAM = "tab";
+export const PREVIEW_PARAM = "preview";
+
+/**
+ * 기간 프리셋
+ */
+export const PERIOD_PRESETS = ["all", "this_month", "last_3_months"] as const;
+export type PeriodPreset = (typeof PERIOD_PRESETS)[number];
+
+export const PERIOD_PRESET_LABELS: Record<PeriodPreset, string> = {
+  all: "전체",
+  last_3_months: "최근 3개월",
+  this_month: "이번 달",
+};
+
+/**
+ * period preset을 날짜 범위(ISO string)로 변환합니다.
+ * "all"이면 null을 반환합니다.
+ */
+export function getPeriodDateRange(
+  period: PeriodPreset,
+): null | { end: string; start: string } {
+  const now = new Date();
+
+  if (period === "this_month") {
+    const start = new Date(now.getFullYear(), now.getMonth(), 1);
+    const end = new Date(
+      now.getFullYear(),
+      now.getMonth() + 1,
+      0,
+      23,
+      59,
+      59,
+      999,
+    );
+    return { end: end.toISOString(), start: start.toISOString() };
+  }
+
+  if (period === "last_3_months") {
+    const start = new Date(now.getFullYear(), now.getMonth() - 2, 1);
+    return { end: now.toISOString(), start: start.toISOString() };
+  }
+
+  return null;
+}
+
+/**
+ * 탭 값
+ */
+export const TAB_VALUES = ["all", "active", "done"] as const;
+export type TabValue = (typeof TAB_VALUES)[number];
+
+/**
+ * 정렬 값
+ */
+export const SORT_PARAM = "sort";
+export const SORT_VALUES = ["applied_at_desc", "applied_at_asc"] as const;
+export type SortValue = (typeof SORT_VALUES)[number];
+
+export const SORT_LABELS: Record<SortValue, string> = {
+  applied_at_asc: "오래된순",
+  applied_at_desc: "최신순",
+};
+
+/**
+ * URL 파라미터를 PeriodPreset으로 파싱합니다.
+ * 유효하지 않은 값은 "all"로 폴백합니다.
+ */
+export function parsePeriodParam(value: null | string): PeriodPreset {
+  return (PERIOD_PRESETS as readonly string[]).includes(value ?? "")
+    ? (value as PeriodPreset)
+    : "all";
+}
+
+/**
+ * URL 파라미터를 SortValue로 파싱합니다.
+ * 유효하지 않은 값은 "applied_at_desc"로 폴백합니다.
+ */
+export function parseSortParam(value: null | string): SortValue {
+  return (SORT_VALUES as readonly string[]).includes(value ?? "")
+    ? (value as SortValue)
+    : "applied_at_desc";
+}
+
+/**
+ * URL 파라미터를 TabValue로 파싱합니다.
+ * 유효하지 않은 값은 "all"로 폴백합니다.
+ */
+export function parseTabParam(value: null | string): TabValue {
+  return (TAB_VALUES as readonly string[]).includes(value ?? "")
+    ? (value as TabValue)
+    : "all";
+}
+
+/**
+ * useInfiniteQuery / prefetchInfiniteQuery 공통 query key 베이스
  */
 export const APPLICATIONS_QUERY_KEY = ["applications"] as const;
+
+/**
+ * 필터가 포함된 query key를 생성합니다.
+ * Panel과 View에서 동일한 key를 사용해 HydrationBoundary가 올바르게 작동합니다.
+ */
+export function buildApplicationsQueryKey(params: {
+  period: PeriodPreset;
+  search: string;
+  sort: SortValue;
+}) {
+  return [...APPLICATIONS_QUERY_KEY, params] as const;
+}
 
 /**
  * useInfiniteQuery / prefetchInfiniteQuery 공통 getNextPageParam.

--- a/app/(protected)/applications/page.tsx
+++ b/app/(protected)/applications/page.tsx
@@ -1,5 +1,10 @@
 import { ApplicationsView } from "./_components/ApplicationsView";
 
-export default function ApplicationsPage() {
-  return <ApplicationsView />;
+export default async function ApplicationsPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const resolvedParams = await searchParams;
+  return <ApplicationsView searchParams={resolvedParams} />;
 }

--- a/lib/actions/getApplications.ts
+++ b/lib/actions/getApplications.ts
@@ -16,9 +16,17 @@ const ERROR_MESSAGES = {
 export async function getApplications({
   limit,
   offset,
+  periodEnd,
+  periodStart,
+  search,
+  sort = "applied_at_desc",
 }: {
   limit: number;
   offset: number;
+  periodEnd?: string;
+  periodStart?: string;
+  search?: string;
+  sort?: "applied_at_asc" | "applied_at_desc";
 }): Promise<GetApplicationsResult> {
   const supabase = await createClient();
   const { data: authData, error: authError } = await supabase.auth.getUser();
@@ -31,14 +39,14 @@ export async function getApplications({
     };
   }
 
-  const { data, error } = await supabase
+  let query = supabase
     .from("applications")
     .select(
       `
       id,
       applied_at,
       status,
-      jobs (
+      jobs!inner (
         company_name,
         position_title,
         platform
@@ -46,8 +54,20 @@ export async function getApplications({
     `,
     )
     .eq("user_id", authData.user.id)
-    .order("applied_at", { ascending: false })
+    .order("applied_at", { ascending: sort === "applied_at_asc" })
     .range(offset, offset + limit);
+
+  if (search) {
+    query = query.ilike("jobs.company_name", `%${search}%`);
+  }
+  if (periodStart) {
+    query = query.gte("applied_at", periodStart);
+  }
+  if (periodEnd) {
+    query = query.lte("applied_at", periodEnd);
+  }
+
+  const { data, error } = await query;
 
   if (error) {
     const code =

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,7 @@ import { withSentryConfig } from "@sentry/nextjs";
 
 const nextConfig: NextConfig = {
   /* config options here */
-  reactCompiler: false,
+  reactCompiler: true,
   turbopack: {
     rules: {
       "*.svg": {


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #239

## 📌 작업 내용

- SEARCH_PARAM, PERIOD_PARAM, SORT_PARAM, TAB_PARAM 상수 및 파서 함수 추가 (유효하지 않은 값은 기본값으로 폴백)
- buildApplicationsQueryKey로 필터 파라미터를 query key에 포함해 서버 프리페치(HydrationBoundary)와 클라이언트 쿼리 key 정합성 보장
- getPeriodDateRange로 기간 프리셋을 ISO 날짜 범위로 변환
- getApplications에 search(ilike), periodStart/End(gte/lte), sort 파라미터 추가
  - jobs → jobs!inner(INNER JOIN)으로 변경
- ApplicationFilters 컴포넌트 추가: 회사명 검색 폼, 기간 프리셋 버튼(aria-pressed)
  -  정렬 select, 필터 적용 시 결과 수 live region
- ApplicationsPanel에 URL 파라미터 읽기, updateParams 헬퍼, 필터 핸들러 통합
- ApplicationsView(서버 컴포넌트)에서 searchParams를 받아 prefetchInfiniteQuery에 필터 전달
- ApplicationTabs 탭을 비제어 → 제어(value + onTabChangeAction)로 변경, 탭 UI 밑줄 스타일로 교체 및 항목 수 배지 추가
- onSelect / onNearEnd / onRangeChange 등 콜백 프롭을 *Action 접미사로 통일


