### PR TITLE
release: 헤더 테마 토글, 다크모드 UI 정리, 상세 이동 스크롤 복원

### DIFF
--- a/app/(protected)/_components/Header.tsx
+++ b/app/(protected)/_components/Header.tsx
@@ -1,5 +1,6 @@
 import { LogOutIcon } from "lucide-react";
 
+import { HeaderActions } from "@/app/_components/HeaderActions";
 import { Button } from "@/components/ui/button/Button";
 import { signOut } from "@/lib/actions/signOut";
 
@@ -33,17 +34,20 @@ export function Header() {
             </ul>
           </nav>
         </div>
-        <form action={signOut}>
-          <Button
-            aria-label="로그아웃"
-            size="icon"
-            title="로그아웃"
-            type="submit"
-            variant="ghost"
-          >
-            <LogOutIcon aria-hidden="true" />
-          </Button>
-        </form>
+        <div className="flex items-center gap-2">
+          <HeaderActions />
+          <form action={signOut}>
+            <Button
+              aria-label="로그아웃"
+              size="icon"
+              title="로그아웃"
+              type="submit"
+              variant="ghost"
+            >
+              <LogOutIcon aria-hidden="true" />
+            </Button>
+          </form>
+        </div>
       </div>
     </header>
   );

--- a/app/(protected)/applications/[applicationId]/_components/ApplicationDetailHero.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/ApplicationDetailHero.tsx
@@ -1,3 +1,5 @@
+import type { CSSProperties } from "react";
+
 import { ExternalLinkIcon } from "lucide-react";
 
 import type {
@@ -38,6 +40,11 @@ type UpdateStatusAction = (
 
 const STATUS_PANEL_ANIMATION_DELAY = "120ms";
 
+const HERO_OVERLAY_STYLE: CSSProperties = {
+  backgroundImage:
+    "radial-gradient(circle at top left, color-mix(in srgb, var(--color-primary) 16%, transparent) 0%, transparent 36%), linear-gradient(180deg, color-mix(in srgb, var(--color-muted) 78%, transparent) 0%, color-mix(in srgb, var(--color-background) 88%, transparent) 42%, var(--color-background) 100%)",
+};
+
 export function ApplicationDetailHero({
   deleteAction,
   detail,
@@ -71,7 +78,7 @@ export function ApplicationDetailHero({
 
   return (
     <section className="relative overflow-hidden rounded-[32px] border border-border/60 bg-background shadow-[0_36px_120px_-64px_rgba(23,23,23,0.45)] motion-safe:animate-fade-in">
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(64,81,59,0.14),transparent_36%),linear-gradient(180deg,rgba(245,245,245,0.95),rgba(255,255,255,0.82)_42%,rgba(255,255,255,1))]" />
+      <div className="absolute inset-0" style={HERO_OVERLAY_STYLE} />
       <div className="relative grid gap-8 p-5 sm:p-8 lg:grid-cols-[minmax(0,1fr)_minmax(300px,360px)] lg:gap-10">
         <div className="space-y-8 motion-safe:animate-fade-up">
           <div className="flex items-center justify-between gap-3">

--- a/app/(protected)/applications/[applicationId]/page.tsx
+++ b/app/(protected)/applications/[applicationId]/page.tsx
@@ -1,5 +1,5 @@
 import { FileTextIcon, LockKeyholeIcon } from "lucide-react";
-import { Suspense } from "react";
+import { type CSSProperties, Suspense } from "react";
 
 import { ApplicationsProviders } from "@/app/(protected)/applications/ApplicationsProviders";
 import { Skeleton } from "@/components/ui";
@@ -27,6 +27,11 @@ const DETAIL_PANEL_ANIMATION_DELAYS = {
   jobDescription: "160ms",
   memo: "220ms",
 } as const;
+
+const DETAIL_PAGE_BACKGROUND_STYLE: CSSProperties = {
+  backgroundImage:
+    "linear-gradient(180deg, color-mix(in srgb, var(--color-muted) 72%, transparent) 0%, color-mix(in srgb, var(--color-background) 88%, transparent) 18%, var(--color-background) 40%)",
+};
 
 const ERROR_STATE_META = {
   AUTH_REQUIRED: {
@@ -96,7 +101,10 @@ async function ApplicationDetailContent({
   const shouldShowJobDescription = detail.platform !== "MANUAL";
 
   return (
-    <main className="min-h-screen bg-[linear-gradient(180deg,rgba(245,245,245,0.9)_0%,rgba(255,255,255,0.82)_18%,rgba(255,255,255,1)_40%)] pb-20">
+    <main
+      className="min-h-screen bg-background pb-20"
+      style={DETAIL_PAGE_BACKGROUND_STYLE}
+    >
       <ApplicationsProviders>
         <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
           <ApplicationDetailHero
@@ -158,7 +166,10 @@ async function ApplicationDetailContent({
 
 function ApplicationDetailPageSkeleton() {
   return (
-    <main className="min-h-screen bg-[linear-gradient(180deg,rgba(245,245,245,0.9)_0%,rgba(255,255,255,0.82)_18%,rgba(255,255,255,1)_40%)] pb-20">
+    <main
+      className="min-h-screen bg-background pb-20"
+      style={DETAIL_PAGE_BACKGROUND_STYLE}
+    >
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
         <section
           aria-busy="true"

--- a/app/(protected)/applications/_components/components/ApplicationPreviewSheet.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationPreviewSheet.tsx
@@ -266,7 +266,7 @@ export function ApplicationPreviewSheet({
           </div>
         </BottomSheet.Body>
 
-        <div className="border-t border-border bg-white px-6 py-4">
+        <div className="border-t border-border bg-background px-6 py-4">
           {application ? (
             <Button
               asChild

--- a/app/_components/HeaderActions.tsx
+++ b/app/_components/HeaderActions.tsx
@@ -1,0 +1,24 @@
+import GitHubIcon from "@/assets/github.svg";
+import { Button } from "@/components/ui/button/Button";
+
+import { ThemeToggle } from "./ThemeToggle";
+
+const GITHUB_REPOSITORY_URL = "https://github.com/quartzs2/201-escape";
+
+export function HeaderActions() {
+  return (
+    <div className="flex items-center gap-2">
+      <ThemeToggle />
+      <Button asChild size="icon" variant="ghost">
+        <a
+          aria-label="GitHub 저장소"
+          href={GITHUB_REPOSITORY_URL}
+          rel="noreferrer"
+          target="_blank"
+        >
+          <GitHubIcon className="size-4" />
+        </a>
+      </Button>
+    </div>
+  );
+}

--- a/app/_components/PublicHeader.tsx
+++ b/app/_components/PublicHeader.tsx
@@ -1,43 +1,25 @@
 import { LogInIcon } from "lucide-react";
 
-import GitHubIcon from "@/assets/github.svg";
 import { Button } from "@/components/ui/button/Button";
+
+import { HeaderActions } from "./HeaderActions";
 
 export function PublicHeader() {
   return (
-    <header className="sticky top-0 z-20 border-b border-[#40513b]/10 bg-white/90 px-6 py-4 text-[#192016] backdrop-blur-xl lg:px-10">
+    <header className="sticky top-0 z-20 border-b border-border bg-background/90 px-6 py-4 text-foreground backdrop-blur-xl lg:px-10">
       <div className="mx-auto flex max-w-7xl items-center justify-between gap-4">
         {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- Public entrypoints intentionally avoid client navigation JS. */}
         <a
-          className="text-base font-bold tracking-[-0.03em] text-[#192016]"
+          className="text-base font-bold tracking-[-0.03em] text-foreground"
           href="/"
         >
           201 escape
         </a>
 
         <div className="flex items-center gap-2">
-          <Button
-            asChild
-            className="h-9 w-9 rounded-full border border-[#40513b]/14 bg-white text-[#192016] hover:bg-[#eef1eb]"
-            size="icon"
-            variant="outline"
-          >
-            <a
-              aria-label="GitHub 저장소"
-              href="https://github.com/quartzs2/201-escape"
-              rel="noreferrer"
-              target="_blank"
-            >
-              <GitHubIcon className="size-4" />
-            </a>
-          </Button>
-          <Button
-            asChild
-            className="h-9 rounded-full bg-[#40513b] px-3.5 text-white hover:bg-[#354230]"
-            size="sm"
-          >
-            <a href="/login">
-              시작하기
+          <HeaderActions />
+          <Button asChild size="icon" title="로그인" variant="ghost">
+            <a aria-label="로그인" href="/login">
               <LogInIcon className="size-4" />
             </a>
           </Button>

--- a/app/_components/ThemeScript.tsx
+++ b/app/_components/ThemeScript.tsx
@@ -1,0 +1,23 @@
+import { THEME_STORAGE_KEY } from "@/lib/constants/theme";
+
+const themeScript = `
+  (() => {
+    try {
+      const storedTheme = window.localStorage.getItem("${THEME_STORAGE_KEY}");
+      const systemPrefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      const theme = storedTheme === "light" || storedTheme === "dark"
+        ? storedTheme
+        : systemPrefersDark
+          ? "dark"
+          : "light";
+
+      document.documentElement.dataset.theme = theme;
+    } catch {
+      document.documentElement.dataset.theme = "light";
+    }
+  })();
+`;
+
+export function ThemeScript() {
+  return <script dangerouslySetInnerHTML={{ __html: themeScript }} />;
+}

--- a/app/_components/ThemeToggle.tsx
+++ b/app/_components/ThemeToggle.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { MoonIcon, SunIcon } from "lucide-react";
+import { useSyncExternalStore } from "react";
+
+import { Button } from "@/components/ui/button/Button";
+import { type Theme, THEME_STORAGE_KEY } from "@/lib/constants/theme";
+
+const DEFAULT_THEME: Theme = "light";
+
+export function ThemeToggle() {
+  const theme = useSyncExternalStore(
+    subscribeToThemeChange,
+    readThemeFromDocument,
+    getServerThemeSnapshot,
+  );
+  const isDark = theme === "dark";
+
+  const handleToggleTheme = () => {
+    const nextTheme = getNextTheme(theme);
+
+    document.documentElement.dataset.theme = nextTheme;
+    window.localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+    window.dispatchEvent(new CustomEvent("theme-change"));
+  };
+
+  return (
+    <Button
+      aria-label={isDark ? "라이트 모드로 전환" : "다크 모드로 전환"}
+      onClick={handleToggleTheme}
+      size="icon"
+      title={isDark ? "라이트 모드" : "다크 모드"}
+      variant="ghost"
+    >
+      {isDark ? (
+        <SunIcon aria-hidden="true" />
+      ) : (
+        <MoonIcon aria-hidden="true" />
+      )}
+    </Button>
+  );
+}
+
+function getNextTheme(theme: Theme) {
+  if (theme === "light") {
+    return "dark";
+  }
+
+  return "light";
+}
+
+function getServerThemeSnapshot(): Theme {
+  return DEFAULT_THEME;
+}
+
+function readThemeFromDocument(): Theme {
+  const theme = document.documentElement.dataset.theme;
+
+  if (theme === "dark") {
+    return "dark";
+  }
+
+  return DEFAULT_THEME;
+}
+
+function subscribeToThemeChange(onStoreChange: () => void) {
+  window.addEventListener("theme-change", onStoreChange);
+
+  return () => {
+    window.removeEventListener("theme-change", onStoreChange);
+  };
+}

--- a/app/_components/landing/FeaturesSection.tsx
+++ b/app/_components/landing/FeaturesSection.tsx
@@ -3,32 +3,32 @@ import { landingFeatures } from "./utils/content";
 export function FeaturesSection() {
   return (
     <section
-      className="border-t border-black/6 bg-white py-16 text-[#192016] lg:py-18"
+      className="border-t border-border bg-background py-16 text-foreground lg:py-18"
       id="features"
     >
       <div className="mx-auto max-w-7xl px-6 lg:px-10">
         <header className="max-w-2xl">
-          <p className="text-sm font-semibold tracking-[0.24em] text-[#667064] uppercase">
+          <p className="text-sm font-semibold tracking-[0.24em] text-muted-foreground uppercase">
             기능
           </p>
           <h2 className="mt-4 text-[2rem] leading-[1.08] font-black tracking-[-0.05em] text-balance sm:text-[2.6rem]">
             필요한 기능만 간단하게 담았습니다.
           </h2>
-          <p className="mt-5 text-base leading-7 text-[#5f675c]">
+          <p className="mt-5 text-base leading-7 text-muted-foreground">
             공고, 일정, 현황처럼 자주 보는 정보만 담았습니다.
           </p>
         </header>
 
-        <ul className="mt-10 grid gap-8 border-t border-black/6 pt-8 md:grid-cols-3">
+        <ul className="mt-10 grid gap-8 border-t border-border pt-8 md:grid-cols-3">
           {landingFeatures.map(({ description, icon: Icon, title }) => (
             <li key={title}>
-              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#f3f4f1] text-[#364133]">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-secondary text-primary">
                 <Icon aria-hidden="true" className="size-5" />
               </div>
-              <h3 className="mt-4 text-lg font-bold tracking-[-0.03em] text-[#192016]">
+              <h3 className="mt-4 text-lg font-bold tracking-[-0.03em] text-foreground">
                 {title}
               </h3>
-              <p className="mt-3 text-sm leading-6 text-[#5f675c]">
+              <p className="mt-3 text-sm leading-6 text-muted-foreground">
                 {description}
               </p>
             </li>

--- a/app/_components/landing/FinalCtaSection.tsx
+++ b/app/_components/landing/FinalCtaSection.tsx
@@ -4,23 +4,23 @@ import { Button } from "@/components/ui/button/Button";
 
 export function FinalCtaSection() {
   return (
-    <section className="border-t border-[#40513b]/10 bg-white py-16 text-[#192016] lg:py-18">
+    <section className="border-t border-border bg-background py-16 text-foreground lg:py-18">
       <div className="mx-auto flex max-w-7xl flex-col gap-6 px-6 sm:flex-row sm:items-end sm:justify-between lg:px-10">
         <div className="max-w-xl">
-          <p className="text-sm font-semibold tracking-[0.24em] text-[#40513b]/70 uppercase">
+          <p className="text-sm font-semibold tracking-[0.24em] text-primary uppercase">
             시작하기
           </p>
           <h2 className="mt-4 text-[2rem] leading-[1.08] font-black tracking-[-0.05em] text-balance sm:text-[2.6rem]">
             흩어진 지원 기록을 한곳에 모아보세요.
           </h2>
-          <p className="mt-4 text-sm leading-6 text-[#4f594b]">
+          <p className="mt-4 text-sm leading-6 text-muted-foreground">
             지금 바로 로그인해서 공고와 일정을 정리할 수 있습니다.
           </p>
         </div>
 
         <Button
           asChild
-          className="h-[3.25rem] w-full rounded-full bg-[#40513b] px-7 text-sm font-bold text-white hover:bg-[#354230] focus-visible:ring-[#40513b] sm:w-auto"
+          className="h-[3.25rem] w-full rounded-full px-7 text-sm font-bold sm:w-auto"
         >
           <a href="/login">
             로그인하고 시작하기

--- a/app/_components/landing/HeroSection.tsx
+++ b/app/_components/landing/HeroSection.tsx
@@ -7,27 +7,27 @@ const HERO_ANIMATION_DELAYS = {
 
 export function HeroSection() {
   return (
-    <section className="bg-white">
+    <section className="bg-background">
       <div className="mx-auto flex min-h-[calc(100svh-4.5rem)] max-w-7xl items-center px-6 py-20 lg:px-10">
         <div className="max-w-2xl">
-          <p className="animate-fade-up text-sm font-semibold tracking-[0.24em] text-[#40513b]/80 uppercase">
+          <p className="animate-fade-up text-sm font-semibold tracking-[0.24em] text-primary uppercase">
             201 escape
           </p>
           <p
-            className="mt-4 animate-fade-up text-sm text-[#4f594b]"
+            className="mt-4 animate-fade-up text-sm text-muted-foreground"
             style={{ animationDelay: HERO_ANIMATION_DELAYS.intro }}
           >
             공고, 지원 단계, 면접 일정을 한곳에서 정리합니다.
           </p>
           <h1
-            className="mt-5 animate-fade-up text-[2.7rem] leading-[1.02] font-black tracking-[-0.05em] text-balance text-[#192016] sm:text-[3.6rem] lg:text-[4.2rem]"
+            className="mt-5 animate-fade-up text-[2.7rem] leading-[1.02] font-black tracking-[-0.05em] text-balance text-foreground sm:text-[3.6rem] lg:text-[4.2rem]"
             style={{ animationDelay: HERO_ANIMATION_DELAYS.heading }}
           >
             지원 흐름을
             <br />더 쉽게 정리하세요.
           </h1>
           <p
-            className="mt-6 max-w-xl animate-fade-up text-base leading-7 text-[#4f594b]"
+            className="mt-6 max-w-xl animate-fade-up text-base leading-7 text-muted-foreground"
             style={{ animationDelay: HERO_ANIMATION_DELAYS.summary }}
           >
             저장한 공고와 현재 상태, 예정된 면접 일정을 한 화면에서 확인할 수
@@ -35,7 +35,7 @@ export function HeroSection() {
           </p>
 
           <ul
-            className="mt-10 grid animate-fade-up gap-3 border-t border-[#40513b]/10 pt-6 text-sm text-[#4f594b] sm:grid-cols-3"
+            className="mt-10 grid animate-fade-up gap-3 border-t border-border pt-6 text-sm text-muted-foreground sm:grid-cols-3"
             style={{ animationDelay: HERO_ANIMATION_DELAYS.list }}
           >
             <li>공고를 저장하고 단계별로 관리</li>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,14 @@
 @import "tailwindcss";
 
 @layer base {
+  html {
+    color-scheme: light;
+  }
+
+  html[data-theme="dark"] {
+    color-scheme: dark;
+  }
+
   html,
   body {
     width: 100%;
@@ -49,6 +57,26 @@
   --animate-slide-up: slide-up 0.5s ease-out both;
 }
 
+@layer base {
+  html[data-theme="dark"] {
+    --color-background: #16171a;
+    --color-foreground: #f3f1ec;
+    --color-primary: #9db58d;
+    --color-primary-foreground: #0f140f;
+    --color-secondary: #202228;
+    --color-secondary-foreground: #f3f1ec;
+    --color-destructive: #f87171;
+    --color-destructive-foreground: #1f1111;
+    --color-muted: #1a1c21;
+    --color-muted-foreground: #abaeb8;
+    --color-accent: #262930;
+    --color-accent-foreground: #f3f1ec;
+    --color-border: #31343c;
+    --color-input: #31343c;
+    --color-ring: #9db58d;
+  }
+}
+
 @keyframes slide-up {
   from {
     transform: translateY(16px);
@@ -81,4 +109,12 @@
 .bg-dot-pattern {
   background-image: radial-gradient(circle, #40513b18 1px, transparent 1px);
   background-size: 24px 24px;
+}
+
+html[data-theme="dark"] .bg-dot-pattern {
+  background-image: radial-gradient(
+    circle,
+    rgb(157 181 141 / 0.14) 1px,
+    transparent 1px
+  );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import localFont from "next/font/local";
 
 import { PORTAL_ROOT_ID } from "@/lib/constants/dom";
 
+import { ThemeScript } from "./_components/ThemeScript";
 import "./globals.css";
 
 const DEFAULT_SITE_URL = "https://201-escape.vercel.app";
@@ -51,7 +52,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ko">
+    <html lang="ko" suppressHydrationWarning>
+      <head>
+        <ThemeScript />
+      </head>
       <body className={`${pretendard.className} antialiased`}>
         {children}
         <div id={PORTAL_ROOT_ID} />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import { PublicHeader } from "./_components/PublicHeader";
 
 export default function Home() {
   return (
-    <div className="flex min-h-dvh flex-col bg-white text-[#192016]">
+    <div className="flex min-h-dvh flex-col bg-background text-foreground">
       <PublicHeader />
       <main className="flex-1">
         <HeroSection />

--- a/hooks/useScrollLock.ts
+++ b/hooks/useScrollLock.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+import { useEffect, useEffectEvent } from "react";
 
 // 여러 컴포넌트가 동시에 scroll lock을 요청할 때 올바르게 관리하기 위한 Set
 const scrollLockOwners = new Set<object>();
@@ -9,12 +10,17 @@ const scrollLockOwners = new Set<object>();
 let lockState: null | { paddingRight: string; scrollY: number } = null;
 
 export const useScrollLock = (isActive: boolean) => {
+  const pathname = usePathname();
+  const getLatestPathname = useEffectEvent(() => pathname);
+
   useEffect(() => {
     if (!isActive) {
       return;
     }
 
     const token = {};
+    // lock 획득 시점의 경로를 캡처 — cleanup 시 페이지 이동 여부 판단에 사용
+    const acquiredPathname = getLatestPathname();
     scrollLockOwners.add(token);
 
     if (scrollLockOwners.size === 1) {
@@ -46,7 +52,11 @@ export const useScrollLock = (isActive: boolean) => {
         document.body.style.overscrollBehavior = "";
         document.body.style.paddingRight = paddingRight;
 
-        window.scrollTo(0, scrollY);
+        // 페이지가 변경된 경우 최상단으로, 동일 페이지면 원래 위치로 복원
+        window.scrollTo(
+          0,
+          getLatestPathname() !== acquiredPathname ? 0 : scrollY,
+        );
       }
     };
   }, [isActive]);

--- a/lib/constants/theme.ts
+++ b/lib/constants/theme.ts
@@ -1,0 +1,3 @@
+export const THEME_STORAGE_KEY = "201-escape-theme";
+
+export type Theme = "dark" | "light";


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #289, #291

## 📌 작업 내용

- BottomSheet가 열린 상태에서 지원 상세 페이지로 이동할 때 기존 scrollY가 복원되며 화면이 중간 위치로 내려가던 문제를 수정하고, 경로 변경 시 최상단으로 복원되도록 정리
- 보호/공개 헤더에 공용 `HeaderActions`를 도입하고 GitHub 아이콘과 테마 토글을 일관된 액션 영역으로 통합
- `ThemeScript`와 `ThemeToggle`을 추가해 localStorage와 시스템 테마를 반영하는 전역 라이트/다크 모드 초기화 및 전환 흐름을 적용
- `globals.css`의 색상 토큰을 다크 테마까지 확장하고, 랜딩 페이지와 지원 상세 페이지가 토큰 기반 배경/텍스트 스타일을 사용하도록 정리
- 공개 헤더 로그인 버튼을 아이콘 전용으로 다듬고, 지원 상세/미리보기 영역의 하드코딩된 라이트 스타일을 제거해 테마 일관성을 맞춤