### PR TITLE
feat: 반응형 네비게이션 추가(#241)

### DIFF
--- a/app/(protected)/_components/BottomTabBar.tsx
+++ b/app/(protected)/_components/BottomTabBar.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { cn } from "@/lib/utils/cn";
+
+import { isNavItemActive, NAV_ITEMS } from "./nav-items";
+
+export function BottomTabBar() {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      aria-label="주 내비게이션"
+      className="fixed right-0 bottom-0 left-0 z-10 flex border-t border-border bg-background/80 backdrop-blur-sm md:hidden"
+    >
+      {NAV_ITEMS.map(({ href, icon: Icon, label }) => {
+        const isActive = isNavItemActive(pathname, href);
+        return (
+          <Link
+            aria-current={isActive ? "page" : undefined}
+            className={cn(
+              "flex flex-1 flex-col items-center gap-1 py-3 text-xs font-medium transition-colors",
+              isActive
+                ? "text-primary"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+            href={href}
+            key={href}
+          >
+            <Icon aria-hidden="true" className="size-5" />
+            {label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/app/(protected)/_components/Header.tsx
+++ b/app/(protected)/_components/Header.tsx
@@ -2,7 +2,7 @@
 
 import { LogOutIcon } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -11,9 +11,13 @@ import { Button } from "@/components/ui/button/Button";
 import { Tooltip } from "@/components/ui/tooltip/Tooltip";
 import { POSTHOG_EVENTS } from "@/lib/posthog/events";
 import { createClient } from "@/lib/supabase/client";
+import { cn } from "@/lib/utils/cn";
+
+import { isNavItemActive, NAV_ITEMS } from "./nav-items";
 
 export function Header() {
   const router = useRouter();
+  const pathname = usePathname();
   const posthog = usePostHog();
   const supabase = createClient();
   const [isLoggingOut, setIsLoggingOut] = useState(false);
@@ -42,13 +46,38 @@ export function Header() {
 
   return (
     <header className="sticky top-0 z-10 flex items-center justify-between border-b border-border bg-background/80 px-6 py-3 backdrop-blur-sm">
-      <Button
-        asChild
-        className="text-xl font-black tracking-tighter text-primary hover:bg-transparent"
-        variant="ghost"
-      >
-        <Link href="/dashboard">201</Link>
-      </Button>
+      <div className="flex items-center gap-6">
+        <Button
+          asChild
+          className="text-xl font-black tracking-tighter text-primary hover:bg-transparent"
+          variant="ghost"
+        >
+          <Link href="/dashboard">201</Link>
+        </Button>
+        <nav aria-label="주 내비게이션" className="hidden md:flex">
+          <ul className="flex items-center gap-1">
+            {NAV_ITEMS.map(({ href, label }) => {
+              const isActive = isNavItemActive(pathname, href);
+              return (
+                <li key={href}>
+                  <Button
+                    asChild
+                    className={cn(
+                      "text-sm font-medium",
+                      isActive
+                        ? "text-primary"
+                        : "text-muted-foreground hover:text-foreground",
+                    )}
+                    variant="ghost"
+                  >
+                    <Link href={href}>{label}</Link>
+                  </Button>
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
+      </div>
       <Tooltip label={isLoggingOut ? "로그아웃 중..." : "로그아웃"}>
         <Button
           aria-label={isLoggingOut ? "로그아웃 중..." : "로그아웃"}

--- a/app/(protected)/_components/nav-items.ts
+++ b/app/(protected)/_components/nav-items.ts
@@ -1,0 +1,10 @@
+import { LayoutDashboardIcon, UsersIcon } from "lucide-react";
+
+export const NAV_ITEMS = [
+  { href: "/dashboard", icon: LayoutDashboardIcon, label: "대시보드" },
+  { href: "/applications", icon: UsersIcon, label: "지원 목록" },
+] as const;
+
+export function isNavItemActive(pathname: string, href: string): boolean {
+  return pathname === href || pathname.startsWith(href + "/");
+}

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -1,5 +1,6 @@
 export const dynamic = "force-dynamic";
 
+import { BottomTabBar } from "./_components/BottomTabBar";
 import { Header } from "./_components/Header";
 
 export default function ProtectedLayout({
@@ -10,7 +11,8 @@ export default function ProtectedLayout({
   return (
     <>
       <Header />
-      {children}
+      <main className="pb-16 md:pb-0">{children}</main>
+      <BottomTabBar />
     </>
   );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2023",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #241

## 📌 작업 내용

- Header에 md 이상에서 표시되는 nav 링크 추가
- 모바일 전용 BottomTabBar 컴포넌트 추가 (fixed bottom)
- NAV_ITEMS와 isNavItemActive를 nav-items.ts로 분리해 단일 소스 유지
- layout.tsx에서 children을 main으로 감싸 BottomTabBar 가림 방지 (pb-16 md:pb-0)
- 프로젝트 target을 ES2017에서 ES2023으로 수정


