### PR TITLE
fix: 지원 상세 복귀 흐름 및 직접입력 화면 노출 조건 정리(#282)

### DIFF
--- a/app/(protected)/applications/[applicationId]/_components/ApplicationDetailHero.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/ApplicationDetailHero.tsx
@@ -36,7 +36,6 @@ type UpdateStatusAction = (
   input: UpdateApplicationStatusInput,
 ) => Promise<UpdateApplicationStatusResult>;
 
-const MANUAL_PLATFORM_LABEL = "직접 입력";
 const STATUS_PANEL_ANIMATION_DELAY = "120ms";
 
 export function ApplicationDetailHero({
@@ -45,19 +44,21 @@ export function ApplicationDetailHero({
   updateStatusAction,
 }: ApplicationDetailHeroProps) {
   const statusMeta = APPLICATION_STATUS_META[detail.status];
+  const isManualPlatform = detail.platform === "MANUAL";
   const hasOriginUrl =
     detail.originUrl !== null &&
     detail.originUrl.trim() !== "" &&
     !detail.originUrl.startsWith("manual:");
   const appliedAtLabel = detail.status === "SAVED" ? "저장일" : "지원일";
   const summaryItems: SummaryItem[] = [
-    {
-      label: "플랫폼",
-      value:
-        detail.platform === "MANUAL"
-          ? MANUAL_PLATFORM_LABEL
-          : PLATFORM_LABEL[detail.platform],
-    },
+    ...(!isManualPlatform
+      ? [
+          {
+            label: "플랫폼",
+            value: PLATFORM_LABEL[detail.platform],
+          },
+        ]
+      : []),
     {
       label: appliedAtLabel,
       value: formatAppliedAt(detail.appliedAt),

--- a/app/(protected)/applications/[applicationId]/page.tsx
+++ b/app/(protected)/applications/[applicationId]/page.tsx
@@ -93,6 +93,7 @@ async function ApplicationDetailContent({
   }
 
   const detail = result.data;
+  const shouldShowJobDescription = detail.platform !== "MANUAL";
 
   return (
     <main className="min-h-screen bg-[linear-gradient(180deg,rgba(245,245,245,0.9)_0%,rgba(255,255,255,0.82)_18%,rgba(255,255,255,1)_40%)] pb-20">
@@ -106,18 +107,21 @@ async function ApplicationDetailContent({
 
           <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(320px,0.82fr)]">
             <div className="order-2 grid gap-6 lg:order-1">
-              <DetailSectionPanel
-                className="motion-safe:animate-fade-up"
-                style={{
-                  animationDelay: DETAIL_PANEL_ANIMATION_DELAYS.jobDescription,
-                }}
-              >
-                <JobDescriptionEditor
-                  applicationId={detail.id}
-                  description={detail.description}
-                  updateDescriptionAction={updateJobDescription}
-                />
-              </DetailSectionPanel>
+              {shouldShowJobDescription ? (
+                <DetailSectionPanel
+                  className="motion-safe:animate-fade-up"
+                  style={{
+                    animationDelay:
+                      DETAIL_PANEL_ANIMATION_DELAYS.jobDescription,
+                  }}
+                >
+                  <JobDescriptionEditor
+                    applicationId={detail.id}
+                    description={detail.description}
+                    updateDescriptionAction={updateJobDescription}
+                  />
+                </DetailSectionPanel>
+              ) : null}
 
               <DetailSectionPanel
                 className="motion-safe:animate-fade-up"

--- a/app/(protected)/applications/_components/components/ApplicationPreviewSheet.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationPreviewSheet.tsx
@@ -55,6 +55,13 @@ type ApplicationPreviewState =
       status: "loading";
     };
 
+const DEFAULT_PREVIEW_BODY_MIN_HEIGHT_CLASS = "min-h-58";
+const DEFAULT_PREVIEW_SHEET_HEIGHT_CLASS = "min-h-[40vh]";
+const MANUAL_PREVIEW_BODY_MIN_HEIGHT_CLASS = "min-h-36";
+const MANUAL_PREVIEW_SHEET_HEIGHT_CLASS = "min-h-[30vh]";
+const DEFAULT_PREVIEW_SKELETON_COUNT = 2;
+const MANUAL_PREVIEW_SKELETON_COUNT = 1;
+
 export function ApplicationPreviewSheet({
   application,
   isOpen,
@@ -119,6 +126,11 @@ export function ApplicationPreviewSheet({
   const status = detail?.status ?? application?.status;
   const descriptionMeta = getDescriptionMeta(detail);
   const notesMeta = getNotesMeta(detail);
+  const isManualPlatform = platform === "MANUAL";
+  const shouldShowDescription = !isManualPlatform;
+  const previewSkeletonCount = isManualPlatform
+    ? MANUAL_PREVIEW_SKELETON_COUNT
+    : DEFAULT_PREVIEW_SKELETON_COUNT;
 
   const footerButtonContent = (
     <>
@@ -130,7 +142,13 @@ export function ApplicationPreviewSheet({
   return (
     <BottomSheet isOpen={isOpen} onClose={onCloseAction}>
       <BottomSheet.Overlay />
-      <BottomSheet.Content>
+      <BottomSheet.Content
+        className={
+          isManualPlatform
+            ? MANUAL_PREVIEW_SHEET_HEIGHT_CLASS
+            : DEFAULT_PREVIEW_SHEET_HEIGHT_CLASS
+        }
+      >
         <BottomSheet.Header />
         <div className="px-6 pb-4">
           {(platform || appliedAt) && (
@@ -179,7 +197,13 @@ export function ApplicationPreviewSheet({
           )}
 
           {/* min-h는 로딩→콘텐츠 전환 시 시트 높이 변동(레이아웃 시프트)을 방지합니다. */}
-          <div className="min-h-58">
+          <div
+            className={
+              isManualPlatform
+                ? MANUAL_PREVIEW_BODY_MIN_HEIGHT_CLASS
+                : DEFAULT_PREVIEW_BODY_MIN_HEIGHT_CLASS
+            }
+          >
             {visiblePreviewState.status === "loading" && (
               <div
                 aria-busy="true"
@@ -187,8 +211,11 @@ export function ApplicationPreviewSheet({
                 className="space-y-4"
                 role="status"
               >
-                <ApplicationPreviewSectionSkeleton />
-                <ApplicationPreviewSectionSkeleton />
+                {Array.from({ length: previewSkeletonCount }).map(
+                  (_, index) => (
+                    <ApplicationPreviewSectionSkeleton key={index} />
+                  ),
+                )}
               </div>
             )}
 
@@ -216,12 +243,16 @@ export function ApplicationPreviewSheet({
 
             {detail && (
               <>
-                <ApplicationPreviewSection
-                  body={descriptionMeta.text}
-                  icon={<FileTextIcon aria-hidden="true" className="size-4" />}
-                  isEmpty={descriptionMeta.isEmpty}
-                  title="공고 설명"
-                />
+                {shouldShowDescription ? (
+                  <ApplicationPreviewSection
+                    body={descriptionMeta.text}
+                    icon={
+                      <FileTextIcon aria-hidden="true" className="size-4" />
+                    }
+                    isEmpty={descriptionMeta.isEmpty}
+                    title="공고 설명"
+                  />
+                ) : null}
                 <ApplicationPreviewSection
                   body={notesMeta.text}
                   icon={

--- a/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
@@ -9,7 +9,7 @@ import {
 } from "@tanstack/react-query";
 import dynamic from "next/dynamic";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import type { GetApplicationsPage } from "@/lib/types/application";
 import type { JobStatus } from "@/lib/types/job";
@@ -59,9 +59,11 @@ export function ApplicationsPanel({ dateLabel }: ApplicationsPanelProps) {
 
   const tabsRef = useRef<ApplicationTabsHandle>(null);
   const [isListScrolled, setIsListScrolled] = useState(false);
-  const [shouldRenderPreviewSheet, setShouldRenderPreviewSheet] = useState(
-    selectedPreviewExists(searchParams.get(PREVIEW_PARAM)),
-  );
+  const [previewApplicationId, setPreviewApplicationId] = useState<
+    null | string
+  >(null);
+  const [shouldRenderPreviewSheet, setShouldRenderPreviewSheet] =
+    useState(false);
 
   const search = searchParams.get(SEARCH_PARAM) ?? "";
   const period = parsePeriodParam(searchParams.get(PERIOD_PARAM));
@@ -96,10 +98,27 @@ export function ApplicationsPanel({ dateLabel }: ApplicationsPanelProps) {
     (page) => page.items,
   );
 
-  const selectedApplicationId = searchParams.get(PREVIEW_PARAM);
+  const selectedApplicationId = previewApplicationId;
   const isPreviewOpen = selectedApplicationId !== null;
   const selectedApplication =
     applications.find((a) => a.id === selectedApplicationId) ?? null;
+
+  useEffect(() => {
+    const previewParam = searchParams.get(PREVIEW_PARAM);
+
+    if (!previewParam) {
+      return;
+    }
+
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete(PREVIEW_PARAM);
+    const query = params.toString();
+
+    router.replace(
+      `${pathname}${query ? `?${query}` : ""}` as unknown as Route,
+      { scroll: false },
+    );
+  }, [pathname, router, searchParams]);
 
   const updateParams = (updates: Record<string, string>) => {
     const params = new URLSearchParams(searchParams.toString());
@@ -118,27 +137,28 @@ export function ApplicationsPanel({ dateLabel }: ApplicationsPanelProps) {
   };
 
   const handleSearchSubmit = (nextSearch: string) => {
-    updateParams({ [PREVIEW_PARAM]: "", [SEARCH_PARAM]: nextSearch });
+    setPreviewApplicationId(null);
+    updateParams({ [SEARCH_PARAM]: nextSearch });
   };
 
   const handlePeriodChange = (nextPeriod: PeriodPreset) => {
+    setPreviewApplicationId(null);
     updateParams({
       [PERIOD_PARAM]: nextPeriod === "all" ? "" : nextPeriod,
-      [PREVIEW_PARAM]: "",
     });
   };
 
   const handleSortChange = (nextSort: SortValue) => {
+    setPreviewApplicationId(null);
     updateParams({
-      [PREVIEW_PARAM]: "",
       [SORT_PARAM]: nextSort === "applied_at_desc" ? "" : nextSort,
     });
   };
 
   const handleResetFilters = () => {
+    setPreviewApplicationId(null);
     updateParams({
       [PERIOD_PARAM]: "",
-      [PREVIEW_PARAM]: "",
       [SEARCH_PARAM]: "",
       [SORT_PARAM]: "",
       [TAB_PARAM]: "",
@@ -146,19 +166,19 @@ export function ApplicationsPanel({ dateLabel }: ApplicationsPanelProps) {
   };
 
   const handleTabChange = (nextTab: TabValue) => {
+    setPreviewApplicationId(null);
     updateParams({
-      [PREVIEW_PARAM]: "",
       [TAB_PARAM]: nextTab === "all" ? "" : nextTab,
     });
   };
 
   const handleSelectApplication = (application: ApplicationListItem) => {
     setShouldRenderPreviewSheet(true);
-    updateParams({ [PREVIEW_PARAM]: application.id });
+    setPreviewApplicationId(application.id);
   };
 
   const handleClosePreview = () => {
-    updateParams({ [PREVIEW_PARAM]: "" });
+    setPreviewApplicationId(null);
   };
 
   const handleStatusChange = (applicationId: string, nextStatus: JobStatus) => {
@@ -242,8 +262,4 @@ export function ApplicationsPanel({ dateLabel }: ApplicationsPanelProps) {
       />
     </div>
   );
-}
-
-function selectedPreviewExists(value: null | string) {
-  return value !== null;
 }

--- a/app/(protected)/dashboard/_components/dashboard-view/DashboardOverview.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DashboardOverview.tsx
@@ -52,11 +52,17 @@ export function DashboardOverview({ stats }: DashboardOverviewProps) {
                 지원 완료 건수
               </p>
             </div>
-            <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
-              전체 등록 {total}건 중 관심 공고 {saved}건을 제외한 실제 지원
-              건수입니다. 현재 서류 단계 {docs}건, 면접 단계 {interviewing}건,
-              합격 단계 {offered}건입니다.
-            </p>
+            <div className="max-w-2xl text-sm leading-6 text-muted-foreground">
+              <p className="break-keep">
+                전체 등록 {total}건 중 관심 공고 {saved}건을 제외한 실제 지원
+                건수입니다.
+              </p>
+              <p className="break-keep">
+                현재 서류 단계 {docs}건, 면접 단계 {interviewing}건, 합격 단계{" "}
+                {offered}
+                건입니다.
+              </p>
+            </div>
           </div>
 
           <dl className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -23,8 +23,12 @@ export default function DashboardPage() {
                 지원 대시보드
               </h1>
               <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
-                전체 파이프라인 규모, 최근 12개월 지원 추이, 단계별 전환 흐름을
-                한 화면에서 확인합니다.
+                <span className="block break-keep">
+                  전체 파이프라인 규모, 최근 12개월 지원 추이,
+                </span>
+                <span className="block break-keep">
+                  단계별 전환 흐름을 한 화면에서 확인합니다.
+                </span>
               </p>
             </div>
 


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #282

## 📌 작업 내용

- 지원 목록 미리보기 시트 상태를 URL query가 아닌 로컬 상태로 관리해 상세 페이지에서 뒤로가기 시 목록만 복귀되도록 정리
- legacy preview query가 남아 있어도 목록 진입 시 즉시 제거되도록 처리
- 직접입력 지원 상세에서 공고 설명 패널과 플랫폼 요약 카드가 노출되지 않도록 분기 추가
- 지원 미리보기 바텀시트에서 직접입력일 때 공고 설명 섹션이 보이지 않도록 정리
- 지원 미리보기 바텀시트 높이를 플랫폼에 따라 분기하고 직접입력 로딩 스켈레톤 높이도 함께 맞춰 초기 높이 튐을 완화
- dashboard 요약 문구를 두 줄 구조와 단어 단위 줄바꿈 기준에 맞게 정리


