### PR TITLE
refactor: 랜딩페이지 UI 정리(#265)

### DIFF
--- a/app/(protected)/applications/[applicationId]/_components/ApplicationDetailHero.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/ApplicationDetailHero.tsx
@@ -37,6 +37,7 @@ type UpdateStatusAction = (
 ) => Promise<UpdateApplicationStatusResult>;
 
 const MANUAL_PLATFORM_LABEL = "직접 입력";
+const STATUS_PANEL_ANIMATION_DELAY = "120ms";
 
 export function ApplicationDetailHero({
   deleteAction,
@@ -146,7 +147,7 @@ export function ApplicationDetailHero({
 
         <div
           className="motion-safe:animate-fade-up"
-          style={{ animationDelay: "120ms" }}
+          style={{ animationDelay: STATUS_PANEL_ANIMATION_DELAY }}
         >
           <div className="rounded-[28px] border border-border/60 bg-background/90 p-5 shadow-[0_24px_60px_-40px_rgba(23,23,23,0.28)] backdrop-blur-sm sm:p-6">
             <div className="space-y-2">

--- a/app/(protected)/applications/[applicationId]/page.tsx
+++ b/app/(protected)/applications/[applicationId]/page.tsx
@@ -22,6 +22,12 @@ type ApplicationDetailPageProps = {
   }>;
 };
 
+const DETAIL_PANEL_ANIMATION_DELAYS = {
+  interview: "200ms",
+  jobDescription: "160ms",
+  memo: "220ms",
+} as const;
+
 const ERROR_STATE_META = {
   AUTH_REQUIRED: {
     description: "상세 내용을 보려면 로그인 상태가 필요합니다.",
@@ -91,7 +97,9 @@ export default async function ApplicationDetailPage({
           <div className="order-2 grid gap-6 lg:order-1">
             <DetailSectionPanel
               className="motion-safe:animate-fade-up"
-              style={{ animationDelay: "160ms" }}
+              style={{
+                animationDelay: DETAIL_PANEL_ANIMATION_DELAYS.jobDescription,
+              }}
             >
               <JobDescriptionEditor
                 applicationId={detail.id}
@@ -102,7 +110,7 @@ export default async function ApplicationDetailPage({
 
             <DetailSectionPanel
               className="motion-safe:animate-fade-up"
-              style={{ animationDelay: "220ms" }}
+              style={{ animationDelay: DETAIL_PANEL_ANIMATION_DELAYS.memo }}
             >
               <MemoEditor
                 applicationId={detail.id}
@@ -115,7 +123,9 @@ export default async function ApplicationDetailPage({
           <div className="order-1 grid gap-6 lg:sticky lg:top-6 lg:order-2 lg:self-start">
             <DetailSectionPanel
               className="motion-safe:animate-fade-up"
-              style={{ animationDelay: "200ms" }}
+              style={{
+                animationDelay: DETAIL_PANEL_ANIMATION_DELAYS.interview,
+              }}
             >
               <SectionErrorBoundary>
                 <Suspense fallback={<InterviewSectionSkeleton />}>

--- a/app/_components/PublicHeader.tsx
+++ b/app/_components/PublicHeader.tsx
@@ -1,40 +1,47 @@
-import { LogIn } from "lucide-react";
+import { LogInIcon } from "lucide-react";
 import Link from "next/link";
 
 import GitHubIcon from "@/assets/github.svg";
 import { Button } from "@/components/ui/button/Button";
-import { Tooltip } from "@/components/ui/tooltip/Tooltip";
 
 export function PublicHeader() {
   return (
-    <header className="sticky top-0 z-10 flex items-center justify-between border-b border-border bg-background/80 px-6 py-3 backdrop-blur-sm">
-      <Button
-        asChild
-        className="text-lg font-bold hover:bg-transparent"
-        variant="ghost"
-      >
-        <Link href="/">201</Link>
-      </Button>
-      <div className="flex items-center gap-1">
-        <Tooltip label="GitHub">
-          <Button asChild size="icon" variant="ghost">
+    <header className="sticky top-0 z-20 border-b border-[#40513b]/10 bg-white/90 px-6 py-4 text-[#192016] backdrop-blur-xl lg:px-10">
+      <div className="mx-auto flex max-w-7xl items-center justify-between gap-4">
+        <Link
+          className="text-base font-bold tracking-[-0.03em] text-[#192016]"
+          href="/"
+        >
+          201 escape
+        </Link>
+
+        <div className="flex items-center gap-2">
+          <Button
+            asChild
+            className="h-9 w-9 rounded-full border border-[#40513b]/14 bg-white text-[#192016] hover:bg-[#eef1eb]"
+            size="icon"
+            variant="outline"
+          >
             <a
               aria-label="GitHub 저장소"
               href="https://github.com/quartzs2/201-escape"
               rel="noreferrer"
               target="_blank"
             >
-              <GitHubIcon className="h-4 w-4" />
+              <GitHubIcon className="size-4" />
             </a>
           </Button>
-        </Tooltip>
-        <Tooltip label="시작하기">
-          <Button asChild size="icon" variant="ghost">
-            <Link aria-label="시작하기" href="/login">
-              <LogIn className="h-4 w-4" />
+          <Button
+            asChild
+            className="h-9 rounded-full bg-[#40513b] px-3.5 text-white hover:bg-[#354230]"
+            size="sm"
+          >
+            <Link href="/login">
+              시작하기
+              <LogInIcon className="size-4" />
             </Link>
           </Button>
-        </Tooltip>
+        </div>
       </div>
     </header>
   );

--- a/app/_components/landing/FeaturesSection.tsx
+++ b/app/_components/landing/FeaturesSection.tsx
@@ -1,69 +1,40 @@
-import {
-  BarChart2,
-  Briefcase,
-  CalendarDays,
-  type LucideIcon,
-} from "lucide-react";
-
-type Feature = {
-  description: string;
-  icon: LucideIcon;
-  title: string;
-};
-
-const features: Feature[] = [
-  {
-    description:
-      "지원한 모든 공고를 상태별로 정리. 서류·면접·최종 단계를 한 곳에서 관리하세요.",
-    icon: Briefcase,
-    title: "공고를 한눈에",
-  },
-  {
-    description:
-      "면접 라운드별 정보를 기록하고 추적. 어떤 단계까지 진행됐는지 놓치지 않아요.",
-    icon: CalendarDays,
-    title: "면접 정보 기록",
-  },
-  {
-    description:
-      "전체·서류·면접·합격 건수를 대시보드에서 바로 확인. 내 지원 흐름을 파악하세요.",
-    icon: BarChart2,
-    title: "지원 현황 통계",
-  },
-];
+import { landingFeatures } from "./_utils/content";
 
 export function FeaturesSection() {
   return (
-    <section className="px-6 py-20" id="features">
-      <header className="mb-12">
-        <span className="text-[11px] font-bold tracking-[0.2em] text-primary uppercase">
-          Features
-        </span>
-        <h2 className="mt-3 text-[32px] leading-tight font-extrabold tracking-tight text-foreground">
-          필요한 기능만,
-          <br />
-          군더더기 없이
-        </h2>
-      </header>
+    <section
+      className="border-t border-black/6 bg-white py-16 text-[#192016] lg:py-18"
+      id="features"
+    >
+      <div className="mx-auto max-w-7xl px-6 lg:px-10">
+        <header className="max-w-2xl">
+          <p className="text-sm font-semibold tracking-[0.24em] text-[#667064] uppercase">
+            기능
+          </p>
+          <h2 className="mt-4 text-[2rem] leading-[1.08] font-black tracking-[-0.05em] text-balance sm:text-[2.6rem]">
+            필요한 기능만 간단하게 담았습니다.
+          </h2>
+          <p className="mt-5 text-base leading-7 text-[#5f675c]">
+            공고, 일정, 현황처럼 자주 보는 정보만 담았습니다.
+          </p>
+        </header>
 
-      <ul className="grid grid-cols-1 gap-6 md:grid-cols-2">
-        {features.map(({ description, icon: Icon, title }) => (
-          <li
-            className="rounded-3xl border border-border/50 bg-background p-7 shadow-sm transition-shadow hover:shadow-md"
-            key={title}
-          >
-            <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/8">
-              <Icon aria-hidden="true" className="h-6 w-6 text-primary" />
-            </div>
-            <h3 className="mt-6 text-xl font-bold tracking-tight text-foreground">
-              {title}
-            </h3>
-            <p className="mt-3 text-base leading-relaxed font-medium text-muted-foreground/80">
-              {description}
-            </p>
-          </li>
-        ))}
-      </ul>
+        <ul className="mt-10 grid gap-8 border-t border-black/6 pt-8 md:grid-cols-3">
+          {landingFeatures.map(({ description, icon: Icon, title }) => (
+            <li key={title}>
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#f3f4f1] text-[#364133]">
+                <Icon aria-hidden="true" className="size-5" />
+              </div>
+              <h3 className="mt-4 text-lg font-bold tracking-[-0.03em] text-[#192016]">
+                {title}
+              </h3>
+              <p className="mt-3 text-sm leading-6 text-[#5f675c]">
+                {description}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </div>
     </section>
   );
 }

--- a/app/_components/landing/FinalCtaSection.tsx
+++ b/app/_components/landing/FinalCtaSection.tsx
@@ -1,0 +1,34 @@
+import { ArrowRightIcon } from "lucide-react";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button/Button";
+
+export function FinalCtaSection() {
+  return (
+    <section className="border-t border-[#40513b]/10 bg-white py-16 text-[#192016] lg:py-18">
+      <div className="mx-auto flex max-w-7xl flex-col gap-6 px-6 sm:flex-row sm:items-end sm:justify-between lg:px-10">
+        <div className="max-w-xl">
+          <p className="text-sm font-semibold tracking-[0.24em] text-[#40513b]/70 uppercase">
+            시작하기
+          </p>
+          <h2 className="mt-4 text-[2rem] leading-[1.08] font-black tracking-[-0.05em] text-balance sm:text-[2.6rem]">
+            흩어진 지원 기록을 한곳에 모아보세요.
+          </h2>
+          <p className="mt-4 text-sm leading-6 text-[#4f594b]">
+            지금 바로 로그인해서 공고와 일정을 정리할 수 있습니다.
+          </p>
+        </div>
+
+        <Button
+          asChild
+          className="h-[3.25rem] w-full rounded-full bg-[#40513b] px-7 text-sm font-bold text-white hover:bg-[#354230] focus-visible:ring-[#40513b] sm:w-auto"
+        >
+          <Link href="/login">
+            로그인하고 시작하기
+            <ArrowRightIcon className="size-4" />
+          </Link>
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/app/_components/landing/HeroSection.tsx
+++ b/app/_components/landing/HeroSection.tsx
@@ -1,29 +1,49 @@
+const HERO_ANIMATION_DELAYS = {
+  heading: "140ms",
+  intro: "80ms",
+  list: "380ms",
+  summary: "220ms",
+} as const;
+
 export function HeroSection() {
   return (
-    <section className="flex flex-col px-6 pt-20 pb-12">
-      <div className="animate-slide-up">
-        <span className="inline-flex items-center gap-1.5 rounded-full bg-primary/10 px-3.5 py-1.5 text-[11px] font-bold tracking-wider text-primary uppercase">
-          채용 공고 관리 대시보드
-        </span>
+    <section className="bg-white">
+      <div className="mx-auto flex min-h-[calc(100svh-4.5rem)] max-w-7xl items-center px-6 py-20 lg:px-10">
+        <div className="max-w-2xl">
+          <p className="animate-fade-up text-sm font-semibold tracking-[0.24em] text-[#40513b]/80 uppercase">
+            201 escape
+          </p>
+          <p
+            className="mt-4 animate-fade-up text-sm text-[#4f594b]"
+            style={{ animationDelay: HERO_ANIMATION_DELAYS.intro }}
+          >
+            공고, 지원 단계, 면접 일정을 한곳에서 정리합니다.
+          </p>
+          <h1
+            className="mt-5 animate-fade-up text-[2.7rem] leading-[1.02] font-black tracking-[-0.05em] text-balance text-[#192016] sm:text-[3.6rem] lg:text-[4.2rem]"
+            style={{ animationDelay: HERO_ANIMATION_DELAYS.heading }}
+          >
+            지원 흐름을
+            <br />더 쉽게 정리하세요.
+          </h1>
+          <p
+            className="mt-6 max-w-xl animate-fade-up text-base leading-7 text-[#4f594b]"
+            style={{ animationDelay: HERO_ANIMATION_DELAYS.summary }}
+          >
+            저장한 공고와 현재 상태, 예정된 면접 일정을 한 화면에서 확인할 수
+            있습니다. 처음 열어도 바로 이해할 수 있는 흐름에 집중했습니다.
+          </p>
+
+          <ul
+            className="mt-10 grid animate-fade-up gap-3 border-t border-[#40513b]/10 pt-6 text-sm text-[#4f594b] sm:grid-cols-3"
+            style={{ animationDelay: HERO_ANIMATION_DELAYS.list }}
+          >
+            <li>공고를 저장하고 단계별로 관리</li>
+            <li>면접 일정과 메모를 함께 기록</li>
+            <li>전체 진행 현황을 빠르게 확인</li>
+          </ul>
+        </div>
       </div>
-
-      <h1
-        className="mt-6 animate-slide-up text-[40px] leading-[1.1] font-extrabold tracking-tight text-foreground sm:text-5xl"
-        style={{ animationDelay: "80ms" }}
-      >
-        취업 준비,
-        <br />
-        <span className="text-primary">체계적으로</span>
-      </h1>
-
-      <p
-        className="mt-6 animate-slide-up text-lg leading-relaxed font-medium text-muted-foreground/80"
-        style={{ animationDelay: "160ms" }}
-      >
-        지원 현황부터 일정 관리까지,
-        <br />
-        201 Escape로 한눈에 관리하세요.
-      </p>
     </section>
   );
 }

--- a/app/_components/landing/_utils/content.ts
+++ b/app/_components/landing/_utils/content.ts
@@ -1,0 +1,89 @@
+import {
+  CalendarRangeIcon,
+  ChartSplineIcon,
+  FolderKanbanIcon,
+  type LucideIcon,
+} from "lucide-react";
+
+export type LandingFeature = {
+  description: string;
+  icon: LucideIcon;
+  title: string;
+};
+
+export type LandingTimelineItem = {
+  detail: string;
+  label: string;
+  value: string;
+};
+
+export type LandingWorkflowStep = {
+  description: string;
+  id: string;
+  title: string;
+};
+
+export const landingFeatures: LandingFeature[] = [
+  {
+    description:
+      "지원한 회사와 포지션을 단계별로 정리해 다음 액션이 필요한 항목만 빠르게 확인합니다.",
+    icon: FolderKanbanIcon,
+    title: "공고를 흐름으로 정리",
+  },
+  {
+    description:
+      "면접 일정, 라운드 메모, 준비 포인트를 한 화면에서 이어서 관리할 수 있습니다.",
+    icon: CalendarRangeIcon,
+    title: "일정을 놓치지 않는 기록",
+  },
+  {
+    description:
+      "서류, 면접, 합격까지의 변화를 숫자로 확인해 현재 페이스를 현실적으로 판단합니다.",
+    icon: ChartSplineIcon,
+    title: "지원 현황을 바로 판단",
+  },
+];
+
+export const landingTimeline: LandingTimelineItem[] = [
+  {
+    detail: "이번 주 집중 회사",
+    label: "Saved",
+    value: "08",
+  },
+  {
+    detail: "제출 완료",
+    label: "Applied",
+    value: "14",
+  },
+  {
+    detail: "예정된 라운드",
+    label: "Interview",
+    value: "03",
+  },
+  {
+    detail: "기록 유지",
+    label: "Offer",
+    value: "01",
+  },
+];
+
+export const landingWorkflowSteps: LandingWorkflowStep[] = [
+  {
+    description:
+      "링크나 수기 입력으로 공고를 저장하고, 기준이 되는 포지션명과 회사를 바로 남깁니다.",
+    id: "01",
+    title: "공고를 모은다",
+  },
+  {
+    description:
+      "지원 단계가 바뀔 때마다 상태와 메모를 업데이트해 지금 해야 할 일을 명확하게 만듭니다.",
+    id: "02",
+    title: "변화를 기록한다",
+  },
+  {
+    description:
+      "면접 일정과 결과를 이어서 보며 준비 순서와 우선순위를 다시 정리합니다.",
+    id: "03",
+    title: "다음을 결정한다",
+  },
+];

--- a/app/globals.css
+++ b/app/globals.css
@@ -6,6 +6,11 @@
     width: 100%;
     height: 100%;
   }
+
+  body {
+    background: var(--color-background);
+    color: var(--color-foreground);
+  }
 }
 
 @theme {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,31 +1,17 @@
-import { ArrowRight } from "lucide-react";
-import Link from "next/link";
-
 import { FeaturesSection } from "./_components/landing/FeaturesSection";
+import { FinalCtaSection } from "./_components/landing/FinalCtaSection";
 import { HeroSection } from "./_components/landing/HeroSection";
 import { PublicHeader } from "./_components/PublicHeader";
 
 export default function Home() {
   return (
-    <div className="flex min-h-dvh flex-col bg-muted/30">
+    <div className="flex min-h-dvh flex-col bg-white text-[#192016]">
       <PublicHeader />
       <main className="flex-1">
         <HeroSection />
         <FeaturesSection />
+        <FinalCtaSection />
       </main>
-      <footer className="flex justify-center px-6 py-16">
-        <Link
-          className="group flex flex-col items-center gap-4 transition-transform active:scale-95"
-          href="/login"
-        >
-          <span className="flex h-16 w-16 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg shadow-primary/20 transition-all group-hover:bg-primary/90 group-hover:shadow-xl">
-            <ArrowRight className="h-7 w-7 transition-transform group-hover:translate-x-0.5" />
-          </span>
-          <span className="text-sm font-bold tracking-wider text-muted-foreground uppercase">
-            시작하기
-          </span>
-        </Link>
-      </footer>
     </div>
   );
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #265

## 📌 작업 내용

- 히어로와 헤더를 더 가볍게 단순화
- 기능 섹션 색감과 정렬 기준 보정
- 랜딩 카피를 짧고 명확한 표현으로 수정


