### PR TITLE
fix: iOS Safari에서 스크롤 잠금이 동작하지 않는 문제 수정(#243)

### DIFF
--- a/hooks/__tests__/useScrollLock.test.ts
+++ b/hooks/__tests__/useScrollLock.test.ts
@@ -1,13 +1,21 @@
 import { cleanup, renderHook } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useScrollLock } from "../useScrollLock";
 
+beforeEach(() => {
+  vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+  Object.defineProperty(window, "scrollY", { configurable: true, value: 0 });
+});
+
 afterEach(() => {
   cleanup();
-  document.documentElement.style.scrollbarGutter = "";
-  document.body.style.overflow = "";
+  vi.restoreAllMocks();
+  document.body.style.position = "";
+  document.body.style.top = "";
+  document.body.style.width = "";
   document.body.style.overscrollBehavior = "";
+  document.body.style.paddingRight = "";
 });
 
 describe("useScrollLock", () => {
@@ -15,17 +23,16 @@ describe("useScrollLock", () => {
     it("스타일을 변경하지 않는다", () => {
       renderHook(() => useScrollLock(false));
 
-      expect(document.documentElement.style.scrollbarGutter).toBe("");
-      expect(document.body.style.overflow).toBe("");
+      expect(document.body.style.position).toBe("");
       expect(document.body.style.overscrollBehavior).toBe("");
     });
   });
 
   describe("isActive: true", () => {
-    it("overflow를 hidden으로 설정한다", () => {
+    it("position을 fixed로 설정한다", () => {
       renderHook(() => useScrollLock(true));
 
-      expect(document.body.style.overflow).toBe("hidden");
+      expect(document.body.style.position).toBe("fixed");
     });
 
     it("overscrollBehavior를 none으로 설정한다", () => {
@@ -34,10 +41,21 @@ describe("useScrollLock", () => {
       expect(document.body.style.overscrollBehavior).toBe("none");
     });
 
-    it("scrollbarGutter를 stable로 설정한다", () => {
+    it("width를 100%로 설정한다", () => {
       renderHook(() => useScrollLock(true));
 
-      expect(document.documentElement.style.scrollbarGutter).toBe("stable");
+      expect(document.body.style.width).toBe("100%");
+    });
+
+    it("현재 스크롤 위치를 top에 반영한다", () => {
+      Object.defineProperty(window, "scrollY", {
+        configurable: true,
+        value: 300,
+      });
+
+      renderHook(() => useScrollLock(true));
+
+      expect(document.body.style.top).toBe("-300px");
     });
   });
 
@@ -47,9 +65,23 @@ describe("useScrollLock", () => {
 
       unmount();
 
-      expect(document.documentElement.style.scrollbarGutter).toBe("");
-      expect(document.body.style.overflow).toBe("");
+      expect(document.body.style.position).toBe("");
+      expect(document.body.style.top).toBe("");
+      expect(document.body.style.width).toBe("");
       expect(document.body.style.overscrollBehavior).toBe("");
+    });
+
+    it("isActive: true 상태에서 언마운트하면 스크롤 위치를 복원한다", () => {
+      Object.defineProperty(window, "scrollY", {
+        configurable: true,
+        value: 200,
+      });
+
+      const { unmount } = renderHook(() => useScrollLock(true));
+
+      unmount();
+
+      expect(window.scrollTo).toHaveBeenCalledWith(0, 200);
     });
 
     it("isActive: false 상태에서 언마운트해도 스타일은 그대로다", () => {
@@ -57,8 +89,7 @@ describe("useScrollLock", () => {
 
       unmount();
 
-      expect(document.documentElement.style.scrollbarGutter).toBe("");
-      expect(document.body.style.overflow).toBe("");
+      expect(document.body.style.position).toBe("");
       expect(document.body.style.overscrollBehavior).toBe("");
     });
   });
@@ -70,12 +101,11 @@ describe("useScrollLock", () => {
         { initialProps: { isActive: false } },
       );
 
-      expect(document.body.style.overflow).toBe("");
+      expect(document.body.style.position).toBe("");
 
       rerender({ isActive: true });
 
-      expect(document.documentElement.style.scrollbarGutter).toBe("stable");
-      expect(document.body.style.overflow).toBe("hidden");
+      expect(document.body.style.position).toBe("fixed");
       expect(document.body.style.overscrollBehavior).toBe("none");
     });
 
@@ -85,12 +115,11 @@ describe("useScrollLock", () => {
         { initialProps: { isActive: true } },
       );
 
-      expect(document.body.style.overflow).toBe("hidden");
+      expect(document.body.style.position).toBe("fixed");
 
       rerender({ isActive: false });
 
-      expect(document.documentElement.style.scrollbarGutter).toBe("");
-      expect(document.body.style.overflow).toBe("");
+      expect(document.body.style.position).toBe("");
       expect(document.body.style.overscrollBehavior).toBe("");
     });
   });
@@ -100,7 +129,7 @@ describe("useScrollLock", () => {
       renderHook(() => useScrollLock(true));
       renderHook(() => useScrollLock(true));
 
-      expect(document.body.style.overflow).toBe("hidden");
+      expect(document.body.style.position).toBe("fixed");
     });
 
     it("첫 번째 소유자가 해제되어도 두 번째 소유자가 있으면 스타일이 유지된다", () => {
@@ -109,8 +138,7 @@ describe("useScrollLock", () => {
 
       unmountFirst();
 
-      expect(document.documentElement.style.scrollbarGutter).toBe("stable");
-      expect(document.body.style.overflow).toBe("hidden");
+      expect(document.body.style.position).toBe("fixed");
       expect(document.body.style.overscrollBehavior).toBe("none");
     });
 
@@ -121,9 +149,23 @@ describe("useScrollLock", () => {
       unmountFirst();
       unmountSecond();
 
-      expect(document.documentElement.style.scrollbarGutter).toBe("");
-      expect(document.body.style.overflow).toBe("");
+      expect(document.body.style.position).toBe("");
       expect(document.body.style.overscrollBehavior).toBe("");
+    });
+
+    it("모든 소유자가 해제되면 스크롤 위치를 복원한다", () => {
+      Object.defineProperty(window, "scrollY", {
+        configurable: true,
+        value: 100,
+      });
+
+      const { unmount: unmountFirst } = renderHook(() => useScrollLock(true));
+      const { unmount: unmountSecond } = renderHook(() => useScrollLock(true));
+
+      unmountFirst();
+      unmountSecond();
+
+      expect(window.scrollTo).toHaveBeenCalledWith(0, 100);
     });
   });
 });

--- a/hooks/useScrollLock.ts
+++ b/hooks/useScrollLock.ts
@@ -5,6 +5,9 @@ import { useEffect } from "react";
 // 여러 컴포넌트가 동시에 scroll lock을 요청할 때 올바르게 관리하기 위한 Set
 const scrollLockOwners = new Set<object>();
 
+// 첫 번째 lock 획득 시 저장, 마지막 lock 해제 시 복원
+let lockState: null | { paddingRight: string; scrollY: number } = null;
+
 export const useScrollLock = (isActive: boolean) => {
   useEffect(() => {
     if (!isActive) {
@@ -15,18 +18,35 @@ export const useScrollLock = (isActive: boolean) => {
     scrollLockOwners.add(token);
 
     if (scrollLockOwners.size === 1) {
-      document.documentElement.style.scrollbarGutter = "stable";
-      document.body.style.overflow = "hidden";
+      // iOS Safari는 overflow: hidden을 무시하므로 position: fixed 방식 사용
+      const scrollY = window.scrollY;
+      // 스크롤바가 사라지면서 생기는 레이아웃 시프트를 패딩으로 보정
+      const scrollbarWidth =
+        window.innerWidth - document.documentElement.clientWidth;
+
+      lockState = { paddingRight: document.body.style.paddingRight, scrollY };
+
+      document.body.style.position = "fixed";
+      document.body.style.top = `-${scrollY}px`;
+      document.body.style.width = "100%";
       document.body.style.overscrollBehavior = "none";
+      document.body.style.paddingRight = `${scrollbarWidth}px`;
     }
 
     return () => {
       scrollLockOwners.delete(token);
 
-      if (scrollLockOwners.size === 0) {
-        document.documentElement.style.scrollbarGutter = "";
-        document.body.style.overflow = "";
+      if (scrollLockOwners.size === 0 && lockState !== null) {
+        const { paddingRight, scrollY } = lockState;
+        lockState = null;
+
+        document.body.style.position = "";
+        document.body.style.top = "";
+        document.body.style.width = "";
         document.body.style.overscrollBehavior = "";
+        document.body.style.paddingRight = paddingRight;
+
+        window.scrollTo(0, scrollY);
       }
     };
   }, [isActive]);


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #243

## 📌 작업 내용

- overflow: hidden → position: fixed + top: -scrollY 방식으로 교체
- scrollbarGutter: stable 제거, 스크롤바 너비(innerWidth - clientWidth)를 paddingRight로 적용하여 레이아웃 시프트 방지
- 해제 시 저장해둔 scrollY로 window.scrollTo 호출하여 스크롤 위치 복원
- savedPaddingRight 단독 변수를 lockState 객체로 통합하여 scrollY와 paddingRight를 함께 관리

