### PR TITLE
feat: 지원 목록 화면 정보 구조 개선(#269)

### DIFF
--- a/app/(protected)/_components/GoToTopFAB.tsx
+++ b/app/(protected)/_components/GoToTopFAB.tsx
@@ -6,17 +6,23 @@ import { Button } from "@/components/ui";
 import { cn } from "@/lib/utils";
 
 type GoToTopFABProps = {
+  className?: string;
   isVisible: boolean;
   onScrollToTop: () => void;
 };
 
-export function GoToTopFAB({ isVisible, onScrollToTop }: GoToTopFABProps) {
+export function GoToTopFAB({
+  className,
+  isVisible,
+  onScrollToTop,
+}: GoToTopFABProps) {
   return (
     <Button
       aria-hidden={!isVisible}
       aria-label="맨 위로 이동"
       className={cn(
         "fixed right-5 bottom-[calc(env(safe-area-inset-bottom)+6.5rem)] z-40 shadow-lg transition-all duration-300 active:scale-95 md:bottom-6",
+        className,
         isVisible
           ? "scale-100 opacity-100"
           : "pointer-events-none scale-75 opacity-0",

--- a/app/(protected)/_components/WindowScrollTopFAB.tsx
+++ b/app/(protected)/_components/WindowScrollTopFAB.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { usePathname } from "next/navigation";
 import { useEffect, useEffectEvent, useState } from "react";
 
 import { GoToTopFAB } from "./GoToTopFAB";
@@ -7,6 +8,7 @@ import { GoToTopFAB } from "./GoToTopFAB";
 const VISIBILITY_SCROLL_Y = 280;
 
 export function WindowScrollTopFAB() {
+  const pathname = usePathname();
   const [isVisible, setIsVisible] = useState(false);
 
   const updateVisibility = useEffectEvent(() => {
@@ -14,6 +16,10 @@ export function WindowScrollTopFAB() {
   });
 
   useEffect(() => {
+    if (pathname === "/applications") {
+      return;
+    }
+
     updateVisibility();
 
     const handleScroll = () => {
@@ -25,7 +31,11 @@ export function WindowScrollTopFAB() {
     return () => {
       window.removeEventListener("scroll", handleScroll);
     };
-  }, []);
+  }, [pathname]);
+
+  if (pathname === "/applications") {
+    return null;
+  }
 
   return (
     <GoToTopFAB

--- a/app/(protected)/applications/[applicationId]/_components/BackLink.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/BackLink.tsx
@@ -6,14 +6,14 @@ import { Tooltip } from "@/components/ui/tooltip/Tooltip";
 
 export function BackLink() {
   return (
-    <Tooltip label="대시보드로 돌아가기" side="bottom">
+    <Tooltip label="지원 목록으로 돌아가기" side="bottom">
       <Button
         asChild
         className="-ml-2 text-muted-foreground hover:text-foreground"
         size="sm"
         variant="ghost"
       >
-        <Link aria-label="대시보드로 돌아가기" href="/dashboard">
+        <Link aria-label="지원 목록으로 돌아가기" href="/applications">
           <ArrowLeftIcon aria-hidden="true" />
         </Link>
       </Button>

--- a/app/(protected)/applications/_components/ApplicationsPageHeader.tsx
+++ b/app/(protected)/applications/_components/ApplicationsPageHeader.tsx
@@ -1,0 +1,72 @@
+import type { ApplicationListItem } from "@/lib/types/application";
+
+import { buildApplicationsOverviewContent } from "./_utils/summary";
+import { type PeriodPreset, type SortValue, type TabValue } from "./constants";
+
+type ApplicationsPageHeaderProps = {
+  applications: ApplicationListItem[];
+  dateLabel: string;
+  hasNextPage: boolean;
+  period: PeriodPreset;
+  search: string;
+  sort: SortValue;
+  tab: TabValue;
+};
+
+export function ApplicationsPageHeader({
+  applications,
+  dateLabel,
+  hasNextPage,
+  period,
+  search,
+  sort,
+  tab,
+}: ApplicationsPageHeaderProps) {
+  const content = buildApplicationsOverviewContent({
+    applications,
+    hasNextPage,
+    period,
+    search,
+    sort,
+    tab,
+  });
+  const [visibleMetric, activeMetric, doneMetric, latestMetric] =
+    content.metrics;
+
+  return (
+    <section className="relative left-1/2 w-screen -translate-x-1/2 bg-muted/30">
+      <div className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6 lg:px-8 lg:py-12">
+        <header className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(320px,0.82fr)] lg:items-end">
+          <div className="space-y-3">
+            <p className="text-xs font-medium tracking-[0.08em] text-muted-foreground uppercase">
+              {dateLabel}
+            </p>
+            <h1 className="text-4xl font-black tracking-tight text-foreground sm:text-5xl">
+              지원 목록
+            </h1>
+            <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+              {latestMetric?.label}: {latestMetric?.value}
+              {hasNextPage && " · 아래로 스크롤하면 다음 항목이 이어집니다."}
+            </p>
+          </div>
+
+          <dl className="grid grid-cols-3 gap-3">
+            {[visibleMetric, activeMetric, doneMetric].map((metric) => (
+              <div
+                className="rounded-2xl bg-background/70 px-4 py-3.5"
+                key={metric?.label}
+              >
+                <dt className="text-xs font-semibold tracking-[0.16em] text-muted-foreground uppercase">
+                  {metric?.label}
+                </dt>
+                <dd className="mt-1.5 text-2xl font-black tracking-tight text-foreground sm:text-3xl">
+                  {metric?.value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </header>
+      </div>
+    </section>
+  );
+}

--- a/app/(protected)/applications/_components/ApplicationsView.tsx
+++ b/app/(protected)/applications/_components/ApplicationsView.tsx
@@ -7,6 +7,7 @@ import { Suspense } from "react";
 
 import { Skeleton } from "@/components/ui";
 import { getApplications } from "@/lib/actions";
+import { formatKoreanDate } from "@/lib/utils";
 
 import { AddJobTrigger } from "./add-job";
 import { ApplicationsPanel } from "./components/ApplicationsPanel";
@@ -35,6 +36,7 @@ export async function ApplicationsView({
   );
   const sort = parseSortParam(getString(searchParams[SORT_PARAM]) || null);
   const dateRange = getPeriodDateRange(period);
+  const dateLabel = formatKoreanDate(new Date());
 
   const queryClient = new QueryClient();
 
@@ -62,21 +64,13 @@ export async function ApplicationsView({
   });
 
   return (
-    <main className="min-h-screen bg-muted/30 pb-20">
-      <div className="mx-auto w-full max-w-4xl px-4 pt-8 pb-6 sm:px-6 lg:px-8">
-        <header className="mb-8 space-y-1.5 px-1">
-          <h1 className="text-3xl font-extrabold tracking-tight text-foreground sm:text-4xl">
-            지원 목록
-          </h1>
-        </header>
-
-        <div className="h-200 overflow-hidden rounded-3xl border border-border/50 bg-background shadow-sm">
-          <HydrationBoundary state={dehydrate(queryClient)}>
-            <Suspense fallback={<ApplicationsViewSkeleton />}>
-              <ApplicationsPanel />
-            </Suspense>
-          </HydrationBoundary>
-        </div>
+    <main className="min-h-screen bg-background pb-20">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 pt-0 pb-10 sm:px-6 lg:gap-20 lg:px-8 lg:pb-12">
+        <HydrationBoundary state={dehydrate(queryClient)}>
+          <Suspense fallback={<ApplicationsViewSkeleton />}>
+            <ApplicationsPanel dateLabel={dateLabel} />
+          </Suspense>
+        </HydrationBoundary>
       </div>
       <AddJobTrigger />
     </main>
@@ -88,12 +82,46 @@ function ApplicationsViewSkeleton() {
     <div
       aria-busy="true"
       aria-label="지원 목록을 불러오는 중입니다"
-      className="space-y-4 p-6"
       role="status"
     >
-      {Array.from({ length: 5 }).map((_, i) => (
-        <Skeleton className="h-20 w-full rounded-2xl" key={i} />
-      ))}
+      <section className="overflow-hidden rounded-3xl bg-muted/30">
+        <div className="px-5 py-8 sm:px-6 lg:px-8 lg:py-10">
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.9fr)] lg:items-end">
+            <div className="space-y-3">
+              <Skeleton className="h-4 w-32 rounded-full" />
+              <Skeleton className="h-12 w-40 rounded-full" />
+              <Skeleton className="h-5 w-full max-w-2xl rounded-full" />
+              <Skeleton className="h-5 w-5/6 max-w-xl rounded-full" />
+              <Skeleton className="h-5 w-full max-w-lg rounded-full" />
+            </div>
+
+            <div className="grid grid-cols-3 gap-3">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div className="rounded-2xl bg-background/70 px-4 py-4" key={i}>
+                  <Skeleton className="h-4 w-12 rounded-full" />
+                  <Skeleton className="mt-2 h-8 w-12 rounded-full" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div className="overflow-hidden rounded-3xl border border-border/70 bg-background">
+        <div className="space-y-4 border-b border-border/70 px-5 py-5 sm:px-6">
+          <Skeleton className="h-10 w-full rounded-2xl" />
+          <div className="flex gap-2">
+            <Skeleton className="h-9 w-18 rounded-full" />
+            <Skeleton className="h-9 w-28 rounded-full" />
+            <Skeleton className="h-9 w-22 rounded-full" />
+          </div>
+        </div>
+        <div className="space-y-1 px-4 pb-6 sm:px-5">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton className="h-26 w-full rounded-2xl" key={i} />
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/(protected)/applications/_components/_utils/summary.ts
+++ b/app/(protected)/applications/_components/_utils/summary.ts
@@ -1,0 +1,186 @@
+import type { ApplicationListItem } from "@/lib/types/application";
+
+import { formatAppliedAt } from "@/lib/utils";
+
+import type { PeriodPreset, SortValue, TabValue } from "../constants";
+
+import {
+  DONE_STATUSES,
+  IN_PROGRESS_STATUSES,
+  PERIOD_PRESET_LABELS,
+  SORT_LABELS,
+} from "../constants";
+
+export type ApplicationsOverviewContent = {
+  chips: string[];
+  description: string;
+  eyebrow: string;
+  headline: string;
+  metrics: ApplicationsOverviewMetric[];
+};
+
+export type ApplicationsOverviewMetric = {
+  description: string;
+  label: string;
+  value: string;
+};
+
+export function buildApplicationsOverviewContent(params: {
+  applications: ApplicationListItem[];
+  hasNextPage: boolean;
+  period: PeriodPreset;
+  search: string;
+  sort: SortValue;
+  tab: TabValue;
+}): ApplicationsOverviewContent {
+  const { applications, hasNextPage, period, search, sort, tab } = params;
+  const searchKeyword = search.trim();
+  const visibleCount = applications.length;
+  const activeCount = applications.filter((application) =>
+    IN_PROGRESS_STATUSES.includes(application.status),
+  ).length;
+  const doneCount = applications.filter((application) =>
+    DONE_STATUSES.includes(application.status),
+  ).length;
+  const latestAppliedAt = applications[0]?.appliedAt ?? null;
+  const tabLabel = getTabLabel(tab);
+
+  return {
+    chips: getScopeChips({ period, searchKeyword, sort, tab }),
+    description: getOverviewDescription({
+      hasNextPage,
+      period,
+      searchKeyword,
+      sort,
+      tabLabel,
+      visibleCount,
+    }),
+    eyebrow: hasNextPage ? "현재 로드된 목록 기준" : "현재 표시 중인 목록 기준",
+    headline: getHeadline({ searchKeyword, tab, visibleCount }),
+    metrics: [
+      {
+        description: hasNextPage
+          ? "스크롤하면 다음 항목이 이어집니다."
+          : "현재 범위의 목록이 모두 표시되었습니다.",
+        label: "현재 표시",
+        value: formatCount(visibleCount),
+      },
+      {
+        description: "상태 변경이 필요한 흐름을 먼저 확인합니다.",
+        label: "진행중",
+        value: formatCount(activeCount),
+      },
+      {
+        description: "합격과 불합격까지 마무리된 항목입니다.",
+        label: "완료",
+        value: formatCount(doneCount),
+      },
+      {
+        description:
+          latestAppliedAt === null
+            ? "목록이 비어 있습니다."
+            : "가장 먼저 보이는 최근 등록 기준입니다.",
+        label: "최근 등록",
+        value:
+          latestAppliedAt === null ? "없음" : formatAppliedAt(latestAppliedAt),
+      },
+    ],
+  };
+}
+
+function formatCount(value: number): string {
+  return value.toLocaleString("ko-KR");
+}
+
+function getHeadline(params: {
+  searchKeyword: string;
+  tab: TabValue;
+  visibleCount: number;
+}): string {
+  const { searchKeyword, tab, visibleCount } = params;
+
+  if (searchKeyword !== "") {
+    return `"${searchKeyword}" 검색 결과 ${formatCount(visibleCount)}건`;
+  }
+
+  switch (tab) {
+    case "active": {
+      return `진행 중인 지원 ${formatCount(visibleCount)}건`;
+    }
+    case "done": {
+      return `완료된 지원 ${formatCount(visibleCount)}건`;
+    }
+    default: {
+      return `현재 지원 파이프라인 ${formatCount(visibleCount)}건`;
+    }
+  }
+}
+
+function getOverviewDescription(params: {
+  hasNextPage: boolean;
+  period: PeriodPreset;
+  searchKeyword: string;
+  sort: SortValue;
+  tabLabel: string;
+  visibleCount: number;
+}): string {
+  const { hasNextPage, period, searchKeyword, sort, tabLabel, visibleCount } =
+    params;
+  const countLabel = hasNextPage
+    ? `${formatCount(visibleCount)}건이 먼저 로드되어 있고 아래로 더 이어집니다`
+    : `${formatCount(visibleCount)}건이 현재 범위에서 모두 표시되어 있습니다`;
+
+  if (searchKeyword !== "") {
+    return `${tabLabel}에서 "${searchKeyword}" 회사명을 기준으로 찾은 결과입니다. ${countLabel}. 기간은 ${PERIOD_PRESET_LABELS[period]}, 정렬은 ${SORT_LABELS[sort]}입니다.`;
+  }
+
+  return `${tabLabel}을 ${PERIOD_PRESET_LABELS[period]} 범위로 보고 있습니다. ${countLabel}. 정렬은 ${SORT_LABELS[sort]}입니다.`;
+}
+
+function getScopeChips(params: {
+  period: PeriodPreset;
+  searchKeyword: string;
+  sort: SortValue;
+  tab: TabValue;
+}): string[] {
+  const { period, searchKeyword, sort, tab } = params;
+  const chips = [
+    `탭 ${getTabChipLabel(tab)}`,
+    `기간 ${PERIOD_PRESET_LABELS[period]}`,
+    `정렬 ${SORT_LABELS[sort]}`,
+  ];
+
+  if (searchKeyword !== "") {
+    chips.push(`검색 ${searchKeyword}`);
+  }
+
+  return chips;
+}
+
+function getTabChipLabel(tab: TabValue): string {
+  switch (tab) {
+    case "active": {
+      return "진행중";
+    }
+    case "done": {
+      return "완료";
+    }
+    default: {
+      return "전체";
+    }
+  }
+}
+
+function getTabLabel(tab: TabValue): string {
+  switch (tab) {
+    case "active": {
+      return "진행중 탭";
+    }
+    case "done": {
+      return "완료 탭";
+    }
+    default: {
+      return "전체 목록";
+    }
+  }
+}

--- a/app/(protected)/applications/_components/components/ApplicationFilters.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationFilters.tsx
@@ -3,6 +3,7 @@
 import { ChevronDownIcon, SearchIcon, XIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 
+import { Button } from "@/components/ui";
 import { cn } from "@/lib/utils";
 
 import type { PeriodPreset, SortValue } from "../constants";
@@ -16,6 +17,7 @@ import {
 
 type ApplicationFiltersProps = {
   onPeriodChangeAction: (period: PeriodPreset) => void;
+  onResetFiltersAction: () => void;
   onSearchSubmitAction: (search: string) => void;
   onSortChangeAction: (sort: SortValue) => void;
   period: PeriodPreset;
@@ -26,6 +28,7 @@ type ApplicationFiltersProps = {
 
 export function ApplicationFilters({
   onPeriodChangeAction,
+  onResetFiltersAction,
   onSearchSubmitAction,
   onSortChangeAction,
   period,
@@ -40,7 +43,8 @@ export function ApplicationFilters({
     setInputValue(search);
   }, [search]);
 
-  const isFiltered = search !== "" || period !== "all";
+  const isFiltered =
+    search !== "" || period !== "all" || sort !== "applied_at_desc";
 
   function handleSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -61,81 +65,106 @@ export function ApplicationFilters({
   }
 
   return (
-    <div className="flex flex-col gap-3 px-5 pt-4 pb-2">
-      {/* 1행: 검색 */}
-      <form onSubmit={handleSubmit} role="search">
-        <div className="relative">
-          <SearchIcon
-            aria-hidden="true"
-            className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground"
-          />
-          <input
-            aria-label="회사명 검색"
-            className="w-full rounded-xl border border-border bg-muted/50 py-2 pr-9 pl-9 text-sm placeholder:text-muted-foreground focus:border-primary/50 focus:ring-2 focus:ring-primary/10 focus:outline-none"
-            onChange={handleChange}
-            placeholder="회사명 검색"
-            type="text"
-            value={inputValue}
-          />
-          {inputValue !== "" && (
-            <button
-              aria-label="검색어 지우기"
-              className="absolute top-1/2 right-3 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-              onClick={handleClear}
-              type="button"
+    <section className="bg-background/95 px-5 py-5 backdrop-blur-sm sm:px-6">
+      <div className="flex flex-col gap-4">
+        <div className="flex justify-end">
+          {isFiltered && (
+            <Button
+              className="self-start rounded-full px-4"
+              onClick={onResetFiltersAction}
+              size="sm"
+              variant="outline"
             >
-              <XIcon aria-hidden="true" className="size-4" />
-            </button>
+              필터 초기화
+            </Button>
           )}
         </div>
-      </form>
 
-      {/* 2행: 기간 필터 + 정렬 */}
-      <div className="flex items-center justify-between gap-2">
-        <div aria-label="기간 필터" className="flex gap-2" role="group">
-          {PERIOD_PRESETS.map((preset) => (
-            <button
-              aria-pressed={period === preset}
-              className={cn(
-                "rounded-full px-3 py-1 text-xs font-semibold transition-colors",
-                period === preset
-                  ? "bg-primary text-primary-foreground"
-                  : "bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground",
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+          <form onSubmit={handleSubmit} role="search">
+            <div className="relative">
+              <SearchIcon
+                aria-hidden="true"
+                className="absolute top-1/2 left-4 size-4 -translate-y-1/2 text-muted-foreground"
+              />
+              <input
+                aria-label="회사명 검색"
+                className="w-full rounded-2xl border border-border bg-muted/40 py-3 pr-11 pl-11 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary/50 focus:ring-2 focus:ring-primary/10 focus:outline-none"
+                id="applications-company-search"
+                onChange={handleChange}
+                placeholder="회사명으로 현재 목록 좁히기"
+                type="text"
+                value={inputValue}
+              />
+              {inputValue !== "" && (
+                <button
+                  aria-label="검색어 지우기"
+                  className="absolute top-1/2 right-4 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
+                  onClick={handleClear}
+                  type="button"
+                >
+                  <XIcon aria-hidden="true" className="size-4" />
+                </button>
               )}
-              key={preset}
-              onClick={() => onPeriodChangeAction(preset)}
-              type="button"
-            >
-              {PERIOD_PRESET_LABELS[preset]}
-            </button>
-          ))}
+            </div>
+          </form>
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-end">
+            <div>
+              <div
+                aria-label="기간 필터"
+                className="flex flex-wrap gap-2"
+                role="group"
+              >
+                {PERIOD_PRESETS.map((preset) => (
+                  <button
+                    aria-pressed={period === preset}
+                    className={cn(
+                      "rounded-full border px-3.5 py-2 text-xs font-semibold transition-colors",
+                      period === preset
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-border bg-background text-muted-foreground hover:border-primary/30 hover:text-foreground",
+                    )}
+                    key={preset}
+                    onClick={() => onPeriodChangeAction(preset)}
+                    type="button"
+                  >
+                    {PERIOD_PRESET_LABELS[preset]}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <div className="relative inline-flex shrink-0">
+                <select
+                  aria-label="정렬"
+                  className="appearance-none rounded-full border border-border bg-background py-2 pr-8 pl-3.5 text-sm font-semibold text-foreground focus:border-primary/50 focus:ring-2 focus:ring-primary/10 focus:outline-none sm:min-w-28 sm:pr-10 sm:pl-4"
+                  id="applications-sort"
+                  onChange={(e) =>
+                    onSortChangeAction(e.target.value as SortValue)
+                  }
+                  value={sort}
+                >
+                  {SORT_VALUES.map((value) => (
+                    <option key={value} value={value}>
+                      {SORT_LABELS[value]}
+                    </option>
+                  ))}
+                </select>
+                <ChevronDownIcon
+                  aria-hidden="true"
+                  className="pointer-events-none absolute top-1/2 right-3 size-3.5 -translate-y-1/2 text-muted-foreground sm:right-4"
+                />
+              </div>
+            </div>
+          </div>
         </div>
 
-        <div className="relative shrink-0">
-          <select
-            aria-label="정렬"
-            className="appearance-none bg-transparent py-1 pr-6 pl-0 text-sm font-semibold text-muted-foreground focus:outline-none"
-            onChange={(e) => onSortChangeAction(e.target.value as SortValue)}
-            value={sort}
-          >
-            {SORT_VALUES.map((value) => (
-              <option key={value} value={value}>
-                {SORT_LABELS[value]}
-              </option>
-            ))}
-          </select>
-          <ChevronDownIcon
-            aria-hidden="true"
-            className="pointer-events-none absolute top-1/2 right-2.5 size-3.5 -translate-y-1/2 text-muted-foreground"
-          />
-        </div>
-      </div>
-
-      {isFiltered && (
         <p aria-atomic="true" aria-live="polite" className="sr-only">
           {resultCount}개의 지원 내역이 있습니다
         </p>
-      )}
-    </div>
+      </div>
+    </section>
   );
 }

--- a/app/(protected)/applications/_components/components/ApplicationList.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationList.tsx
@@ -43,7 +43,7 @@ export function ApplicationList({
   };
 
   const emptyState = (
-    <div className="flex flex-col items-center gap-3 py-16 text-muted-foreground">
+    <div className="flex flex-col items-center gap-3 py-20 text-muted-foreground">
       <InboxIcon className="size-8 stroke-[1.5]" />
       <p className="text-sm">{emptyMessage}</p>
     </div>
@@ -53,7 +53,7 @@ export function ApplicationList({
     <div className="flex h-full flex-col">
       <VirtualList
         aria-label="지원서 목록"
-        className="flex-1"
+        className="flex-1 pt-2"
         emptyState={emptyState}
         estimatedItemHeight={ESTIMATED_ROW_HEIGHT}
         items={applications}
@@ -67,13 +67,13 @@ export function ApplicationList({
           />
         )}
       />
-      {!isFetchingNextPage && <div className="h-12 shrink-0" />}
+      {!isFetchingNextPage && <div className="h-10 shrink-0" />}
 
       {isFetchingNextPage && (
         <div
           aria-label="추가 항목을 불러오는 중입니다"
           aria-live="polite"
-          className="pb-12"
+          className="pb-10"
           role="status"
         >
           {Array.from({ length: 3 }).map((_, i) => (
@@ -87,20 +87,23 @@ export function ApplicationList({
 
 function ApplicationRowSkeleton() {
   return (
-    <div className="flex w-full items-start justify-between gap-4 border-b border-border py-4">
-      <div className="flex min-w-0 flex-1 flex-col gap-2">
-        <div className="flex flex-col gap-1">
+    <div className="border-b border-border/70 py-4">
+      <div className="flex w-full items-start justify-between gap-4">
+        <div className="flex min-w-0 flex-1 flex-col gap-2.5">
+          <div className="flex flex-col gap-1.5">
+            <Skeleton className="h-4.5 w-24" />
+            <Skeleton className="h-4 w-40" />
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Skeleton className="h-6 w-16 rounded-full" />
+            <Skeleton className="h-4 w-14" />
+            <Skeleton className="h-4 w-12" />
+          </div>
+        </div>
+        <div className="flex flex-col items-end gap-2">
           <Skeleton className="h-4.5 w-24" />
-          <Skeleton className="h-4 w-40" />
+          <Skeleton className="size-4" />
         </div>
-        <div className="flex items-center gap-1.5">
-          <Skeleton className="h-4 w-10" />
-          <Skeleton className="h-4 w-16" />
-        </div>
-      </div>
-      <div className="flex shrink-0 items-center gap-2">
-        <Skeleton className="h-4 w-12" />
-        <Skeleton className="size-4" />
       </div>
     </div>
   );

--- a/app/(protected)/applications/_components/components/ApplicationRow.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationRow.tsx
@@ -24,13 +24,13 @@ export function ApplicationRow({
   const { badgeClassName, label } = STATUS_META[application.status];
 
   return (
-    <div className="px-1 py-1.5">
+    <div className="border-b border-border/70">
       <button
         aria-label={`${application.companyName} ${application.positionTitle} 지원 미리보기 열기`}
         className={cn(
-          "flex w-full items-center justify-between gap-4 rounded-2xl border border-transparent bg-background p-4 text-left shadow-sm transition-all",
-          "cursor-pointer hover:border-primary/20 hover:bg-primary/2 hover:shadow-md",
-          "focus-visible:border-primary/50 focus-visible:ring-2 focus-visible:ring-primary/10 focus-visible:outline-none",
+          "group flex w-full items-start justify-between gap-4 px-1 py-4 text-left transition-colors",
+          "cursor-pointer hover:bg-muted/30",
+          "focus-visible:rounded-2xl focus-visible:bg-muted/30 focus-visible:ring-2 focus-visible:ring-primary/15 focus-visible:outline-none",
         )}
         onClick={() => {
           posthog.capture(POSTHOG_EVENTS.APPLICATION_PREVIEW_OPENED);
@@ -39,18 +39,18 @@ export function ApplicationRow({
         type="button"
       >
         <div className="flex min-w-0 flex-1 flex-col gap-2.5">
-          <div className="flex flex-col space-y-0.5">
+          <div className="flex flex-col gap-1">
             <span className="text-[15px] font-bold tracking-tight text-foreground">
               {application.companyName}
             </span>
-            <span className="truncate text-sm font-medium text-muted-foreground">
+            <span className="truncate text-sm leading-6 font-medium text-muted-foreground">
               {application.positionTitle}
             </span>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <span
               className={cn(
-                "rounded-full px-2.5 py-0.5 text-[10px] font-bold tracking-wider uppercase",
+                "rounded-full px-2.5 py-1 text-[10px] font-bold tracking-wider uppercase",
                 badgeClassName,
               )}
             >
@@ -61,13 +61,17 @@ export function ApplicationRow({
                 {PLATFORM_LABEL[application.platform]}
               </span>
             )}
+            <span className="text-xs text-muted-foreground/80">
+              <TimeAgo dateString={application.appliedAt} />
+            </span>
           </div>
         </div>
-        <div className="flex shrink-0 items-center gap-2 text-muted-foreground/60">
-          <span className="text-xs font-medium">
-            <TimeAgo dateString={application.appliedAt} />
-          </span>
-          <ChevronRightIcon aria-hidden="true" className="size-4" />
+        <div className="flex shrink-0 items-center gap-2 pt-1 text-muted-foreground">
+          <span className="hidden text-xs font-medium sm:block">미리보기</span>
+          <ChevronRightIcon
+            aria-hidden="true"
+            className="size-4 transition-transform group-hover:translate-x-0.5"
+          />
         </div>
       </button>
     </div>

--- a/app/(protected)/applications/_components/components/ApplicationTabs.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationTabs.tsx
@@ -81,7 +81,7 @@ export function ApplicationTabs({
       }}
       value={tab}
     >
-      <div className="border-b border-border px-5">
+      <div className="border-b border-border/70 bg-background px-5 sm:px-6">
         <Tabs.List className="flex h-auto items-end gap-5 rounded-none bg-transparent p-0">
           <Tabs.Trigger className={TAB_TRIGGER_CLASS} value="all">
             전체
@@ -98,7 +98,7 @@ export function ApplicationTabs({
         </Tabs.List>
       </div>
 
-      <Tabs.Content className="mt-0 min-h-0 flex-1 px-4" value="all">
+      <Tabs.Content className="mt-0 min-h-0 flex-1 px-4 sm:px-5" value="all">
         <ApplicationList
           applications={applications}
           emptyMessage="아직 지원한 곳이 없습니다"
@@ -109,7 +109,7 @@ export function ApplicationTabs({
           ref={listRef}
         />
       </Tabs.Content>
-      <Tabs.Content className="mt-0 min-h-0 flex-1 px-4" value="active">
+      <Tabs.Content className="mt-0 min-h-0 flex-1 px-4 sm:px-5" value="active">
         <ApplicationList
           applications={inProgressApplications}
           emptyMessage="진행 중인 지원이 없습니다"
@@ -120,7 +120,7 @@ export function ApplicationTabs({
           ref={listRef}
         />
       </Tabs.Content>
-      <Tabs.Content className="mt-0 min-h-0 flex-1 px-4" value="done">
+      <Tabs.Content className="mt-0 min-h-0 flex-1 px-4 sm:px-5" value="done">
         <ApplicationList
           applications={doneApplications}
           emptyMessage="완료된 지원이 없습니다"

--- a/app/(protected)/applications/_components/components/ApplicationsOverview.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsOverview.tsx
@@ -1,0 +1,123 @@
+import type { ApplicationListItem } from "@/lib/types/application";
+
+import type { PeriodPreset, SortValue, TabValue } from "../constants";
+
+import { buildApplicationsOverviewContent } from "../_utils/summary";
+
+type ApplicationsOverviewProps = {
+  applications: ApplicationListItem[];
+  hasNextPage: boolean;
+  period: PeriodPreset;
+  search: string;
+  sort: SortValue;
+  tab: TabValue;
+};
+
+export function ApplicationsOverview({
+  applications,
+  hasNextPage,
+  period,
+  search,
+  sort,
+  tab,
+}: ApplicationsOverviewProps) {
+  const content = buildApplicationsOverviewContent({
+    applications,
+    hasNextPage,
+    period,
+    search,
+    sort,
+    tab,
+  });
+  const [visibleMetric, ...secondaryMetrics] = content.metrics;
+
+  return (
+    <section className="animate-fade-up" style={{ animationDelay: "60ms" }}>
+      <div className="grid gap-10 lg:grid-cols-[minmax(0,1.45fr)_minmax(280px,0.8fr)] lg:gap-12">
+        <div className="space-y-8">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold tracking-[0.22em] text-muted-foreground uppercase">
+              {content.eyebrow}
+            </p>
+            <div className="flex flex-wrap items-end gap-x-4 gap-y-2">
+              <span className="text-5xl font-black tracking-tight text-foreground sm:text-6xl">
+                {visibleMetric?.value}
+              </span>
+              <p className="pb-1 text-sm font-medium text-muted-foreground">
+                {visibleMetric?.label}
+              </p>
+            </div>
+            <p className="max-w-2xl text-sm leading-6 text-muted-foreground sm:text-[15px]">
+              {content.headline}. {content.description}
+            </p>
+          </div>
+
+          <dl className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {secondaryMetrics.map((metric) => (
+              <div
+                className="rounded-3xl bg-muted/45 px-5 py-5 transition-colors hover:bg-muted/60"
+                key={metric.label}
+              >
+                <dt className="text-xs font-semibold tracking-[0.18em] text-muted-foreground uppercase">
+                  {metric.label}
+                </dt>
+                <dd className="mt-3 text-3xl font-black tracking-tight text-foreground">
+                  {metric.value}
+                </dd>
+                <dd className="mt-2 text-xs leading-5 text-muted-foreground">
+                  {metric.description}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+
+        <aside className="rounded-3xl border border-border/70 bg-muted/55 px-5 py-6">
+          <p className="text-xs font-semibold tracking-[0.22em] text-muted-foreground uppercase">
+            Quick Notes
+          </p>
+          <h3 className="mt-3 text-xl font-bold tracking-tight text-foreground">
+            현재 목록 해석 포인트
+          </h3>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            지금 보고 있는 조건과 스크롤 상태를 먼저 확인할 수 있게
+            정리했습니다.
+          </p>
+
+          <ul aria-label="현재 보기 조건" className="mt-6 flex flex-wrap gap-2">
+            {content.chips.map((chip) => (
+              <li
+                className="rounded-full bg-background px-3 py-1 text-xs font-medium text-foreground"
+                key={chip}
+              >
+                {chip}
+              </li>
+            ))}
+          </ul>
+
+          <dl className="mt-8 space-y-6">
+            <div className="space-y-1">
+              <dt className="text-sm font-semibold text-foreground">
+                현재 기준
+              </dt>
+              <dd className="text-2xl font-black tracking-tight text-foreground">
+                {visibleMetric?.value}
+              </dd>
+              <dd className="text-sm leading-6 text-muted-foreground">
+                {visibleMetric?.description}
+              </dd>
+            </div>
+            <div className="space-y-1">
+              <dt className="text-sm font-semibold text-foreground">
+                보기 맥락
+              </dt>
+              <dd className="text-sm leading-6 text-muted-foreground">
+                {content.description}
+              </dd>
+            </div>
+          </dl>
+        </aside>
+      </div>
+    </section>
+  );
+}

--- a/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
@@ -13,13 +13,13 @@ import { useMemo, useRef, useState } from "react";
 import type { GetApplicationsPage } from "@/lib/types/application";
 import type { JobStatus } from "@/lib/types/job";
 
-import { GoToTopFAB } from "@/app/(protected)/_components/GoToTopFAB";
 import { getApplications } from "@/lib/actions";
 
 import type { PeriodPreset, SortValue, TabValue } from "../constants";
 import type { ApplicationListItem } from "../types";
 import type { ApplicationTabsHandle } from "./ApplicationTabs";
 
+import { ApplicationsPageHeader } from "../ApplicationsPageHeader";
 import {
   buildApplicationsQueryKey,
   getApplicationsNextPageParam,
@@ -34,11 +34,16 @@ import {
   SORT_PARAM,
   TAB_PARAM,
 } from "../constants";
+import { GoToTopFAB } from "../go-to-top";
 import { ApplicationFilters } from "./ApplicationFilters";
 import { ApplicationPreviewSheet } from "./ApplicationPreviewSheet";
 import { ApplicationTabs } from "./ApplicationTabs";
 
-export function ApplicationsPanel() {
+type ApplicationsPanelProps = {
+  dateLabel: string;
+};
+
+export function ApplicationsPanel({ dateLabel }: ApplicationsPanelProps) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -113,7 +118,18 @@ export function ApplicationsPanel() {
 
   const handleSortChange = (nextSort: SortValue) => {
     updateParams({
+      [PREVIEW_PARAM]: "",
       [SORT_PARAM]: nextSort === "applied_at_desc" ? "" : nextSort,
+    });
+  };
+
+  const handleResetFilters = () => {
+    updateParams({
+      [PERIOD_PARAM]: "",
+      [PREVIEW_PARAM]: "",
+      [SEARCH_PARAM]: "",
+      [SORT_PARAM]: "",
+      [TAB_PARAM]: "",
     });
   };
 
@@ -161,29 +177,43 @@ export function ApplicationsPanel() {
   };
 
   return (
-    <div className="flex h-full flex-col">
-      <ApplicationFilters
-        onPeriodChangeAction={handlePeriodChange}
-        onSearchSubmitAction={handleSearchSubmit}
-        onSortChangeAction={handleSortChange}
+    <div className="flex flex-col gap-6">
+      <ApplicationsPageHeader
+        applications={applications}
+        dateLabel={dateLabel}
+        hasNextPage={hasNextPage ?? false}
         period={period}
-        resultCount={applications.length}
         search={search}
         sort={sort}
-      />
-      <ApplicationTabs
-        applications={applications}
-        className="min-h-0 flex-1"
-        isFetchingNextPage={isFetchingNextPage}
-        onNearEndAction={handleNearEnd}
-        onRangeChangeAction={(startIndex: number) =>
-          setIsListScrolled(startIndex > 0)
-        }
-        onSelectApplicationAction={handleSelectApplication}
-        onTabChangeAction={handleTabChange}
-        ref={tabsRef}
         tab={tab}
       />
+
+      <section className="flex flex-col overflow-hidden rounded-3xl border border-border/70 bg-background">
+        <ApplicationFilters
+          onPeriodChangeAction={handlePeriodChange}
+          onResetFiltersAction={handleResetFilters}
+          onSearchSubmitAction={handleSearchSubmit}
+          onSortChangeAction={handleSortChange}
+          period={period}
+          resultCount={applications.length}
+          search={search}
+          sort={sort}
+        />
+        <ApplicationTabs
+          applications={applications}
+          className="h-[32rem] min-h-0 sm:h-[36rem] lg:h-[40rem]"
+          isFetchingNextPage={isFetchingNextPage}
+          onNearEndAction={handleNearEnd}
+          onRangeChangeAction={(startIndex: number) =>
+            setIsListScrolled(startIndex > 0)
+          }
+          onSelectApplicationAction={handleSelectApplication}
+          onTabChangeAction={handleTabChange}
+          ref={tabsRef}
+          tab={tab}
+        />
+      </section>
+
       <ApplicationPreviewSheet
         application={selectedApplication}
         isOpen={isPreviewOpen}
@@ -191,6 +221,7 @@ export function ApplicationsPanel() {
         onStatusChangeAction={handleStatusChange}
       />
       <GoToTopFAB
+        className="md:bottom-24"
         isVisible={isListScrolled}
         onScrollToTop={() => tabsRef.current?.scrollToTop()}
       />

--- a/app/(protected)/applications/_components/go-to-top/GoToTopFAB.tsx
+++ b/app/(protected)/applications/_components/go-to-top/GoToTopFAB.tsx
@@ -4,17 +4,23 @@ import { Button } from "@/components/ui";
 import { cn } from "@/lib/utils";
 
 type GoToTopFABProps = {
+  className?: string;
   isVisible: boolean;
   onScrollToTop: () => void;
 };
 
-export function GoToTopFAB({ isVisible, onScrollToTop }: GoToTopFABProps) {
+export function GoToTopFAB({
+  className,
+  isVisible,
+  onScrollToTop,
+}: GoToTopFABProps) {
   return (
     <Button
       aria-hidden={!isVisible}
       aria-label="맨 위로 이동"
       className={cn(
         "fixed right-5 bottom-[calc(env(safe-area-inset-bottom)+6.5rem)] z-40 shadow-lg transition-all duration-300 active:scale-95",
+        className,
         isVisible
           ? "scale-100 opacity-100"
           : "pointer-events-none scale-75 opacity-0",


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #269

## 📌 작업 내용

- 요약 헤더와 핵심 지표 카드 추가
- 필터/정렬/탭 상태 기반 요약 로직 분리
- 필터 초기화와 리스트 행 UI 개선
- 지원 상세에서 목록으로 돌아가도록 링크 정리

