### PR TITLE
feat: 지원 상세 페이지 정보 위계와 작업 레이아웃 개선(#263)

### DIFF
--- a/app/(protected)/applications/[applicationId]/_components/ApplicationDetailHero.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/ApplicationDetailHero.tsx
@@ -1,0 +1,179 @@
+import { ExternalLinkIcon } from "lucide-react";
+
+import type {
+  ApplicationDetail,
+  DeleteApplicationInput,
+  DeleteApplicationResult,
+  UpdateApplicationStatusInput,
+  UpdateApplicationStatusResult,
+} from "@/lib/types/application";
+
+import { ApplicationStatusSelector } from "@/app/(protected)/_components/ApplicationStatusSelector";
+import { Button } from "@/components/ui/button/Button";
+import { APPLICATION_STATUS_META } from "@/lib/constants/application-status";
+import { PLATFORM_LABEL } from "@/lib/constants/job-platform";
+import { cn, formatAppliedAt } from "@/lib/utils";
+
+import { BackLink } from "./BackLink";
+import { DeleteApplicationButton } from "./DeleteApplicationButton";
+
+type ApplicationDetailHeroProps = {
+  deleteAction: DeleteApplicationAction;
+  detail: ApplicationDetail;
+  updateStatusAction: UpdateStatusAction;
+};
+
+type DeleteApplicationAction = (
+  input: DeleteApplicationInput,
+) => Promise<DeleteApplicationResult>;
+
+type SummaryItem = {
+  label: string;
+  value: string;
+};
+
+type UpdateStatusAction = (
+  input: UpdateApplicationStatusInput,
+) => Promise<UpdateApplicationStatusResult>;
+
+const MANUAL_PLATFORM_LABEL = "직접 입력";
+
+export function ApplicationDetailHero({
+  deleteAction,
+  detail,
+  updateStatusAction,
+}: ApplicationDetailHeroProps) {
+  const statusMeta = APPLICATION_STATUS_META[detail.status];
+  const hasOriginUrl =
+    detail.originUrl !== null &&
+    detail.originUrl.trim() !== "" &&
+    !detail.originUrl.startsWith("manual:");
+  const appliedAtLabel = detail.status === "SAVED" ? "저장일" : "지원일";
+  const summaryItems: SummaryItem[] = [
+    {
+      label: "플랫폼",
+      value:
+        detail.platform === "MANUAL"
+          ? MANUAL_PLATFORM_LABEL
+          : PLATFORM_LABEL[detail.platform],
+    },
+    {
+      label: appliedAtLabel,
+      value: formatAppliedAt(detail.appliedAt),
+    },
+    {
+      label: "현재 상태",
+      value: statusMeta.label,
+    },
+  ];
+
+  return (
+    <section className="relative overflow-hidden rounded-[32px] border border-border/60 bg-background shadow-[0_36px_120px_-64px_rgba(23,23,23,0.45)] motion-safe:animate-fade-in">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(64,81,59,0.14),transparent_36%),linear-gradient(180deg,rgba(245,245,245,0.95),rgba(255,255,255,0.82)_42%,rgba(255,255,255,1))]" />
+      <div className="relative grid gap-8 p-5 sm:p-8 lg:grid-cols-[minmax(0,1fr)_minmax(300px,360px)] lg:gap-10">
+        <div className="space-y-8 motion-safe:animate-fade-up">
+          <div className="flex items-center justify-between gap-3">
+            <BackLink />
+            <DeleteApplicationButton
+              applicationId={detail.id}
+              companyName={detail.companyName}
+              deleteAction={deleteAction}
+              positionTitle={detail.positionTitle}
+            />
+          </div>
+
+          <div className="space-y-5">
+            <div className="flex flex-wrap items-center gap-2">
+              <span
+                className={cn(
+                  "inline-flex rounded-full px-3 py-1 text-xs font-semibold",
+                  statusMeta.badgeClassName,
+                )}
+              >
+                {statusMeta.label}
+              </span>
+              <span className="text-xs font-medium text-muted-foreground">
+                {appliedAtLabel} {formatAppliedAt(detail.appliedAt)}
+              </span>
+            </div>
+
+            <div className="space-y-3">
+              <p className="text-sm font-semibold tracking-[0.18em] text-primary/75 uppercase">
+                {detail.companyName}
+              </p>
+              <h1 className="max-w-3xl text-3xl font-semibold tracking-tight text-foreground sm:text-4xl lg:text-5xl lg:leading-[1.05]">
+                {detail.positionTitle}
+              </h1>
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              {hasOriginUrl ? (
+                <Button
+                  asChild
+                  className="h-10 rounded-full border-border/70 bg-background/80 px-4 text-sm font-semibold shadow-none"
+                  variant="outline"
+                >
+                  <a
+                    aria-label="원문 공고 보러가기"
+                    href={detail.originUrl!}
+                    rel="noreferrer noopener"
+                    target="_blank"
+                  >
+                    원문 공고 보기
+                    <ExternalLinkIcon aria-hidden="true" className="size-4" />
+                  </a>
+                </Button>
+              ) : null}
+            </div>
+          </div>
+
+          <dl className="grid gap-3 sm:grid-cols-3">
+            {summaryItems.map((item) => (
+              <div
+                className="rounded-2xl border border-border/50 bg-background/70 px-4 py-4 backdrop-blur-sm"
+                key={item.label}
+              >
+                <dt className="text-xs font-semibold tracking-[0.12em] text-muted-foreground uppercase">
+                  {item.label}
+                </dt>
+                <dd className="mt-2 text-sm font-semibold tracking-tight text-foreground sm:text-[15px]">
+                  {item.value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+
+        <div
+          className="motion-safe:animate-fade-up"
+          style={{ animationDelay: "120ms" }}
+        >
+          <div className="rounded-[28px] border border-border/60 bg-background/90 p-5 shadow-[0_24px_60px_-40px_rgba(23,23,23,0.28)] backdrop-blur-sm sm:p-6">
+            <div className="space-y-2">
+              <p className="text-xs font-semibold tracking-[0.16em] text-muted-foreground uppercase">
+                진행 관리
+              </p>
+              <p className="text-2xl font-semibold tracking-tight text-foreground">
+                {statusMeta.label}
+              </p>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                지원 단계 변경은 즉시 저장됩니다.
+              </p>
+            </div>
+
+            <div className="mt-6">
+              <ApplicationStatusSelector
+                applicationId={detail.id}
+                ariaLabel="지원 상태 변경"
+                className="space-y-3"
+                label="상태 변경"
+                status={detail.status}
+                updateStatusAction={updateStatusAction}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/(protected)/applications/[applicationId]/_components/DeleteApplicationButton.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/DeleteApplicationButton.tsx
@@ -53,7 +53,7 @@ export function DeleteApplicationButton({
     },
     onSuccess: () => {
       posthog.capture(POSTHOG_EVENTS.APPLICATION_DELETED);
-      router.push("/dashboard");
+      router.replace("/applications");
     },
   });
 

--- a/app/(protected)/applications/[applicationId]/_components/DetailSectionHeader.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/DetailSectionHeader.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+
+type DetailSectionHeaderProps = {
+  action?: ReactNode;
+  description?: string;
+  headingId?: string;
+  icon: ReactNode;
+  title: string;
+};
+
+export function DetailSectionHeader({
+  action,
+  description,
+  headingId,
+  icon,
+  title,
+}: DetailSectionHeaderProps) {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div className="flex min-w-0 items-start gap-3">
+        <span className="flex size-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary ring-1 ring-primary/10">
+          {icon}
+        </span>
+        <div className="min-w-0 space-y-1">
+          <h2
+            className="text-base font-semibold tracking-tight text-foreground"
+            id={headingId}
+          >
+            {title}
+          </h2>
+          {description ? (
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              {description}
+            </p>
+          ) : null}
+        </div>
+      </div>
+      {action ? <div className="shrink-0">{action}</div> : null}
+    </div>
+  );
+}

--- a/app/(protected)/applications/[applicationId]/_components/DetailSectionPanel.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/DetailSectionPanel.tsx
@@ -1,0 +1,25 @@
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type DetailSectionPanelProps = ComponentPropsWithoutRef<"section"> & {
+  children: ReactNode;
+};
+
+export function DetailSectionPanel({
+  children,
+  className,
+  ...props
+}: DetailSectionPanelProps) {
+  return (
+    <section
+      className={cn(
+        "rounded-[28px] border border-border/60 bg-background/95 p-5 shadow-[0_24px_60px_-36px_rgba(23,23,23,0.28)] backdrop-blur-sm sm:p-6",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </section>
+  );
+}

--- a/app/(protected)/applications/[applicationId]/_components/InterviewSection.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/InterviewSection.tsx
@@ -9,6 +9,7 @@ import { INTERVIEW_TYPE_LABEL } from "@/lib/constants/interview-type";
 import { formatScheduledAt } from "@/lib/utils";
 
 import { DeleteInterviewButton } from "./DeleteInterviewButton";
+import { DetailSectionHeader } from "./DetailSectionHeader";
 import { InterviewFormSheet } from "./InterviewFormSheet";
 
 type InterviewListProps = {
@@ -31,24 +32,19 @@ export async function InterviewSection({
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2 text-foreground">
-          <span className="text-muted-foreground">
-            <CalendarIcon aria-hidden="true" className="size-5" />
-          </span>
-          <h2 className="text-sm font-bold tracking-tight uppercase">
-            면접 일정
-          </h2>
-        </div>
-        <div className="ml-auto">
+      <DetailSectionHeader
+        action={
           <InterviewFormSheet
             applicationId={applicationId}
             defaultRound={result.data.length + 1}
             mode="add"
             upsertAction={upsertInterview}
           />
-        </div>
-      </div>
+        }
+        description="다음 면접 일정을 추가하고 기존 일정을 수정합니다."
+        icon={<CalendarIcon aria-hidden="true" className="size-5" />}
+        title="면접 일정"
+      />
 
       <InterviewList applicationId={applicationId} interviews={result.data} />
     </div>
@@ -58,8 +54,8 @@ export async function InterviewSection({
 function InterviewList({ applicationId, interviews }: InterviewListProps) {
   if (interviews.length === 0) {
     return (
-      <div className="rounded-xl bg-muted/30 p-4">
-        <p className="text-[15px] text-muted-foreground/60 italic">
+      <div className="rounded-2xl border border-dashed border-border/80 bg-muted/10 p-5">
+        <p className="text-[15px] leading-relaxed text-muted-foreground">
           등록된 면접 일정이 없습니다.
         </p>
       </div>
@@ -67,18 +63,32 @@ function InterviewList({ applicationId, interviews }: InterviewListProps) {
   }
 
   return (
-    <ul className="grid gap-3">
+    <ul className="divide-y divide-border/60 overflow-hidden rounded-2xl border border-border/60 bg-muted/10">
       {interviews.map((interview) => (
         <li
-          className="flex flex-col gap-1.5 rounded-xl border border-border bg-muted/20 px-4 py-3 transition-colors hover:bg-muted/30"
+          className="flex flex-col gap-3 px-4 py-4 sm:px-5"
           key={interview.id}
         >
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <span className="flex items-center gap-1 text-sm font-bold text-foreground">
-                <span>{interview.round}차 —</span>
-                <span>{INTERVIEW_TYPE_LABEL[interview.interviewType]}</span>
-              </span>
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="inline-flex rounded-full bg-primary/10 px-2.5 py-1 text-xs font-semibold text-primary">
+                  {interview.round}차
+                </span>
+                <span className="text-sm font-semibold text-foreground">
+                  {INTERVIEW_TYPE_LABEL[interview.interviewType]}
+                </span>
+              </div>
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-foreground">
+                  {formatScheduledAt(interview.scheduledAt)}
+                </p>
+                {interview.location !== null ? (
+                  <p className="text-sm leading-relaxed text-muted-foreground">
+                    {interview.location}
+                  </p>
+                ) : null}
+              </div>
             </div>
             <div className="flex items-center gap-0.5">
               <InterviewFormSheet
@@ -94,16 +104,6 @@ function InterviewList({ applicationId, interviews }: InterviewListProps) {
                 round={interview.round}
               />
             </div>
-          </div>
-          <div className="space-y-0.5">
-            <p className="text-sm font-medium text-muted-foreground">
-              {formatScheduledAt(interview.scheduledAt)}
-            </p>
-            {interview.location !== null && (
-              <p className="text-xs text-muted-foreground/80">
-                {interview.location}
-              </p>
-            )}
           </div>
         </li>
       ))}

--- a/app/(protected)/applications/[applicationId]/_components/JobDescriptionEditor.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/JobDescriptionEditor.tsx
@@ -15,6 +15,8 @@ import { Button } from "@/components/ui";
 import { Tooltip } from "@/components/ui/tooltip/Tooltip";
 import { POSTHOG_EVENTS } from "@/lib/posthog/events";
 
+import { DetailSectionHeader } from "./DetailSectionHeader";
+
 type JobDescriptionEditorProps = {
   applicationId: string;
   description: null | string;
@@ -116,33 +118,28 @@ export function JobDescriptionEditor({
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2 text-foreground">
-          <span className="text-muted-foreground">
-            <FileTextIcon aria-hidden="true" className="size-5" />
-          </span>
-          <h2
-            className="text-sm font-bold tracking-tight uppercase"
-            id={`job-description-label-${applicationId}`}
-          >
-            공고 설명
-          </h2>
-        </div>
-        {!isEditing && (
-          <Tooltip label="편집" side="bottom">
-            <Button
-              aria-label="편집"
-              className="size-8 rounded-full"
-              disabled={mutation.isPending}
-              onClick={handleEditStart}
-              ref={editButtonRef}
-              variant="ghost"
-            >
-              <PencilIcon aria-hidden="true" className="size-4" />
-            </Button>
-          </Tooltip>
-        )}
-      </div>
+      <DetailSectionHeader
+        action={
+          !isEditing ? (
+            <Tooltip label="편집" side="bottom">
+              <Button
+                aria-label="편집"
+                className="size-9 rounded-full"
+                disabled={mutation.isPending}
+                onClick={handleEditStart}
+                ref={editButtonRef}
+                variant="ghost"
+              >
+                <PencilIcon aria-hidden="true" className="size-4" />
+              </Button>
+            </Tooltip>
+          ) : null
+        }
+        description="원문 공고 내용을 저장해 두고 이후에도 같은 기준으로 비교합니다."
+        headingId={`job-description-label-${applicationId}`}
+        icon={<FileTextIcon aria-hidden="true" className="size-5" />}
+        title="공고 설명"
+      />
 
       <div aria-atomic="true" aria-live="polite" className="min-h-0">
         {isEditing && errorMessage && (
@@ -156,7 +153,7 @@ export function JobDescriptionEditor({
         <div className="space-y-3">
           <textarea
             aria-labelledby={`job-description-label-${applicationId}`}
-            className="min-h-50 w-full resize-none rounded-xl border border-input bg-muted/50 px-4 py-3 text-sm leading-relaxed text-foreground transition-colors placeholder:text-muted-foreground focus:bg-background focus:ring-2 focus:ring-ring focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            className="min-h-56 w-full resize-none rounded-2xl border border-input bg-background px-4 py-3 text-sm leading-relaxed text-foreground transition-colors placeholder:text-muted-foreground focus:ring-2 focus:ring-ring focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
             disabled={mutation.isPending}
             onChange={(e) => setDraftText(e.target.value)}
             placeholder="공고 설명을 입력하세요"
@@ -182,10 +179,10 @@ export function JobDescriptionEditor({
           </div>
         </div>
       ) : (
-        <div className="rounded-xl bg-muted/30 p-4">
+        <div className="min-h-56 rounded-2xl border border-border/60 bg-muted/10 px-4 py-4 sm:px-5">
           <p className="text-[15px] leading-relaxed wrap-break-word whitespace-pre-wrap text-foreground/90">
             {currentDescription ?? (
-              <span className="text-muted-foreground/60 italic">
+              <span className="text-muted-foreground">
                 공고 설명이 없습니다
               </span>
             )}

--- a/app/(protected)/applications/[applicationId]/_components/MemoEditor.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/MemoEditor.tsx
@@ -15,6 +15,8 @@ import { Button } from "@/components/ui";
 import { Tooltip } from "@/components/ui/tooltip/Tooltip";
 import { POSTHOG_EVENTS } from "@/lib/posthog/events";
 
+import { DetailSectionHeader } from "./DetailSectionHeader";
+
 type MemoEditorProps = {
   applicationId: string;
   notes: null | string;
@@ -113,33 +115,28 @@ export function MemoEditor({
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2 text-foreground">
-          <span className="text-muted-foreground">
-            <NotebookPenIcon aria-hidden="true" className="size-5" />
-          </span>
-          <h2
-            className="text-sm font-bold tracking-tight uppercase"
-            id={`memo-label-${applicationId}`}
-          >
-            개인 메모
-          </h2>
-        </div>
-        {!isEditing && (
-          <Tooltip label="편집" side="bottom">
-            <Button
-              aria-label="편집"
-              className="size-8 rounded-full"
-              disabled={mutation.isPending}
-              onClick={handleEditStart}
-              ref={editButtonRef}
-              variant="ghost"
-            >
-              <PencilIcon aria-hidden="true" className="size-4" />
-            </Button>
-          </Tooltip>
-        )}
-      </div>
+      <DetailSectionHeader
+        action={
+          !isEditing ? (
+            <Tooltip label="편집" side="bottom">
+              <Button
+                aria-label="편집"
+                className="size-9 rounded-full"
+                disabled={mutation.isPending}
+                onClick={handleEditStart}
+                ref={editButtonRef}
+                variant="ghost"
+              >
+                <PencilIcon aria-hidden="true" className="size-4" />
+              </Button>
+            </Tooltip>
+          ) : null
+        }
+        description="다음 액션, 인상, 비교 포인트를 남겨 두는 작업 공간입니다."
+        headingId={`memo-label-${applicationId}`}
+        icon={<NotebookPenIcon aria-hidden="true" className="size-5" />}
+        title="개인 메모"
+      />
 
       <div aria-atomic="true" aria-live="polite" className="min-h-0">
         {isEditing && errorMessage && (
@@ -153,7 +150,7 @@ export function MemoEditor({
         <div className="space-y-3">
           <textarea
             aria-labelledby={`memo-label-${applicationId}`}
-            className="min-h-30 w-full resize-none rounded-xl border border-input bg-muted/50 px-4 py-3 text-sm leading-relaxed text-foreground transition-colors placeholder:text-muted-foreground focus:bg-background focus:ring-2 focus:ring-ring focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            className="min-h-40 w-full resize-none rounded-2xl border border-input bg-background px-4 py-3 text-sm leading-relaxed text-foreground transition-colors placeholder:text-muted-foreground focus:ring-2 focus:ring-ring focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
             disabled={mutation.isPending}
             onChange={(e) => setDraftText(e.target.value)}
             placeholder="메모를 입력하세요"
@@ -179,12 +176,10 @@ export function MemoEditor({
           </div>
         </div>
       ) : (
-        <div className="rounded-xl bg-muted/30 p-4">
+        <div className="min-h-40 rounded-2xl border border-border/60 bg-muted/10 px-4 py-4 sm:px-5">
           <p className="text-[15px] leading-relaxed wrap-break-word whitespace-pre-wrap text-foreground/90">
             {currentNotes ?? (
-              <span className="text-muted-foreground/60 italic">
-                메모가 없습니다
-              </span>
+              <span className="text-muted-foreground">메모가 없습니다</span>
             )}
           </p>
         </div>

--- a/app/(protected)/applications/[applicationId]/page.tsx
+++ b/app/(protected)/applications/[applicationId]/page.tsx
@@ -1,23 +1,15 @@
-import {
-  ExternalLinkIcon,
-  FileTextIcon,
-  ListChecksIcon,
-  LockKeyholeIcon,
-} from "lucide-react";
+import { FileTextIcon, LockKeyholeIcon } from "lucide-react";
 import { Suspense } from "react";
 
-import { ApplicationStatusSelector } from "@/app/(protected)/_components/ApplicationStatusSelector";
 import { Skeleton } from "@/components/ui";
-import { Button } from "@/components/ui/button/Button";
 import { deleteApplication, getApplicationDetail } from "@/lib/actions";
 import { updateApplicationNotes } from "@/lib/actions/updateApplicationNotes";
 import { updateApplicationStatus } from "@/lib/actions/updateApplicationStatus";
 import { updateJobDescription } from "@/lib/actions/updateJobDescription";
-import { PLATFORM_LABEL } from "@/lib/constants/job-platform";
-import { formatAppliedAt } from "@/lib/utils";
 
+import { ApplicationDetailHero } from "./_components/ApplicationDetailHero";
 import { BackLink } from "./_components/BackLink";
-import { DeleteApplicationButton } from "./_components/DeleteApplicationButton";
+import { DetailSectionPanel } from "./_components/DetailSectionPanel";
 import { ErrorState } from "./_components/ErrorState";
 import { InterviewSection } from "./_components/InterviewSection";
 import { JobDescriptionEditor } from "./_components/JobDescriptionEditor";
@@ -85,107 +77,52 @@ export default async function ApplicationDetailPage({
   }
 
   const detail = result.data;
-  const hasOriginUrl =
-    detail.originUrl !== null &&
-    detail.originUrl.trim() !== "" &&
-    !detail.originUrl.startsWith("manual:");
 
   return (
-    <main className="min-h-screen bg-muted/30 pb-20">
-      <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-8 sm:px-6 lg:px-8">
-        <div className="flex items-center justify-between">
-          <BackLink />
-          <DeleteApplicationButton
-            applicationId={detail.id}
-            companyName={detail.companyName}
-            deleteAction={deleteApplication}
-            positionTitle={detail.positionTitle}
-          />
-        </div>
+    <main className="min-h-screen bg-[linear-gradient(180deg,rgba(245,245,245,0.9)_0%,rgba(255,255,255,0.82)_18%,rgba(255,255,255,1)_40%)] pb-20">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
+        <ApplicationDetailHero
+          deleteAction={deleteApplication}
+          detail={detail}
+          updateStatusAction={updateApplicationStatus}
+        />
 
-        <section className="space-y-6">
-          <div className="space-y-1">
-            <div className="flex flex-wrap items-center gap-x-2 text-xs font-medium text-muted-foreground">
-              {detail.platform !== "MANUAL" && (
-                <>
-                  <span className="tracking-wider uppercase">
-                    {PLATFORM_LABEL[detail.platform]}
-                  </span>
-                  <span aria-hidden="true" className="opacity-40">
-                    /
-                  </span>
-                </>
-              )}
-              <span className="flex gap-1">
-                <span>{detail.status === "SAVED" ? "저장일" : "지원일"}</span>
-                <span>{formatAppliedAt(detail.appliedAt)}</span>
-              </span>
-            </div>
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(320px,0.82fr)]">
+          <div className="order-2 grid gap-6 lg:order-1">
+            <DetailSectionPanel
+              className="motion-safe:animate-fade-up"
+              style={{ animationDelay: "160ms" }}
+            >
+              <JobDescriptionEditor
+                applicationId={detail.id}
+                description={detail.description}
+                updateDescriptionAction={updateJobDescription}
+              />
+            </DetailSectionPanel>
 
-            <div className="flex items-start justify-between gap-4">
-              <div className="space-y-1.5">
-                <p className="text-lg font-medium text-muted-foreground">
-                  {detail.companyName}
-                </p>
-                <h1 className="text-3xl font-extrabold tracking-tight text-foreground sm:text-4xl">
-                  {detail.positionTitle}
-                </h1>
-              </div>
-              {hasOriginUrl && (
-                <Button
-                  asChild
-                  className="size-10 shrink-0 rounded-full border border-border text-muted-foreground hover:bg-muted hover:text-foreground"
-                  variant="ghost"
-                >
-                  <a
-                    aria-label="원문 공고 보러가기"
-                    href={detail.originUrl!}
-                    rel="noreferrer noopener"
-                    target="_blank"
-                  >
-                    <ExternalLinkIcon aria-hidden="true" className="size-5" />
-                  </a>
-                </Button>
-              )}
-            </div>
+            <DetailSectionPanel
+              className="motion-safe:animate-fade-up"
+              style={{ animationDelay: "220ms" }}
+            >
+              <MemoEditor
+                applicationId={detail.id}
+                notes={detail.notes}
+                updateNotesAction={updateApplicationNotes}
+              />
+            </DetailSectionPanel>
           </div>
 
-          <div className="rounded-2xl border border-border/50 bg-background p-5 shadow-sm">
-            <ApplicationStatusSelector
-              applicationId={detail.id}
-              ariaLabel="지원 상태 변경"
-              icon={<ListChecksIcon aria-hidden="true" className="size-4" />}
-              key={detail.id}
-              label="지원 상태"
-              status={detail.status}
-              updateStatusAction={updateApplicationStatus}
-            />
-          </div>
-        </section>
-
-        <div className="grid gap-6">
-          <div className="rounded-2xl border border-border/50 bg-background p-5 shadow-sm">
-            <SectionErrorBoundary>
-              <Suspense fallback={<InterviewSectionSkeleton />}>
-                <InterviewSection applicationId={detail.id} />
-              </Suspense>
-            </SectionErrorBoundary>
-          </div>
-
-          <div className="rounded-2xl border border-border/50 bg-background p-5 shadow-sm">
-            <JobDescriptionEditor
-              applicationId={detail.id}
-              description={detail.description}
-              updateDescriptionAction={updateJobDescription}
-            />
-          </div>
-
-          <div className="rounded-2xl border border-border/50 bg-background p-5 shadow-sm">
-            <MemoEditor
-              applicationId={detail.id}
-              notes={detail.notes}
-              updateNotesAction={updateApplicationNotes}
-            />
+          <div className="order-1 grid gap-6 lg:sticky lg:top-6 lg:order-2 lg:self-start">
+            <DetailSectionPanel
+              className="motion-safe:animate-fade-up"
+              style={{ animationDelay: "200ms" }}
+            >
+              <SectionErrorBoundary>
+                <Suspense fallback={<InterviewSectionSkeleton />}>
+                  <InterviewSection applicationId={detail.id} />
+                </Suspense>
+              </SectionErrorBoundary>
+            </DetailSectionPanel>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #263

## 📌 작업 내용

- 삭제 후 지원 목록으로 이동하도록 상세 삭제 플로우 수정
- 회사명, 포지션, 상태를 상단 브리프 영역으로 재구성
- 상태 변경 영역을 분리해 핵심 액션 가시성 강화
- 면접 일정을 보조 패널형 리스트로 정리
- 공고 설명과 메모 섹션을 문서형 작업면으로 단순화
- 상세 섹션 공통 헤더/패널 컴포넌트 추가


