### PR TITLE
perf: posthog-js 초기 번들 분리로 LCP 개선(#274)

### DIFF
--- a/app/(protected)/applications/ApplicationsProviders.tsx
+++ b/app/(protected)/applications/ApplicationsProviders.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import dynamic from "next/dynamic";
 import { useState } from "react";
 
-import { PostHogProvider } from "@/lib/posthog/PostHogProvider";
-import { PostHogUserSync } from "@/lib/posthog/PostHogUserSync";
+const PostHogProvider = dynamic(
+  () => import("@/lib/posthog/PostHogProvider").then((m) => m.PostHogProvider),
+  { ssr: false },
+);
 
 export function ApplicationsProviders({
   children,
@@ -24,7 +27,6 @@ export function ApplicationsProviders({
 
   return (
     <PostHogProvider>
-      <PostHogUserSync />
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     </PostHogProvider>
   );

--- a/app/(protected)/applications/[applicationId]/_components/ApplicationDetailHero.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/ApplicationDetailHero.tsx
@@ -8,14 +8,14 @@ import type {
   UpdateApplicationStatusResult,
 } from "@/lib/types/application";
 
-import { ApplicationStatusSelector } from "@/app/(protected)/_components/ApplicationStatusSelector";
 import { Button } from "@/components/ui/button/Button";
 import { APPLICATION_STATUS_META } from "@/lib/constants/application-status";
 import { PLATFORM_LABEL } from "@/lib/constants/job-platform";
 import { cn, formatAppliedAt } from "@/lib/utils";
 
 import { BackLink } from "./BackLink";
-import { DeleteApplicationButton } from "./DeleteApplicationButton";
+import { ApplicationStatusSelector } from "./LazyClient";
+import { DeleteApplicationButton } from "./LazyClient";
 
 type ApplicationDetailHeroProps = {
   deleteAction: DeleteApplicationAction;

--- a/app/(protected)/applications/[applicationId]/_components/InterviewSection.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/InterviewSection.tsx
@@ -8,9 +8,8 @@ import { upsertInterview } from "@/lib/actions/upsertInterview";
 import { INTERVIEW_TYPE_LABEL } from "@/lib/constants/interview-type";
 import { formatScheduledAt } from "@/lib/utils";
 
-import { DeleteInterviewButton } from "./DeleteInterviewButton";
 import { DetailSectionHeader } from "./DetailSectionHeader";
-import { InterviewFormSheet } from "./InterviewFormSheet";
+import { DeleteInterviewButton, InterviewFormSheet } from "./LazyClient";
 
 type InterviewListProps = {
   applicationId: string;

--- a/app/(protected)/applications/[applicationId]/_components/LazyClient.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/LazyClient.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import { Skeleton } from "@/components/ui";
+
+function EditorSkeleton() {
+  return (
+    <div
+      aria-busy="true"
+      aria-label="불러오는 중입니다"
+      className="space-y-4"
+      role="status"
+    >
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-5 w-24" />
+        <Skeleton className="h-8 w-16" />
+      </div>
+      <Skeleton className="h-32 w-full rounded-xl" />
+    </div>
+  );
+}
+
+function StatusSelectorSkeleton() {
+  return (
+    <div
+      aria-busy="true"
+      aria-label="상태 선택기를 불러오는 중입니다"
+      className="space-y-2"
+      role="status"
+    >
+      <div className="flex items-center gap-2">
+        <Skeleton className="h-4 w-16" />
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton className="h-11 w-20 rounded-full" key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export const ApplicationStatusSelector = dynamic(
+  () =>
+    import("@/app/(protected)/_components/ApplicationStatusSelector").then(
+      (m) => m.ApplicationStatusSelector,
+    ),
+  { loading: () => <StatusSelectorSkeleton />, ssr: false },
+);
+
+export const DeleteApplicationButton = dynamic(
+  () =>
+    import("./DeleteApplicationButton").then((m) => m.DeleteApplicationButton),
+  { ssr: false },
+);
+
+export const JobDescriptionEditor = dynamic(
+  () => import("./JobDescriptionEditor").then((m) => m.JobDescriptionEditor),
+  { loading: () => <EditorSkeleton />, ssr: false },
+);
+
+export const MemoEditor = dynamic(
+  () => import("./MemoEditor").then((m) => m.MemoEditor),
+  { loading: () => <EditorSkeleton />, ssr: false },
+);
+
+export const InterviewFormSheet = dynamic(
+  () => import("./InterviewFormSheet").then((m) => m.InterviewFormSheet),
+  { ssr: false },
+);
+
+export const DeleteInterviewButton = dynamic(
+  () => import("./DeleteInterviewButton").then((m) => m.DeleteInterviewButton),
+  { ssr: false },
+);

--- a/app/(protected)/applications/[applicationId]/page.tsx
+++ b/app/(protected)/applications/[applicationId]/page.tsx
@@ -12,8 +12,7 @@ import { BackLink } from "./_components/BackLink";
 import { DetailSectionPanel } from "./_components/DetailSectionPanel";
 import { ErrorState } from "./_components/ErrorState";
 import { InterviewSection } from "./_components/InterviewSection";
-import { JobDescriptionEditor } from "./_components/JobDescriptionEditor";
-import { MemoEditor } from "./_components/MemoEditor";
+import { JobDescriptionEditor, MemoEditor } from "./_components/LazyClient";
 import { SectionErrorBoundary } from "./_components/SectionErrorBoundary";
 
 type ApplicationDetailPageProps = {

--- a/lib/posthog/PostHogProvider.tsx
+++ b/lib/posthog/PostHogProvider.tsx
@@ -5,6 +5,8 @@ import posthog from "posthog-js";
 import { PostHogProvider as PHProvider, usePostHog } from "posthog-js/react";
 import { Suspense, useEffect } from "react";
 
+import { PostHogUserSync } from "./PostHogUserSync";
+
 if (typeof window !== "undefined") {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN!, {
     advanced_disable_decide: true,
@@ -25,6 +27,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       <Suspense>
         <PageViewTracker />
       </Suspense>
+      <PostHogUserSync />
       {children}
     </PHProvider>
   );

--- a/package.json
+++ b/package.json
@@ -71,6 +71,12 @@
     "vite": "^7.3.1",
     "vitest": "^4.0.18"
   },
+  "browserslist": [
+    "chrome >= 87",
+    "edge >= 88",
+    "firefox >= 78",
+    "safari >= 14"
+  ],
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mjs}": [
       "prettier --write",


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #274

## 📌 작업 내용

- ApplicationsProviders에서 PostHogProvider를 dynamic import로 전환하여 posthog-js(109KB)를 초기 번들에서 분리
- PostHogUserSync를 PostHogProvider 내부로 이동하여 컨텍스트 의존성 해결
- DeleteApplicationButton, JobDescriptionEditor, MemoEditor, InterviewFormSheet, DeleteInterviewButton을 LazyClient.tsx에 dynamic import로 이동
- JobDescriptionEditor, MemoEditor에 EditorSkeleton 로딩 상태 추가
- ApplicationStatusSelector를 LazyClient.tsx에 dynamic import로 이동하여 [applicationId] 초기 번들의 posthog-js 잔존 문제 해결
- StatusSelectorSkeleton으로 로딩 중 레이아웃 시프트 방지
- package.json에 browserslist 타겟 추가(chrome >= 87, edge >= 88, firefox >= 78, safari >= 14)하여 레거시 폴리필 약 41KB 제거


