### PR TITLE
fix: 지원 상세 페이지가 제대로 렌더링되지 않는 버그 수정(#260)

### DIFF
--- a/app/_components/PublicHeader.tsx
+++ b/app/_components/PublicHeader.tsx
@@ -3,41 +3,39 @@ import Link from "next/link";
 
 import GitHubIcon from "@/assets/github.svg";
 import { Button } from "@/components/ui/button/Button";
-import { Tooltip, TooltipProvider } from "@/components/ui/tooltip/Tooltip";
+import { Tooltip } from "@/components/ui/tooltip/Tooltip";
 
 export function PublicHeader() {
   return (
-    <TooltipProvider>
-      <header className="sticky top-0 z-10 flex items-center justify-between border-b border-border bg-background/80 px-6 py-3 backdrop-blur-sm">
-        <Button
-          asChild
-          className="text-lg font-bold hover:bg-transparent"
-          variant="ghost"
-        >
-          <Link href="/">201</Link>
-        </Button>
-        <div className="flex items-center gap-1">
-          <Tooltip label="GitHub">
-            <Button asChild size="icon" variant="ghost">
-              <a
-                aria-label="GitHub 저장소"
-                href="https://github.com/quartzs2/201-escape"
-                rel="noreferrer"
-                target="_blank"
-              >
-                <GitHubIcon className="h-4 w-4" />
-              </a>
-            </Button>
-          </Tooltip>
-          <Tooltip label="시작하기">
-            <Button asChild size="icon" variant="ghost">
-              <Link aria-label="시작하기" href="/login">
-                <LogIn className="h-4 w-4" />
-              </Link>
-            </Button>
-          </Tooltip>
-        </div>
-      </header>
-    </TooltipProvider>
+    <header className="sticky top-0 z-10 flex items-center justify-between border-b border-border bg-background/80 px-6 py-3 backdrop-blur-sm">
+      <Button
+        asChild
+        className="text-lg font-bold hover:bg-transparent"
+        variant="ghost"
+      >
+        <Link href="/">201</Link>
+      </Button>
+      <div className="flex items-center gap-1">
+        <Tooltip label="GitHub">
+          <Button asChild size="icon" variant="ghost">
+            <a
+              aria-label="GitHub 저장소"
+              href="https://github.com/quartzs2/201-escape"
+              rel="noreferrer"
+              target="_blank"
+            >
+              <GitHubIcon className="h-4 w-4" />
+            </a>
+          </Button>
+        </Tooltip>
+        <Tooltip label="시작하기">
+          <Button asChild size="icon" variant="ghost">
+            <Link aria-label="시작하기" href="/login">
+              <LogIn className="h-4 w-4" />
+            </Link>
+          </Button>
+        </Tooltip>
+      </div>
+    </header>
   );
 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,3 +1,5 @@
+import { TooltipProvider } from "@/components/ui/tooltip/Tooltip";
+
 export function Providers({ children }: { children: React.ReactNode }) {
-  return children;
+  return <TooltipProvider>{children}</TooltipProvider>;
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #260

## 📌 작업 내용

- 루트 providers에 TooltipProvider 추가
- PublicHeader의 중복 provider 제거


