### PR TITLE
perf: applications provider 범위 축소 및 상세 페이지 스트리밍 적용(#280)

### DIFF
--- a/app/(protected)/ProtectedProviders.tsx
+++ b/app/(protected)/ProtectedProviders.tsx
@@ -11,11 +11,31 @@ const SentryUserSync = dynamic(
   { ssr: false },
 );
 
-export function ProtectedProviders({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+const DeferredPostHogBootstrap = dynamic(
+  () =>
+    import("@/lib/posthog/DeferredPostHogBootstrap").then((mod) => ({
+      default: mod.DeferredPostHogBootstrap,
+    })),
+  { ssr: false },
+);
+
+const BottomTabBar = dynamic(
+  () =>
+    import("./_components/BottomTabBar").then((mod) => ({
+      default: mod.BottomTabBar,
+    })),
+  { ssr: false },
+);
+
+const WindowScrollTopFAB = dynamic(
+  () =>
+    import("./_components/WindowScrollTopFAB").then((mod) => ({
+      default: mod.WindowScrollTopFAB,
+    })),
+  { ssr: false },
+);
+
+export function ProtectedEnhancements() {
   const [shouldMount, setShouldMount] = useState(false);
 
   useEffect(() => {
@@ -43,10 +63,16 @@ export function ProtectedProviders({
     };
   }, []);
 
+  if (!shouldMount) {
+    return null;
+  }
+
   return (
     <>
-      {children}
-      {shouldMount && <SentryUserSync />}
+      <DeferredPostHogBootstrap />
+      <BottomTabBar />
+      <WindowScrollTopFAB />
+      <SentryUserSync />
     </>
   );
 }

--- a/app/(protected)/_components/Header.tsx
+++ b/app/(protected)/_components/Header.tsx
@@ -1,10 +1,9 @@
 import { LogOutIcon } from "lucide-react";
-import Link from "next/link";
 
 import { Button } from "@/components/ui/button/Button";
 import { signOut } from "@/lib/actions/signOut";
 
-import { HeaderNavLinks } from "./HeaderNavLinks";
+import { NAV_ITEMS } from "./nav-items";
 
 export function Header() {
   return (
@@ -16,10 +15,22 @@ export function Header() {
             className="text-xl font-black tracking-tighter text-primary hover:bg-transparent"
             variant="ghost"
           >
-            <Link href="/dashboard">201</Link>
+            <a href="/dashboard">201</a>
           </Button>
           <nav aria-label="주 내비게이션" className="hidden md:flex">
-            <HeaderNavLinks />
+            <ul className="flex items-center gap-1">
+              {NAV_ITEMS.map(({ href, label }) => (
+                <li key={href}>
+                  <Button
+                    asChild
+                    className="text-sm font-medium text-muted-foreground hover:text-foreground"
+                    variant="ghost"
+                  >
+                    <a href={href}>{label}</a>
+                  </Button>
+                </li>
+              ))}
+            </ul>
           </nav>
         </div>
         <form action={signOut}>

--- a/app/(protected)/applications/[applicationId]/page.tsx
+++ b/app/(protected)/applications/[applicationId]/page.tsx
@@ -1,6 +1,7 @@
 import { FileTextIcon, LockKeyholeIcon } from "lucide-react";
 import { Suspense } from "react";
 
+import { ApplicationsProviders } from "@/app/(protected)/applications/ApplicationsProviders";
 import { Skeleton } from "@/components/ui";
 import { deleteApplication, getApplicationDetail } from "@/lib/actions";
 import { updateApplicationNotes } from "@/lib/actions/updateApplicationNotes";
@@ -58,6 +59,16 @@ const ERROR_STATE_META = {
 export default async function ApplicationDetailPage({
   params,
 }: ApplicationDetailPageProps) {
+  return (
+    <Suspense fallback={<ApplicationDetailPageSkeleton />}>
+      <ApplicationDetailContent params={params} />
+    </Suspense>
+  );
+}
+
+async function ApplicationDetailContent({
+  params,
+}: ApplicationDetailPageProps) {
   const { applicationId } = await params;
   const result = await getApplicationDetail(applicationId);
 
@@ -85,57 +96,160 @@ export default async function ApplicationDetailPage({
 
   return (
     <main className="min-h-screen bg-[linear-gradient(180deg,rgba(245,245,245,0.9)_0%,rgba(255,255,255,0.82)_18%,rgba(255,255,255,1)_40%)] pb-20">
+      <ApplicationsProviders>
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
+          <ApplicationDetailHero
+            deleteAction={deleteApplication}
+            detail={detail}
+            updateStatusAction={updateApplicationStatus}
+          />
+
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(320px,0.82fr)]">
+            <div className="order-2 grid gap-6 lg:order-1">
+              <DetailSectionPanel
+                className="motion-safe:animate-fade-up"
+                style={{
+                  animationDelay: DETAIL_PANEL_ANIMATION_DELAYS.jobDescription,
+                }}
+              >
+                <JobDescriptionEditor
+                  applicationId={detail.id}
+                  description={detail.description}
+                  updateDescriptionAction={updateJobDescription}
+                />
+              </DetailSectionPanel>
+
+              <DetailSectionPanel
+                className="motion-safe:animate-fade-up"
+                style={{ animationDelay: DETAIL_PANEL_ANIMATION_DELAYS.memo }}
+              >
+                <MemoEditor
+                  applicationId={detail.id}
+                  notes={detail.notes}
+                  updateNotesAction={updateApplicationNotes}
+                />
+              </DetailSectionPanel>
+            </div>
+
+            <div className="order-1 grid gap-6 lg:sticky lg:top-6 lg:order-2 lg:self-start">
+              <DetailSectionPanel
+                className="motion-safe:animate-fade-up"
+                style={{
+                  animationDelay: DETAIL_PANEL_ANIMATION_DELAYS.interview,
+                }}
+              >
+                <SectionErrorBoundary>
+                  <Suspense fallback={<InterviewSectionSkeleton />}>
+                    <InterviewSection applicationId={detail.id} />
+                  </Suspense>
+                </SectionErrorBoundary>
+              </DetailSectionPanel>
+            </div>
+          </div>
+        </div>
+      </ApplicationsProviders>
+    </main>
+  );
+}
+
+function ApplicationDetailPageSkeleton() {
+  return (
+    <main className="min-h-screen bg-[linear-gradient(180deg,rgba(245,245,245,0.9)_0%,rgba(255,255,255,0.82)_18%,rgba(255,255,255,1)_40%)] pb-20">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
-        <ApplicationDetailHero
-          deleteAction={deleteApplication}
-          detail={detail}
-          updateStatusAction={updateApplicationStatus}
-        />
+        <section
+          aria-busy="true"
+          aria-label="지원 상세 정보를 불러오는 중입니다"
+          className="relative overflow-hidden rounded-[32px] border border-border/60 bg-background p-5 shadow-[0_36px_120px_-64px_rgba(23,23,23,0.45)] sm:p-8"
+          role="status"
+        >
+          <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(300px,360px)] lg:gap-10">
+            <div className="space-y-8">
+              <div className="flex items-center justify-between gap-3">
+                <Skeleton className="h-9 w-24 rounded-full" />
+                <Skeleton className="h-9 w-9 rounded-full" />
+              </div>
+
+              <div className="space-y-5">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Skeleton className="h-6 w-18 rounded-full" />
+                  <Skeleton className="h-4 w-28 rounded-full" />
+                </div>
+
+                <div className="space-y-3">
+                  <Skeleton className="h-4 w-28 rounded-full" />
+                  <Skeleton className="h-12 w-full max-w-2xl rounded-2xl" />
+                </div>
+
+                <Skeleton className="h-10 w-32 rounded-full" />
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-3">
+                {Array.from({ length: 3 }).map((_, index) => (
+                  <div
+                    className="rounded-2xl border border-border/50 bg-background/70 px-4 py-4"
+                    key={index}
+                  >
+                    <Skeleton className="h-4 w-14 rounded-full" />
+                    <Skeleton className="mt-2 h-5 w-20 rounded-full" />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-[28px] border border-border/60 bg-background/90 p-5 sm:p-6">
+              <div className="space-y-2">
+                <Skeleton className="h-4 w-18 rounded-full" />
+                <Skeleton className="h-8 w-24 rounded-full" />
+                <Skeleton className="h-4 w-40 rounded-full" />
+              </div>
+
+              <div className="mt-6 space-y-3">
+                <Skeleton className="h-4 w-16 rounded-full" />
+                <div className="flex flex-wrap gap-2">
+                  {Array.from({ length: 5 }).map((_, index) => (
+                    <Skeleton className="h-11 w-20 rounded-full" key={index} />
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
 
         <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(320px,0.82fr)]">
           <div className="order-2 grid gap-6 lg:order-1">
-            <DetailSectionPanel
-              className="motion-safe:animate-fade-up"
-              style={{
-                animationDelay: DETAIL_PANEL_ANIMATION_DELAYS.jobDescription,
-              }}
-            >
-              <JobDescriptionEditor
-                applicationId={detail.id}
-                description={detail.description}
-                updateDescriptionAction={updateJobDescription}
-              />
+            <DetailSectionPanel>
+              <EditorSectionSkeleton />
             </DetailSectionPanel>
-
-            <DetailSectionPanel
-              className="motion-safe:animate-fade-up"
-              style={{ animationDelay: DETAIL_PANEL_ANIMATION_DELAYS.memo }}
-            >
-              <MemoEditor
-                applicationId={detail.id}
-                notes={detail.notes}
-                updateNotesAction={updateApplicationNotes}
-              />
+            <DetailSectionPanel>
+              <EditorSectionSkeleton />
             </DetailSectionPanel>
           </div>
 
-          <div className="order-1 grid gap-6 lg:sticky lg:top-6 lg:order-2 lg:self-start">
-            <DetailSectionPanel
-              className="motion-safe:animate-fade-up"
-              style={{
-                animationDelay: DETAIL_PANEL_ANIMATION_DELAYS.interview,
-              }}
-            >
-              <SectionErrorBoundary>
-                <Suspense fallback={<InterviewSectionSkeleton />}>
-                  <InterviewSection applicationId={detail.id} />
-                </Suspense>
-              </SectionErrorBoundary>
+          <div className="order-1 lg:order-2">
+            <DetailSectionPanel>
+              <InterviewSectionSkeleton />
             </DetailSectionPanel>
           </div>
         </div>
       </div>
     </main>
+  );
+}
+
+function EditorSectionSkeleton() {
+  return (
+    <div
+      aria-busy="true"
+      aria-label="편집 영역을 불러오는 중입니다"
+      className="space-y-4"
+      role="status"
+    >
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-5 w-24 rounded-full" />
+        <Skeleton className="h-8 w-16 rounded-full" />
+      </div>
+      <Skeleton className="h-32 w-full rounded-xl" />
+    </div>
   );
 }
 

--- a/app/(protected)/applications/_components/ApplicationsView.tsx
+++ b/app/(protected)/applications/_components/ApplicationsView.tsx
@@ -5,6 +5,7 @@ import {
 } from "@tanstack/react-query";
 import { Suspense } from "react";
 
+import { ApplicationsProviders } from "@/app/(protected)/applications/ApplicationsProviders";
 import { Skeleton } from "@/components/ui";
 import { getApplications } from "@/lib/actions";
 import { formatKoreanDate } from "@/lib/utils";
@@ -66,11 +67,13 @@ export async function ApplicationsView({
   return (
     <main className="min-h-screen bg-background pb-20">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 pt-0 pb-10 sm:px-6 lg:gap-20 lg:px-8 lg:pb-12">
-        <HydrationBoundary state={dehydrate(queryClient)}>
-          <Suspense fallback={<ApplicationsViewSkeleton />}>
-            <ApplicationsPanel dateLabel={dateLabel} />
-          </Suspense>
-        </HydrationBoundary>
+        <ApplicationsProviders>
+          <HydrationBoundary state={dehydrate(queryClient)}>
+            <Suspense fallback={<ApplicationsViewSkeleton />}>
+              <ApplicationsPanel dateLabel={dateLabel} />
+            </Suspense>
+          </HydrationBoundary>
+        </ApplicationsProviders>
       </div>
       <AddJobTrigger />
     </main>

--- a/app/(protected)/applications/layout.tsx
+++ b/app/(protected)/applications/layout.tsx
@@ -1,9 +1,7 @@
-import { ApplicationsProviders } from "./ApplicationsProviders";
-
 export default function ApplicationsLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return <ApplicationsProviders>{children}</ApplicationsProviders>;
+  return children;
 }

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -1,7 +1,5 @@
-import { BottomTabBar } from "./_components/BottomTabBar";
 import { Header } from "./_components/Header";
-import { WindowScrollTopFAB } from "./_components/WindowScrollTopFAB";
-import { ProtectedProviders } from "./ProtectedProviders";
+import { ProtectedEnhancements } from "./ProtectedProviders";
 
 export default function ProtectedLayout({
   children,
@@ -9,11 +7,10 @@ export default function ProtectedLayout({
   children: React.ReactNode;
 }) {
   return (
-    <ProtectedProviders>
+    <>
       <Header />
       <div className="pt-16 pb-16 md:pb-0">{children}</div>
-      <BottomTabBar />
-      <WindowScrollTopFAB />
-    </ProtectedProviders>
+      <ProtectedEnhancements />
+    </>
   );
 }

--- a/app/_components/PublicHeader.tsx
+++ b/app/_components/PublicHeader.tsx
@@ -1,5 +1,4 @@
 import { LogInIcon } from "lucide-react";
-import Link from "next/link";
 
 import GitHubIcon from "@/assets/github.svg";
 import { Button } from "@/components/ui/button/Button";
@@ -8,12 +7,13 @@ export function PublicHeader() {
   return (
     <header className="sticky top-0 z-20 border-b border-[#40513b]/10 bg-white/90 px-6 py-4 text-[#192016] backdrop-blur-xl lg:px-10">
       <div className="mx-auto flex max-w-7xl items-center justify-between gap-4">
-        <Link
+        {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- Public entrypoints intentionally avoid client navigation JS. */}
+        <a
           className="text-base font-bold tracking-[-0.03em] text-[#192016]"
           href="/"
         >
           201 escape
-        </Link>
+        </a>
 
         <div className="flex items-center gap-2">
           <Button
@@ -36,10 +36,10 @@ export function PublicHeader() {
             className="h-9 rounded-full bg-[#40513b] px-3.5 text-white hover:bg-[#354230]"
             size="sm"
           >
-            <Link href="/login">
+            <a href="/login">
               시작하기
               <LogInIcon className="size-4" />
-            </Link>
+            </a>
           </Button>
         </div>
       </div>

--- a/app/_components/landing/FinalCtaSection.tsx
+++ b/app/_components/landing/FinalCtaSection.tsx
@@ -1,5 +1,4 @@
 import { ArrowRightIcon } from "lucide-react";
-import Link from "next/link";
 
 import { Button } from "@/components/ui/button/Button";
 
@@ -23,10 +22,10 @@ export function FinalCtaSection() {
           asChild
           className="h-[3.25rem] w-full rounded-full bg-[#40513b] px-7 text-sm font-bold text-white hover:bg-[#354230] focus-visible:ring-[#40513b] sm:w-auto"
         >
-          <Link href="/login">
+          <a href="/login">
             로그인하고 시작하기
             <ArrowRightIcon className="size-4" />
-          </Link>
+          </a>
         </Button>
       </div>
     </section>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,8 @@
 import type { Metadata } from "next";
 
 import localFont from "next/font/local";
-import { Suspense } from "react";
 
 import { PORTAL_ROOT_ID } from "@/lib/constants/dom";
-import { DeferredPostHogBootstrap } from "@/lib/posthog/DeferredPostHogBootstrap";
 
 import "./globals.css";
 
@@ -56,9 +54,6 @@ export default function RootLayout({
     <html lang="ko">
       <body className={`${pretendard.className} antialiased`}>
         {children}
-        <Suspense fallback={null}>
-          <DeferredPostHogBootstrap />
-        </Suspense>
         <div id={PORTAL_ROOT_ID} />
       </body>
     </html>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,10 +3,11 @@
 import type { Route } from "next";
 
 import Link from "next/link";
-import { useState } from "react";
+import { Suspense, useState } from "react";
 
 import GoogleIcon from "@/assets/google.svg";
 import { trackEvent } from "@/lib/posthog/client";
+import { DeferredPostHogBootstrap } from "@/lib/posthog/DeferredPostHogBootstrap";
 import { POSTHOG_EVENTS } from "@/lib/posthog/events";
 
 import { PublicHeader } from "../_components/PublicHeader";
@@ -51,54 +52,59 @@ function LoginPageContent() {
   };
 
   return (
-    <div className="flex h-dvh flex-col bg-muted/30">
-      <PublicHeader />
-      <div className="flex flex-1 flex-col items-center justify-center px-5 pb-20">
-        <div className="w-full max-w-sm rounded-[32px] border border-border/50 bg-background p-10 shadow-xl shadow-black/[0.03]">
-          <header className="mb-10 text-center">
-            <span className="text-[11px] font-bold tracking-[0.2em] text-primary uppercase">
-              Welcome
-            </span>
-            <h1 className="mt-3 text-[32px] font-extrabold tracking-tight text-foreground">
-              로그인
-            </h1>
-            <p className="mt-2 text-sm font-medium text-muted-foreground">
-              201 escape에 오신 것을 환영합니다.
-            </p>
-          </header>
-
-          <div className="space-y-4">
-            <button
-              className="flex w-full cursor-pointer items-center justify-center gap-3 rounded-2xl border border-border/60 bg-background px-4 py-4 text-[15px] font-bold text-foreground transition-all hover:border-primary/20 hover:bg-muted/30 active:scale-[0.98]"
-              disabled={isLoading}
-              onClick={handleGoogleLogin}
-              type="button"
-            >
-              <GoogleIcon className="h-5 w-5" />
-              <span>{isLoading ? "로그인 중..." : "Google로 계속하기"}</span>
-            </button>
-
-            {errorMessage && (
-              <p className="px-1 text-center text-sm font-medium text-destructive">
-                {errorMessage}
+    <>
+      <div className="flex h-dvh flex-col bg-muted/30">
+        <PublicHeader />
+        <div className="flex flex-1 flex-col items-center justify-center px-5 pb-20">
+          <div className="w-full max-w-sm rounded-[32px] border border-border/50 bg-background p-10 shadow-xl shadow-black/[0.03]">
+            <header className="mb-10 text-center">
+              <span className="text-[11px] font-bold tracking-[0.2em] text-primary uppercase">
+                Welcome
+              </span>
+              <h1 className="mt-3 text-[32px] font-extrabold tracking-tight text-foreground">
+                로그인
+              </h1>
+              <p className="mt-2 text-sm font-medium text-muted-foreground">
+                201 escape에 오신 것을 환영합니다.
               </p>
-            )}
+            </header>
 
-            <div className="flex justify-center px-1">
-              <p className="inline-flex flex-wrap items-center justify-center gap-x-1 text-center text-xs leading-5 text-muted-foreground">
-                <span>계속 진행하면</span>
-                <Link
-                  className="font-semibold text-primary underline underline-offset-4"
-                  href={PRIVACY_PAGE_HREF}
-                >
-                  개인정보처리방침
-                </Link>
-                <span>에 동의한 것으로 간주됩니다.</span>
-              </p>
+            <div className="space-y-4">
+              <button
+                className="flex w-full cursor-pointer items-center justify-center gap-3 rounded-2xl border border-border/60 bg-background px-4 py-4 text-[15px] font-bold text-foreground transition-all hover:border-primary/20 hover:bg-muted/30 active:scale-[0.98]"
+                disabled={isLoading}
+                onClick={handleGoogleLogin}
+                type="button"
+              >
+                <GoogleIcon className="h-5 w-5" />
+                <span>{isLoading ? "로그인 중..." : "Google로 계속하기"}</span>
+              </button>
+
+              {errorMessage && (
+                <p className="px-1 text-center text-sm font-medium text-destructive">
+                  {errorMessage}
+                </p>
+              )}
+
+              <div className="flex justify-center px-1">
+                <p className="inline-flex flex-wrap items-center justify-center gap-x-1 text-center text-xs leading-5 text-muted-foreground">
+                  <span>계속 진행하면</span>
+                  <Link
+                    className="font-semibold text-primary underline underline-offset-4"
+                    href={PRIVACY_PAGE_HREF}
+                  >
+                    개인정보처리방침
+                  </Link>
+                  <span>에 동의한 것으로 간주됩니다.</span>
+                </p>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+      <Suspense fallback={null}>
+        <DeferredPostHogBootstrap />
+      </Suspense>
+    </>
   );
 }

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,7 +1,5 @@
 import type { Metadata } from "next";
 
-import Link from "next/link";
-
 import { PublicHeader } from "../_components/PublicHeader";
 
 export const metadata: Metadata = {
@@ -176,12 +174,13 @@ export default function PrivacyPage() {
           </div>
 
           <footer className="mt-10 border-t border-border/60 pt-6">
-            <Link
+            {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- Public entrypoints intentionally avoid client navigation JS. */}
+            <a
               className="text-sm font-medium text-primary underline underline-offset-4"
               href="/"
             >
               홈으로 돌아가기
-            </Link>
+            </a>
           </footer>
         </div>
       </main>

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,10 +1,12 @@
 const isProd = process.env.NODE_ENV === "production";
 const sentryDsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+const PUBLIC_BROWSER_SENTRY_DISABLED_PATHS = new Set(["/", "/privacy"]);
 const shouldEnableBrowserSentry =
   process.env.NEXT_PUBLIC_ENABLE_BROWSER_SENTRY === "true" &&
   typeof window !== "undefined" &&
   typeof sentryDsn === "string" &&
-  sentryDsn.length > 0;
+  sentryDsn.length > 0 &&
+  !PUBLIC_BROWSER_SENTRY_DISABLED_PATHS.has(window.location.pathname);
 
 if (shouldEnableBrowserSentry) {
   const initializeBrowserSentry = () => {
@@ -12,7 +14,7 @@ if (shouldEnableBrowserSentry) {
       Sentry.init({
         dsn: sentryDsn,
         enableLogs: !isProd,
-        tracesSampleRate: isProd ? 0.1 : 1.0,
+        tracesSampleRate: 0,
       });
     });
   };

--- a/lib/actions/getApplicationDetail.ts
+++ b/lib/actions/getApplicationDetail.ts
@@ -59,6 +59,7 @@ export async function getApplicationDetail(
     if (code === "QUERY_ERROR") {
       reportQueryError("getApplicationDetail", reason);
     }
+
     return { code, ok: false, reason };
   }
 


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #280

## 📌 작업 내용

- applications layout 전역에 걸려 있던 ApplicationsProviders를 제거하고 목록/상세 페이지의 실제 react-query 사용 경계에만 적용
- applications 하위 전체 공용 클라이언트 비용이 되지 않도록 provider 책임 범위 정리
- 상세 페이지에서 getApplicationDetail 완료 전 전체 응답을 막지 않도록 Suspense 기반 스트리밍 경계와 스켈레톤 추가
- 상세 페이지 초기 응답 체감 개선을 위한 서버 렌더 구조 정리

