### PR TITLE
fix: 지원 상세 이동 시 스크롤 최상단 복원 안 되는 버그 수정(#289)

### DIFF
--- a/hooks/useScrollLock.ts
+++ b/hooks/useScrollLock.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+import { useEffect, useEffectEvent } from "react";
 
 // 여러 컴포넌트가 동시에 scroll lock을 요청할 때 올바르게 관리하기 위한 Set
 const scrollLockOwners = new Set<object>();
@@ -9,12 +10,17 @@ const scrollLockOwners = new Set<object>();
 let lockState: null | { paddingRight: string; scrollY: number } = null;
 
 export const useScrollLock = (isActive: boolean) => {
+  const pathname = usePathname();
+  const getLatestPathname = useEffectEvent(() => pathname);
+
   useEffect(() => {
     if (!isActive) {
       return;
     }
 
     const token = {};
+    // lock 획득 시점의 경로를 캡처 — cleanup 시 페이지 이동 여부 판단에 사용
+    const acquiredPathname = getLatestPathname();
     scrollLockOwners.add(token);
 
     if (scrollLockOwners.size === 1) {
@@ -46,7 +52,11 @@ export const useScrollLock = (isActive: boolean) => {
         document.body.style.overscrollBehavior = "";
         document.body.style.paddingRight = paddingRight;
 
-        window.scrollTo(0, scrollY);
+        // 페이지가 변경된 경우 최상단으로, 동일 페이지면 원래 위치로 복원
+        window.scrollTo(
+          0,
+          getLatestPathname() !== acquiredPathname ? 0 : scrollY,
+        );
       }
     };
   }, [isActive]);


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #289

## 📌 작업 내용

- BottomSheet가 열린 채로 페이지를 이동하면 scroll lock cleanup이 기존 scrollY를 복원해 페이지가 중간 위치로 내려가는 문제 수정
- scroll lock 해제 시 lock 획득 시점 경로와 현재 경로를 비교해, 페이지가 변경된 경우 기존 scrollY 대신 최상단(0)으로 복원하도록 수정


