### PR TITLE
feat: 대시보드 지표 구조 개선 및 보호 레이아웃 UX 정리(#267)

### DIFF
--- a/app/(protected)/_components/GoToTopFAB.tsx
+++ b/app/(protected)/_components/GoToTopFAB.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { ArrowUpIcon } from "lucide-react";
+
+import { Button } from "@/components/ui";
+import { cn } from "@/lib/utils";
+
+type GoToTopFABProps = {
+  isVisible: boolean;
+  onScrollToTop: () => void;
+};
+
+export function GoToTopFAB({ isVisible, onScrollToTop }: GoToTopFABProps) {
+  return (
+    <Button
+      aria-hidden={!isVisible}
+      aria-label="맨 위로 이동"
+      className={cn(
+        "fixed right-5 bottom-[calc(env(safe-area-inset-bottom)+6.5rem)] z-40 shadow-lg transition-all duration-300 active:scale-95 md:bottom-6",
+        isVisible
+          ? "scale-100 opacity-100"
+          : "pointer-events-none scale-75 opacity-0",
+      )}
+      onClick={onScrollToTop}
+      size="fab"
+      tabIndex={isVisible ? undefined : -1}
+      variant="outline"
+    >
+      <ArrowUpIcon aria-hidden="true" />
+    </Button>
+  );
+}

--- a/app/(protected)/_components/Header.tsx
+++ b/app/(protected)/_components/Header.tsx
@@ -8,30 +8,32 @@ import { HeaderNavLinks } from "./HeaderNavLinks";
 
 export function Header() {
   return (
-    <header className="sticky top-0 z-10 flex items-center justify-between border-b border-border bg-background/80 px-6 py-3 backdrop-blur-sm">
-      <div className="flex items-center gap-6">
-        <Button
-          asChild
-          className="text-xl font-black tracking-tighter text-primary hover:bg-transparent"
-          variant="ghost"
-        >
-          <Link href="/dashboard">201</Link>
-        </Button>
-        <nav aria-label="주 내비게이션" className="hidden md:flex">
-          <HeaderNavLinks />
-        </nav>
+    <header className="fixed inset-x-0 top-0 z-40 border-b border-border bg-background/80 backdrop-blur-sm">
+      <div className="flex h-16 items-center justify-between px-6">
+        <div className="flex items-center gap-6">
+          <Button
+            asChild
+            className="text-xl font-black tracking-tighter text-primary hover:bg-transparent"
+            variant="ghost"
+          >
+            <Link href="/dashboard">201</Link>
+          </Button>
+          <nav aria-label="주 내비게이션" className="hidden md:flex">
+            <HeaderNavLinks />
+          </nav>
+        </div>
+        <form action={signOut}>
+          <Button
+            aria-label="로그아웃"
+            size="icon"
+            title="로그아웃"
+            type="submit"
+            variant="ghost"
+          >
+            <LogOutIcon aria-hidden="true" />
+          </Button>
+        </form>
       </div>
-      <form action={signOut}>
-        <Button
-          aria-label="로그아웃"
-          size="icon"
-          title="로그아웃"
-          type="submit"
-          variant="ghost"
-        >
-          <LogOutIcon aria-hidden="true" />
-        </Button>
-      </form>
     </header>
   );
 }

--- a/app/(protected)/_components/WindowScrollTopFAB.tsx
+++ b/app/(protected)/_components/WindowScrollTopFAB.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useEffectEvent, useState } from "react";
+
+import { GoToTopFAB } from "./GoToTopFAB";
+
+const VISIBILITY_SCROLL_Y = 280;
+
+export function WindowScrollTopFAB() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const updateVisibility = useEffectEvent(() => {
+    setIsVisible(window.scrollY > VISIBILITY_SCROLL_Y);
+  });
+
+  useEffect(() => {
+    updateVisibility();
+
+    const handleScroll = () => {
+      updateVisibility();
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  return (
+    <GoToTopFAB
+      isVisible={isVisible}
+      onScrollToTop={() => window.scrollTo({ behavior: "smooth", top: 0 })}
+    />
+  );
+}

--- a/app/(protected)/applications/[applicationId]/page.tsx
+++ b/app/(protected)/applications/[applicationId]/page.tsx
@@ -67,7 +67,7 @@ export default async function ApplicationDetailPage({
 
     return (
       <main className="min-h-screen bg-muted/30">
-        <header className="sticky top-0 z-10 flex h-14 items-center gap-4 border-b border-border bg-background/80 px-4 backdrop-blur-md sm:px-6">
+        <header className="sticky top-16 z-10 flex h-14 items-center gap-4 border-b border-border bg-background/80 px-4 backdrop-blur-md sm:px-6">
           <BackLink />
           <h1 className="text-sm font-semibold tracking-tight">오류</h1>
         </header>

--- a/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
@@ -13,6 +13,7 @@ import { useMemo, useRef, useState } from "react";
 import type { GetApplicationsPage } from "@/lib/types/application";
 import type { JobStatus } from "@/lib/types/job";
 
+import { GoToTopFAB } from "@/app/(protected)/_components/GoToTopFAB";
 import { getApplications } from "@/lib/actions";
 
 import type { PeriodPreset, SortValue, TabValue } from "../constants";
@@ -33,7 +34,6 @@ import {
   SORT_PARAM,
   TAB_PARAM,
 } from "../constants";
-import { GoToTopFAB } from "../go-to-top";
 import { ApplicationFilters } from "./ApplicationFilters";
 import { ApplicationPreviewSheet } from "./ApplicationPreviewSheet";
 import { ApplicationTabs } from "./ApplicationTabs";

--- a/app/(protected)/dashboard/_components/dashboard-view/DashboardCharts.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DashboardCharts.tsx
@@ -2,6 +2,8 @@
 
 import type { FunnelStep, MonthlyCount } from "@/lib/types/application";
 
+import { DashboardFunnelBreakdown } from "./DashboardFunnelBreakdown";
+import { DashboardInsightPanel } from "./DashboardInsightPanel";
 import { FunnelChart } from "./FunnelChart";
 import { MonthlyTrendChart } from "./MonthlyTrendChart";
 
@@ -12,20 +14,53 @@ type Props = {
 
 export function DashboardCharts({ funnel, monthly }: Props) {
   return (
-    <>
-      <section className="mb-6 rounded-2xl border border-border/50 bg-background p-5 shadow-sm">
-        <h2 className="mb-4 text-sm font-bold tracking-wide text-muted-foreground uppercase">
-          월별 지원 추이
-        </h2>
-        <MonthlyTrendChart data={monthly} />
+    <div className="space-y-16 lg:space-y-20">
+      <section
+        className="grid animate-fade-up gap-10 lg:grid-cols-[minmax(0,1.5fr)_minmax(280px,0.8fr)] lg:gap-12"
+        style={{ animationDelay: "120ms" }}
+      >
+        <div className="min-w-0">
+          <div className="mb-8 flex flex-col gap-2">
+            <p className="text-xs font-semibold tracking-[0.22em] text-muted-foreground uppercase">
+              Monthly Trend
+            </p>
+            <div className="space-y-1">
+              <h2 className="text-2xl font-bold tracking-tight text-foreground">
+                최근 12개월 지원 추이
+              </h2>
+              <p className="text-sm leading-6 text-muted-foreground">
+                월별 지원량의 증감 흐름을 먼저 확인하고, 아래 단계별 전환과 함께
+                읽어 보세요.
+              </p>
+            </div>
+          </div>
+          <MonthlyTrendChart data={monthly} />
+        </div>
+
+        <DashboardInsightPanel funnel={funnel} monthly={monthly} />
       </section>
 
-      <section className="rounded-2xl border border-border/50 bg-background p-5 shadow-sm">
-        <h2 className="mb-4 text-sm font-bold tracking-wide text-muted-foreground uppercase">
-          단계별 현황
-        </h2>
-        <FunnelChart data={funnel} />
+      <section
+        className="grid animate-fade-up gap-10 lg:grid-cols-[minmax(260px,0.85fr)_minmax(0,1.15fr)] lg:gap-12"
+        style={{ animationDelay: "180ms" }}
+      >
+        <div className="min-w-0">
+          <div className="mb-8 space-y-1">
+            <p className="text-xs font-semibold tracking-[0.22em] text-muted-foreground uppercase">
+              Funnel
+            </p>
+            <h2 className="text-2xl font-bold tracking-tight text-foreground">
+              지원 기준 단계별 잔존 비율
+            </h2>
+            <p className="text-sm leading-6 text-muted-foreground">
+              전체 지원 수를 기준으로 각 단계에 몇 건이 남아 있는지 확인합니다.
+            </p>
+          </div>
+          <FunnelChart data={funnel} />
+        </div>
+
+        <DashboardFunnelBreakdown data={funnel} />
       </section>
-    </>
+    </div>
   );
 }

--- a/app/(protected)/dashboard/_components/dashboard-view/DashboardFunnelBreakdown.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DashboardFunnelBreakdown.tsx
@@ -1,0 +1,58 @@
+import type { FunnelStep } from "@/lib/types/application";
+
+import { getFunnelBreakdown } from "./_utils/dashboard";
+
+type DashboardFunnelBreakdownProps = {
+  data: FunnelStep[];
+};
+
+export function DashboardFunnelBreakdown({
+  data,
+}: DashboardFunnelBreakdownProps) {
+  const items = getFunnelBreakdown(data);
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <p className="text-xs font-semibold tracking-[0.22em] text-muted-foreground uppercase">
+          Retention By Stage
+        </p>
+        <h3 className="mt-3 text-xl font-bold tracking-tight text-foreground">
+          전체 지원 수 대비 각 단계에 남아 있는 비율입니다
+        </h3>
+      </div>
+
+      <ul aria-label="지원 기준 단계별 잔존 비율" className="space-y-4">
+        {items.map((item) => (
+          <li className="space-y-2" key={item.label}>
+            <div className="flex items-end justify-between gap-4">
+              <div>
+                <p className="text-sm font-semibold text-foreground">
+                  {item.label}
+                </p>
+                <p className="text-xs leading-5 text-muted-foreground">
+                  전체 지원 대비 {item.shareOfStart}
+                </p>
+              </div>
+              <div className="text-right">
+                <p className="text-2xl font-black tracking-tight text-foreground">
+                  {item.count}
+                </p>
+                <p className="text-xs text-muted-foreground">건</p>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              className="h-2 overflow-hidden rounded-full bg-muted"
+            >
+              <div
+                className="h-full rounded-full bg-primary"
+                style={{ width: `${item.width}%` }}
+              />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/(protected)/dashboard/_components/dashboard-view/DashboardInsightPanel.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DashboardInsightPanel.tsx
@@ -1,0 +1,75 @@
+import type { FunnelStep, MonthlyCount } from "@/lib/types/application";
+
+import { formatPercent, getMonthlyTrendSummary } from "./_utils/dashboard";
+
+type DashboardInsightPanelProps = {
+  funnel: FunnelStep[];
+  monthly: MonthlyCount[];
+};
+
+export function DashboardInsightPanel({
+  funnel,
+  monthly,
+}: DashboardInsightPanelProps) {
+  const monthlySummary = getMonthlyTrendSummary(monthly);
+  const appliedCount = funnel[0]?.count ?? 0;
+  const offeredCount = funnel.at(-1)?.count ?? 0;
+  const interviewCount =
+    funnel.find((step) => step.label === "면접")?.count ?? 0;
+  const trendToneClassName =
+    monthlySummary.direction === "up"
+      ? "text-primary"
+      : monthlySummary.direction === "down"
+        ? "text-foreground"
+        : "text-muted-foreground";
+
+  return (
+    <aside className="flex h-full flex-col justify-between rounded-3xl border border-border/70 bg-muted/55 px-5 py-6">
+      <div>
+        <p className="text-xs font-semibold tracking-[0.22em] text-muted-foreground uppercase">
+          Quick Notes
+        </p>
+        <h3 className="mt-3 text-xl font-bold tracking-tight text-foreground">
+          최근 흐름과 전환 상태
+        </h3>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">
+          숫자를 해석할 때 먼저 확인할 포인트만 정리했습니다.
+        </p>
+      </div>
+
+      <dl className="mt-8 space-y-6">
+        <div className="space-y-1">
+          <dt className="text-sm font-semibold text-foreground">
+            최근 월 지원
+          </dt>
+          <dd className="text-2xl font-black tracking-tight text-foreground">
+            {monthlySummary.latestCount}건
+          </dd>
+          <dd className={`text-sm leading-6 ${trendToneClassName}`}>
+            {monthlySummary.latestMonthLabel} 기준,{" "}
+            {monthlySummary.comparisonLabel}
+          </dd>
+        </div>
+        <div className="space-y-1">
+          <dt className="text-sm font-semibold text-foreground">최종 전환율</dt>
+          <dd className="text-2xl font-black tracking-tight text-foreground">
+            {formatPercent(offeredCount, appliedCount)}
+          </dd>
+          <dd className="text-sm leading-6 text-muted-foreground">
+            지원 {appliedCount}건 중 {offeredCount}건이 최종 합격으로
+            이어졌습니다.
+          </dd>
+        </div>
+        <div className="space-y-1">
+          <dt className="text-sm font-semibold text-foreground">면접 집중도</dt>
+          <dd className="text-2xl font-black tracking-tight text-foreground">
+            {formatPercent(interviewCount, appliedCount)}
+          </dd>
+          <dd className="text-sm leading-6 text-muted-foreground">
+            지원 기준으로 현재 면접 단계까지 도달한 비율입니다.
+          </dd>
+        </div>
+      </dl>
+    </aside>
+  );
+}

--- a/app/(protected)/dashboard/_components/dashboard-view/DashboardOverview.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DashboardOverview.tsx
@@ -1,0 +1,130 @@
+import type { StatCounts } from "@/lib/types/application";
+
+import { formatPercent } from "./_utils/dashboard";
+
+type DashboardOverviewProps = {
+  stats: StatCounts;
+};
+
+export function DashboardOverview({ stats }: DashboardOverviewProps) {
+  const { applied, docs, docsPassed, interviewing, offered, saved, total } =
+    stats;
+  const metrics = [
+    {
+      description: "아직 지원 전 단계로 저장된 공고",
+      label: "관심 공고",
+      meta: `전체 등록의 ${formatPercent(saved, total)}`,
+      value: saved,
+    },
+    {
+      description: "현재 서류 검토 및 결과 대기",
+      label: "서류 단계",
+      meta: `지원 기준 ${formatPercent(docs, applied)}`,
+      value: docs,
+    },
+    {
+      description: "면접 진행 또는 일정 조율",
+      label: "면접 단계",
+      meta: `지원 기준 ${formatPercent(interviewing, applied)}`,
+      value: interviewing,
+    },
+    {
+      description: "최종 합격 확정",
+      label: "합격 단계",
+      meta: `지원 기준 ${formatPercent(offered, applied)}`,
+      value: offered,
+    },
+  ];
+
+  return (
+    <section className="animate-fade-up" style={{ animationDelay: "60ms" }}>
+      <div className="grid gap-10 lg:grid-cols-[minmax(0,1.45fr)_minmax(280px,0.8fr)] lg:gap-12">
+        <div className="space-y-8">
+          <div className="space-y-3">
+            <p className="text-xs font-semibold tracking-[0.22em] text-muted-foreground uppercase">
+              Selected KPIs
+            </p>
+            <div className="flex flex-wrap items-end gap-x-4 gap-y-2">
+              <span className="text-5xl font-black tracking-tight text-foreground sm:text-6xl">
+                {applied}
+              </span>
+              <p className="pb-1 text-sm font-medium text-muted-foreground">
+                지원 완료 건수
+              </p>
+            </div>
+            <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+              전체 등록 {total}건 중 관심 공고 {saved}건을 제외한 실제 지원
+              건수입니다. 현재 서류 단계 {docs}건, 면접 단계 {interviewing}건,
+              합격 단계 {offered}건입니다.
+            </p>
+          </div>
+
+          <dl className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            {metrics.map((metric) => (
+              <div
+                className="rounded-3xl bg-muted/45 px-5 py-5 transition-colors hover:bg-muted/60"
+                key={metric.label}
+              >
+                <dt className="text-xs font-semibold tracking-[0.18em] text-muted-foreground uppercase">
+                  {metric.label}
+                </dt>
+                <dd className="mt-3 text-3xl font-black tracking-tight text-foreground">
+                  {metric.value}
+                </dd>
+                <dd className="mt-2 text-xs leading-5 text-muted-foreground">
+                  {metric.meta}
+                </dd>
+                <dd className="mt-1 text-xs leading-5 text-muted-foreground">
+                  {metric.description}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+
+        <aside className="rounded-3xl border border-border/70 bg-muted/55 px-5 py-5">
+          <p className="text-xs font-semibold tracking-[0.22em] text-muted-foreground uppercase">
+            Key Rates
+          </p>
+          <dl className="mt-5 space-y-5">
+            <div className="space-y-1">
+              <dt className="text-sm font-semibold text-foreground">
+                서류 통과율
+              </dt>
+              <dd className="text-2xl font-black tracking-tight text-foreground">
+                {formatPercent(docsPassed, applied)}
+              </dd>
+              <dd className="text-sm leading-6 text-muted-foreground">
+                지원 {applied}건 중 {docsPassed}건이 서류 통과 이후 단계까지
+                진행됐습니다.
+              </dd>
+            </div>
+            <div className="space-y-1">
+              <dt className="text-sm font-semibold text-foreground">
+                최종 합격률
+              </dt>
+              <dd className="text-2xl font-black tracking-tight text-foreground">
+                {formatPercent(offered, applied)}
+              </dd>
+              <dd className="text-sm leading-6 text-muted-foreground">
+                지원 {applied}건 중 {offered}건이 최종 합격으로 이어졌습니다.
+              </dd>
+            </div>
+            <div className="space-y-1">
+              <dt className="text-sm font-semibold text-foreground">
+                저장 공고 비중
+              </dt>
+              <dd className="text-2xl font-black tracking-tight text-foreground">
+                {formatPercent(saved, total)}
+              </dd>
+              <dd className="text-sm leading-6 text-muted-foreground">
+                전체 등록 {total}건 중 {saved}건이 아직 저장 상태에 머물러
+                있습니다.
+              </dd>
+            </div>
+          </dl>
+        </aside>
+      </div>
+    </section>
+  );
+}

--- a/app/(protected)/dashboard/_components/dashboard-view/DashboardSkeleton.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DashboardSkeleton.tsx
@@ -4,15 +4,54 @@ import { FUNNEL_CHART_HEIGHT, MONTHLY_CHART_HEIGHT } from "./constants";
 
 export function ChartsSkeleton() {
   return (
-    <div aria-busy="true" aria-label="차트를 불러오는 중입니다">
-      <section className="mb-6 rounded-2xl border border-border/50 bg-background p-5 shadow-sm">
-        <Skeleton className="mb-4 h-4 w-24" />
-        <Skeleton className="w-full" style={{ height: MONTHLY_CHART_HEIGHT }} />
+    <div
+      aria-busy="true"
+      aria-label="차트를 불러오는 중입니다"
+      className="space-y-16 lg:space-y-20"
+    >
+      <section className="grid gap-10 lg:grid-cols-[minmax(0,1.5fr)_minmax(280px,0.8fr)] lg:gap-12">
+        <div>
+          <Skeleton className="h-3 w-28" />
+          <Skeleton className="mt-4 h-8 w-56" />
+          <Skeleton className="mt-3 h-4 w-full max-w-xl" />
+          <Skeleton
+            className="mt-8 w-full"
+            style={{ height: MONTHLY_CHART_HEIGHT }}
+          />
+        </div>
+        <div className="rounded-3xl border border-border/70 bg-muted/55 p-5">
+          <Skeleton className="h-3 w-24" />
+          <Skeleton className="mt-4 h-7 w-40" />
+          <Skeleton className="mt-3 h-4 w-full" />
+          <Skeleton className="mt-8 h-16 w-full" />
+          <Skeleton className="mt-4 h-16 w-full" />
+          <Skeleton className="mt-4 h-16 w-full" />
+        </div>
       </section>
 
-      <section className="rounded-2xl border border-border/50 bg-background p-5 shadow-sm">
-        <Skeleton className="mb-4 h-4 w-24" />
-        <Skeleton className="w-full" style={{ height: FUNNEL_CHART_HEIGHT }} />
+      <section className="grid gap-10 lg:grid-cols-[minmax(260px,0.85fr)_minmax(0,1.15fr)] lg:gap-12">
+        <div>
+          <Skeleton className="h-3 w-20" />
+          <Skeleton className="mt-4 h-8 w-44" />
+          <Skeleton className="mt-3 h-4 w-full max-w-sm" />
+          <Skeleton
+            className="mt-8 w-full"
+            style={{ height: FUNNEL_CHART_HEIGHT }}
+          />
+        </div>
+        <div>
+          <Skeleton className="h-3 w-28" />
+          <Skeleton className="mt-4 h-7 w-72" />
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div className="mt-5 space-y-2" key={index}>
+              <div className="flex justify-between gap-4">
+                <Skeleton className="h-10 w-28" />
+                <Skeleton className="h-10 w-14" />
+              </div>
+              <Skeleton className="h-2 w-full rounded-full" />
+            </div>
+          ))}
+        </div>
       </section>
     </div>
   );
@@ -20,20 +59,34 @@ export function ChartsSkeleton() {
 
 export function StatCardsSkeleton() {
   return (
-    <section
-      aria-busy="true"
-      aria-label="통계를 불러오는 중입니다"
-      className="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-4"
-    >
-      {Array.from({ length: 4 }).map((_, i) => (
-        <div
-          className="flex flex-col items-center justify-center gap-1.5 rounded-2xl border border-border/50 bg-background p-5 shadow-sm"
-          key={i}
-        >
-          <Skeleton className="h-8 w-10" />
-          <Skeleton className="h-3 w-8" />
+    <section aria-busy="true" aria-label="통계를 불러오는 중입니다">
+      <div className="grid gap-10 lg:grid-cols-[minmax(0,1.45fr)_minmax(280px,0.8fr)] lg:gap-12">
+        <div>
+          <Skeleton className="h-3 w-28" />
+          <Skeleton className="mt-4 h-14 w-32" />
+          <Skeleton className="mt-4 h-4 w-full max-w-2xl" />
+          <div className="mt-8 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <div className="rounded-3xl bg-muted/45 px-5 py-5" key={index}>
+                <Skeleton className="h-3 w-16" />
+                <Skeleton className="mt-4 h-8 w-14" />
+                <Skeleton className="mt-3 h-3 w-20" />
+                <Skeleton className="mt-2 h-3 w-24" />
+              </div>
+            ))}
+          </div>
         </div>
-      ))}
+        <div className="rounded-3xl border border-border/70 bg-muted/55 p-5">
+          <Skeleton className="h-3 w-24" />
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div className="mt-5 space-y-2" key={index}>
+              <Skeleton className="h-4 w-28" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-5/6" />
+            </div>
+          ))}
+        </div>
+      </div>
     </section>
   );
 }

--- a/app/(protected)/dashboard/_components/dashboard-view/FunnelChart.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/FunnelChart.tsx
@@ -23,7 +23,7 @@ export function FunnelChart({ data }: Props) {
       <BarChart
         data={data}
         layout="vertical"
-        margin={{ bottom: 0, left: 8, right: 24, top: 0 }}
+        margin={{ bottom: 0, left: 0, right: 12, top: 4 }}
       >
         <XAxis
           allowDecimals={false}
@@ -38,14 +38,15 @@ export function FunnelChart({ data }: Props) {
           tick={{ fill: "var(--color-foreground)", fontSize: 13 }}
           tickLine={false}
           type="category"
-          width={64}
+          width={72}
         />
         <Tooltip
           contentStyle={{
             backgroundColor: "var(--color-background)",
             border: "1px solid var(--color-border)",
-            borderRadius: "8px",
+            borderRadius: "16px",
             fontSize: 13,
+            padding: "10px 12px",
           }}
           cursor={{ fill: "var(--color-muted)" }}
           formatter={(value) => [`${value}건`] as const}
@@ -54,7 +55,7 @@ export function FunnelChart({ data }: Props) {
           dataKey="count"
           fill="var(--color-primary)"
           fillOpacity={0.9}
-          radius={4}
+          radius={999}
         />
       </BarChart>
     </ResponsiveContainer>

--- a/app/(protected)/dashboard/_components/dashboard-view/MonthlyTrendChart.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/MonthlyTrendChart.tsx
@@ -12,6 +12,7 @@ import {
 
 import type { MonthlyCount } from "@/lib/types/application";
 
+import { formatMonthLabel } from "./_utils/dashboard";
 import { MONTHLY_CHART_HEIGHT } from "./constants";
 
 type Props = {
@@ -19,15 +20,22 @@ type Props = {
 };
 
 export function MonthlyTrendChart({ data }: Props) {
-  const chartData = data.map((d) => ({ ...d, label: formatMonth(d.month) }));
+  const chartData = data.map((month) => ({
+    ...month,
+    label: formatMonthLabel(month.month),
+  }));
 
   return (
     <ResponsiveContainer height={MONTHLY_CHART_HEIGHT} width="100%">
       <LineChart
         data={chartData}
-        margin={{ bottom: 0, left: -20, right: 8, top: 4 }}
+        margin={{ bottom: 0, left: -24, right: 12, top: 8 }}
       >
-        <CartesianGrid stroke="var(--color-border)" strokeDasharray="3 3" />
+        <CartesianGrid
+          stroke="var(--color-border)"
+          strokeDasharray="3 3"
+          vertical={false}
+        />
         <XAxis
           axisLine={false}
           dataKey="label"
@@ -44,8 +52,9 @@ export function MonthlyTrendChart({ data }: Props) {
           contentStyle={{
             backgroundColor: "var(--color-background)",
             border: "1px solid var(--color-border)",
-            borderRadius: "8px",
+            borderRadius: "16px",
             fontSize: 13,
+            padding: "10px 12px",
           }}
           formatter={(value) => [`${value}건`, "지원 수"] as const}
           labelStyle={{ color: "var(--color-foreground)", fontWeight: 600 }}
@@ -55,15 +64,10 @@ export function MonthlyTrendChart({ data }: Props) {
           dataKey="count"
           dot={{ fill: "var(--color-primary)", r: 3, strokeWidth: 0 }}
           stroke="var(--color-primary)"
-          strokeWidth={2}
+          strokeWidth={3}
           type="monotone"
         />
       </LineChart>
     </ResponsiveContainer>
   );
-}
-
-function formatMonth(month: string): string {
-  const [, mm] = month.split("-");
-  return `${parseInt(mm, 10)}월`;
 }

--- a/app/(protected)/dashboard/_components/dashboard-view/StatCardsContent.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/StatCardsContent.tsx
@@ -1,5 +1,7 @@
 import { getStatCounts } from "@/lib/actions";
 
+import { DashboardOverview } from "./DashboardOverview";
+
 export async function StatCardsContent() {
   const result = await getStatCounts();
 
@@ -7,30 +9,5 @@ export async function StatCardsContent() {
     throw new Error(result.reason);
   }
 
-  const { docs, interviewing, offered, total } = result.data;
-
-  const cards = [
-    { label: "전체", value: total },
-    { label: "서류", value: docs },
-    { label: "면접", value: interviewing },
-    { label: "합격", value: offered },
-  ];
-
-  return (
-    <section className="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
-      {cards.map((card) => (
-        <div
-          className="flex flex-col items-center justify-center gap-1.5 rounded-2xl border border-border/50 bg-background p-5 shadow-sm"
-          key={card.label}
-        >
-          <span className="text-2xl font-black tracking-tight text-foreground">
-            {card.value}
-          </span>
-          <span className="text-xs font-bold tracking-wider text-muted-foreground uppercase">
-            {card.label}
-          </span>
-        </div>
-      ))}
-    </section>
-  );
+  return <DashboardOverview stats={result.data} />;
 }

--- a/app/(protected)/dashboard/_components/dashboard-view/_utils/dashboard.ts
+++ b/app/(protected)/dashboard/_components/dashboard-view/_utils/dashboard.ts
@@ -1,0 +1,93 @@
+import type { FunnelStep, MonthlyCount } from "@/lib/types/application";
+
+const MIN_FUNNEL_BAR_WIDTH_PERCENT = 6;
+const PREVIOUS_MONTH_OFFSET = -2;
+
+type FunnelBreakdownItem = FunnelStep & {
+  shareOfStart: string;
+  width: number;
+};
+
+type MonthlyTrendSummary = {
+  comparisonLabel: string;
+  direction: "down" | "steady" | "up";
+  latestCount: number;
+  latestMonthLabel: string;
+};
+
+export function formatMonthLabel(month: string): string {
+  const [, mm] = month.split("-");
+
+  return `${parseInt(mm ?? "0", 10)}월`;
+}
+
+export function formatPercent(value: number, total: number): string {
+  if (total <= 0) {
+    return "0%";
+  }
+
+  return `${Math.round((value / total) * 100)}%`;
+}
+
+export function getFunnelBreakdown(data: FunnelStep[]): FunnelBreakdownItem[] {
+  const startCount = data[0]?.count ?? 0;
+
+  return data.map((step) => ({
+    ...step,
+    shareOfStart: formatPercent(step.count, startCount),
+    width:
+      startCount > 0
+        ? Math.max(
+            (step.count / startCount) * 100,
+            MIN_FUNNEL_BAR_WIDTH_PERCENT,
+          )
+        : MIN_FUNNEL_BAR_WIDTH_PERCENT,
+  }));
+}
+
+export function getMonthlyTrendSummary(
+  monthly: MonthlyCount[],
+): MonthlyTrendSummary {
+  const latest = monthly.at(-1);
+
+  if (!latest) {
+    return {
+      comparisonLabel: "비교할 최근 월 데이터가 아직 없습니다.",
+      direction: "steady",
+      latestCount: 0,
+      latestMonthLabel: "기록 없음",
+    };
+  }
+
+  const previous = monthly.at(PREVIOUS_MONTH_OFFSET);
+
+  if (!previous) {
+    return {
+      comparisonLabel: "이전 월 데이터가 없어 추이를 계산하지 않았습니다.",
+      direction: "steady",
+      latestCount: latest.count,
+      latestMonthLabel: formatMonthLabel(latest.month),
+    };
+  }
+
+  const delta = latest.count - previous.count;
+
+  if (delta === 0) {
+    return {
+      comparisonLabel: "전월과 동일한 지원 수를 유지했습니다.",
+      direction: "steady",
+      latestCount: latest.count,
+      latestMonthLabel: formatMonthLabel(latest.month),
+    };
+  }
+
+  return {
+    comparisonLabel:
+      delta > 0
+        ? `전월보다 ${Math.abs(delta)}건 더 지원했습니다.`
+        : `전월보다 ${Math.abs(delta)}건 적게 지원했습니다.`,
+    direction: delta > 0 ? "up" : "down",
+    latestCount: latest.count,
+    latestMonthLabel: formatMonthLabel(latest.month),
+  };
+}

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -11,17 +11,57 @@ import { StatCardsContent } from "./_components/dashboard-view/StatCardsContent"
 
 export default function DashboardPage() {
   return (
-    <main className="min-h-screen bg-muted/30 pb-20">
-      <div className="mx-auto w-full max-w-4xl px-4 pt-8 pb-6 sm:px-6 lg:px-8">
-        <header className="mb-8 space-y-1.5 px-1">
-          <p className="text-sm font-medium text-muted-foreground">
-            {formatKoreanDate(new Date())}
-          </p>
-          <h1 className="text-3xl font-extrabold tracking-tight text-foreground sm:text-4xl">
-            지원 현황
-          </h1>
-        </header>
+    <main className="min-h-screen bg-background pb-20">
+      <section className="bg-muted/30">
+        <div className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6 lg:px-8 lg:py-12">
+          <header className="grid gap-8 lg:grid-cols-[minmax(0,1.45fr)_minmax(280px,0.8fr)] lg:items-end">
+            <div className="space-y-3">
+              <p className="text-sm font-medium text-muted-foreground">
+                {formatKoreanDate(new Date())}
+              </p>
+              <h1 className="text-4xl font-black tracking-tight text-foreground sm:text-5xl">
+                지원 대시보드
+              </h1>
+              <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+                전체 파이프라인 규모, 최근 12개월 지원 추이, 단계별 전환 흐름을
+                한 화면에서 확인합니다.
+              </p>
+            </div>
 
+            <div className="grid gap-3 sm:grid-cols-3">
+              {[
+                {
+                  description:
+                    "전체 규모와 현재 두꺼운 구간을 먼저 확인합니다.",
+                  label: "핵심 수치",
+                },
+                {
+                  description: "월별 증감 흐름으로 최근 지원 리듬을 읽습니다.",
+                  label: "월별 추이",
+                },
+                {
+                  description: "지원에서 합격까지 단계별 유지율을 확인합니다.",
+                  label: "전환 흐름",
+                },
+              ].map((item) => (
+                <div
+                  className="rounded-2xl bg-background/70 px-4 py-4"
+                  key={item.label}
+                >
+                  <p className="text-sm font-semibold text-foreground">
+                    {item.label}
+                  </p>
+                  <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                    {item.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </header>
+        </div>
+      </section>
+
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 py-10 sm:px-6 lg:gap-20 lg:px-8 lg:py-12">
         <Suspense fallback={<StatCardsSkeleton />}>
           <StatCardsContent />
         </Suspense>

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -1,5 +1,6 @@
 import { BottomTabBar } from "./_components/BottomTabBar";
 import { Header } from "./_components/Header";
+import { WindowScrollTopFAB } from "./_components/WindowScrollTopFAB";
 import { ProtectedProviders } from "./ProtectedProviders";
 
 export default function ProtectedLayout({
@@ -10,8 +11,9 @@ export default function ProtectedLayout({
   return (
     <>
       <Header />
-      <main className="pb-16 md:pb-0">{children}</main>
+      <div className="pt-16 pb-16 md:pb-0">{children}</div>
       <BottomTabBar />
+      <WindowScrollTopFAB />
       <ProtectedProviders />
     </>
   );

--- a/lib/actions/getStatCounts.ts
+++ b/lib/actions/getStatCounts.ts
@@ -4,7 +4,10 @@ import { unstable_cache } from "next/cache";
 
 import type { GetStatCountsResult, StatCounts } from "@/lib/types/application";
 
-import { DOCS_STATUSES } from "@/lib/constants/application-status";
+import {
+  DOCS_PASSED_STATUSES,
+  DOCS_STATUSES,
+} from "@/lib/constants/application-status";
 
 import { createClient, createClientWithToken } from "../supabase/server";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
@@ -19,49 +22,62 @@ const getCachedStatCounts = unstable_cache(
   async (userId: string, accessToken: string): Promise<StatCounts> => {
     const supabase = createClientWithToken(accessToken);
 
-    const [totalRes, docsRes, interviewingRes, offeredRes] = await Promise.all([
-      supabase
-        .from("applications")
-        .select("*", { count: "exact", head: true })
-        .eq("user_id", userId),
-      supabase
-        .from("applications")
-        .select("*", { count: "exact", head: true })
-        .eq("user_id", userId)
-        .in("status", DOCS_STATUSES),
-      supabase
-        .from("applications")
-        .select("*", { count: "exact", head: true })
-        .eq("user_id", userId)
-        .eq("status", "INTERVIEWING"),
-      supabase
-        .from("applications")
-        .select("*", { count: "exact", head: true })
-        .eq("user_id", userId)
-        .eq("status", "OFFERED"),
-    ]);
+    const { data, error } = await supabase
+      .from("applications")
+      .select("status")
+      .eq("user_id", userId);
 
-    const firstError =
-      totalRes.error ??
-      docsRes.error ??
-      interviewingRes.error ??
-      offeredRes.error;
-
-    if (firstError) {
+    if (error) {
       const code =
-        firstError.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
-      const reason = normalizeQueryError(firstError);
+        error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
+      const reason = normalizeQueryError(error);
       if (code === "QUERY_ERROR") {
         reportQueryError("getStatCounts", reason);
       }
       throw new Error(reason);
     }
 
+    let applied = 0;
+    let docs = 0;
+    let docsPassed = 0;
+    let interviewing = 0;
+    let offered = 0;
+    let saved = 0;
+
+    for (const row of data ?? []) {
+      const { status } = row;
+
+      if (status === "SAVED") {
+        saved++;
+      } else {
+        applied++;
+      }
+
+      if ((DOCS_STATUSES as readonly string[]).includes(status)) {
+        docs++;
+      }
+
+      if ((DOCS_PASSED_STATUSES as readonly string[]).includes(status)) {
+        docsPassed++;
+      }
+
+      if (status === "INTERVIEWING") {
+        interviewing++;
+      }
+
+      if (status === "OFFERED") {
+        offered++;
+      }
+    }
+
     return {
-      docs: docsRes.count ?? 0,
-      interviewing: interviewingRes.count ?? 0,
-      offered: offeredRes.count ?? 0,
-      total: totalRes.count ?? 0,
+      applied,
+      docs,
+      docsPassed,
+      interviewing,
+      offered,
+      saved,
+      total: (data ?? []).length,
     };
   },
   ["stat-counts"],

--- a/lib/types/application.ts
+++ b/lib/types/application.ts
@@ -152,9 +152,12 @@ export type MonthlyCount = {
 };
 
 export type StatCounts = {
+  applied: number;
   docs: number;
+  docsPassed: number;
   interviewing: number;
   offered: number;
+  saved: number;
   total: number;
 };
 


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #267

## 📌 작업 내용

- 대시보드 상단 KPI를 지원 기준 지표 중심으로 재구성
- 서류 통과율, 최종 합격률, 저장 공고 비중 지표 추가
- 전체 등록 수와 실제 지원 완료 수를 분리해 의미 정리
- 단계별 잔존 비율 문구를 계산 기준에 맞게 수정
- 대시보드 섹션 구분선을 제거하고 간격 중심 레이아웃으로 정리
- 보호 레이아웃 헤더를 고정 배치로 조정하고 상단 오프셋 보정
- 전역 GoToTop FAB 추가 및 기존 지원 목록 FAB 공용 컴포넌트로 정리
- 퍼널 최소 너비, 이전 월 비교 오프셋 매직넘버를 상수로 분리


