### PR TITLE
fix: 테마 스크립트 개선 및 iOS 모바일 버그 수정(#294)

### DIFF
--- a/app/(protected)/applications/[applicationId]/_components/MemoEditor.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/MemoEditor.tsx
@@ -147,7 +147,7 @@ export function MemoEditor({
         <div className="space-y-3">
           <textarea
             aria-labelledby={`memo-label-${applicationId}`}
-            className="min-h-40 w-full resize-none rounded-2xl border border-input bg-background px-4 py-3 text-sm leading-relaxed text-foreground transition-colors placeholder:text-muted-foreground focus:ring-2 focus:ring-ring focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            className="min-h-40 w-full resize-none rounded-2xl border border-input bg-background px-4 py-3 text-base leading-relaxed text-foreground transition-colors placeholder:text-muted-foreground focus:ring-2 focus:ring-ring focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 sm:text-sm"
             disabled={mutation.isPending}
             onChange={(e) => setDraftText(e.target.value)}
             placeholder="메모를 입력하세요"

--- a/app/(protected)/applications/_components/components/ApplicationFilters.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationFilters.tsx
@@ -76,7 +76,7 @@ export function ApplicationFilters({
               />
               <input
                 aria-label="회사명 검색"
-                className="w-full rounded-2xl border border-border bg-muted/40 py-3 pr-11 pl-11 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary/50 focus:ring-2 focus:ring-primary/10 focus:outline-none"
+                className="w-full rounded-2xl border border-border bg-muted/40 py-3 pr-11 pl-11 text-base text-foreground placeholder:text-muted-foreground focus:border-primary/50 focus:ring-2 focus:ring-primary/10 focus:outline-none sm:text-sm"
                 id="applications-company-search"
                 onChange={handleChange}
                 placeholder="회사명으로 현재 목록 좁히기"

--- a/app/_components/ThemeScript.tsx
+++ b/app/_components/ThemeScript.tsx
@@ -1,23 +1,28 @@
-import { THEME_STORAGE_KEY } from "@/lib/constants/theme";
+import { THEME_DATA_ATTRIBUTE, THEME_STORAGE_KEY } from "@/lib/constants/theme";
 
 const themeScript = `
   (() => {
+    const systemTheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
     try {
       const storedTheme = window.localStorage.getItem("${THEME_STORAGE_KEY}");
-      const systemPrefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-      const theme = storedTheme === "light" || storedTheme === "dark"
-        ? storedTheme
-        : systemPrefersDark
-          ? "dark"
-          : "light";
-
-      document.documentElement.dataset.theme = theme;
+      let theme;
+      if (storedTheme === "light" || storedTheme === "dark") {
+        theme = storedTheme;
+      } else {
+        theme = systemTheme;
+      }
+      document.documentElement.dataset["${THEME_DATA_ATTRIBUTE}"] = theme;
     } catch {
-      document.documentElement.dataset.theme = "light";
+      document.documentElement.dataset["${THEME_DATA_ATTRIBUTE}"] = systemTheme;
     }
   })();
 `;
 
 export function ThemeScript() {
-  return <script dangerouslySetInnerHTML={{ __html: themeScript }} />;
+  return (
+    <script
+      dangerouslySetInnerHTML={{ __html: themeScript }}
+      suppressHydrationWarning
+    />
+  );
 }

--- a/app/_components/ThemeToggle.tsx
+++ b/app/_components/ThemeToggle.tsx
@@ -4,7 +4,11 @@ import { MoonIcon, SunIcon } from "lucide-react";
 import { useSyncExternalStore } from "react";
 
 import { Button } from "@/components/ui/button/Button";
-import { type Theme, THEME_STORAGE_KEY } from "@/lib/constants/theme";
+import {
+  type Theme,
+  THEME_DATA_ATTRIBUTE,
+  THEME_STORAGE_KEY,
+} from "@/lib/constants/theme";
 
 const DEFAULT_THEME: Theme = "light";
 
@@ -19,7 +23,7 @@ export function ThemeToggle() {
   const handleToggleTheme = () => {
     const nextTheme = getNextTheme(theme);
 
-    document.documentElement.dataset.theme = nextTheme;
+    document.documentElement.dataset[THEME_DATA_ATTRIBUTE] = nextTheme;
     window.localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
     window.dispatchEvent(new CustomEvent("theme-change"));
   };
@@ -54,7 +58,7 @@ function getServerThemeSnapshot(): Theme {
 }
 
 function readThemeFromDocument(): Theme {
-  const theme = document.documentElement.dataset.theme;
+  const theme = document.documentElement.dataset[THEME_DATA_ATTRIBUTE];
 
   if (theme === "dark") {
     return "dark";

--- a/hooks/useScrollLock.ts
+++ b/hooks/useScrollLock.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname } from "next/navigation";
-import { useEffect, useEffectEvent } from "react";
+import { useEffectEvent, useLayoutEffect } from "react";
 
 // 여러 컴포넌트가 동시에 scroll lock을 요청할 때 올바르게 관리하기 위한 Set
 const scrollLockOwners = new Set<object>();
@@ -13,7 +13,7 @@ export const useScrollLock = (isActive: boolean) => {
   const pathname = usePathname();
   const getLatestPathname = useEffectEvent(() => pathname);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!isActive) {
       return;
     }

--- a/lib/constants/theme.ts
+++ b/lib/constants/theme.ts
@@ -1,3 +1,4 @@
 export const THEME_STORAGE_KEY = "201-escape-theme";
+export const THEME_DATA_ATTRIBUTE = "theme";
 
 export type Theme = "dark" | "light";


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #294

## 📌 작업 내용

- catch fallback에서 시스템 테마를 참조하도록 수정
- 중첩 삼항을 if/else로 교체, suppressHydrationWarning 추가
- THEME_DATA_ATTRIBUTE 상수 추출로 dataset 키를 단일 소스로 관리
- 검색창·메모 입력란 font-size를 모바일에서 16px으로 설정하여 iOS Safari 자동 확대 방지(sm 이상은 기존 14px 유지)
- useScrollLock을 useLayoutEffect로 변경하여 바텀시트 이동 후 position: fixed 해제가 페인트 전에 실행되도록 수정


