### PR TITLE
fix: 에러 페이지 복구 동선과 헤더 렌더링 안정화(#298)

### DIFF
--- a/app/(protected)/applications/[applicationId]/error.tsx
+++ b/app/(protected)/applications/[applicationId]/error.tsx
@@ -10,7 +10,7 @@ export default function ApplicationDetailError({
   reset: () => void;
 }) {
   return (
-    <main className="min-h-screen bg-muted/30">
+    <main className="bg-muted/30">
       <ErrorPageFallback
         description="일시적인 오류가 발생했습니다. 다시 시도하거나 대시보드로 돌아가 주세요."
         error={error}

--- a/app/(protected)/applications/error.tsx
+++ b/app/(protected)/applications/error.tsx
@@ -10,7 +10,7 @@ export default function ApplicationsError({
   reset: () => void;
 }) {
   return (
-    <main className="min-h-screen bg-muted/30">
+    <main className="bg-muted/30">
       <ErrorPageFallback
         description="목록 로딩 중 오류가 발생했습니다. 다시 시도하거나 잠시 후 돌아와 주세요."
         error={error}

--- a/app/(protected)/dashboard/error.tsx
+++ b/app/(protected)/dashboard/error.tsx
@@ -10,7 +10,7 @@ export default function DashboardError({
   reset: () => void;
 }) {
   return (
-    <main className="min-h-screen bg-muted/30">
+    <main className="bg-muted/30">
       <ErrorPageFallback
         description="목록 로딩 중 오류가 발생했습니다. 다시 시도하거나 잠시 후 돌아와 주세요."
         error={error}

--- a/app/_components/ErrorPageFallback.tsx
+++ b/app/_components/ErrorPageFallback.tsx
@@ -2,9 +2,8 @@
 
 import type { Route } from "next";
 
-import Link from "next/link";
-
 import { Button } from "@/components/ui/button/Button";
+import { cn } from "@/lib/utils/cn";
 
 type ErrorPageFallbackProps = {
   description: string;
@@ -13,6 +12,7 @@ type ErrorPageFallbackProps = {
   navLabel: string;
   resetAction: () => void;
   title: string;
+  viewport?: "full" | "withoutHeader";
 };
 
 export function ErrorPageFallback({
@@ -22,9 +22,31 @@ export function ErrorPageFallback({
   navLabel,
   resetAction,
   title,
+  viewport = "full",
 }: ErrorPageFallbackProps) {
+  const isDeploymentMismatchError = error.message.includes(
+    'Failed to find Server Action "',
+  );
+
+  const handleRetry = () => {
+    if (isDeploymentMismatchError) {
+      window.location.reload();
+
+      return;
+    }
+
+    resetAction();
+  };
+
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-6 p-4 text-center">
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-6 p-4 text-center",
+        viewport === "withoutHeader"
+          ? "min-h-[calc(100svh-4rem)]"
+          : "min-h-screen",
+      )}
+    >
       <div className="space-y-3">
         <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
         <p className="text-sm text-muted-foreground">
@@ -34,14 +56,20 @@ export function ErrorPageFallback({
               오류 코드: {error.digest}
             </span>
           )}
+          {isDeploymentMismatchError && (
+            <span className="mt-2 block text-xs text-muted-foreground/80">
+              배포가 갱신되면서 이전 페이지 상태가 남아 있을 수 있습니다. 다시
+              시도는 전체 새로고침으로 처리됩니다.
+            </span>
+          )}
         </p>
       </div>
       <div className="flex gap-3">
-        <Button onClick={resetAction} variant="outline">
+        <Button onClick={handleRetry} variant="outline">
           다시 시도
         </Button>
         <Button asChild>
-          <Link href={navHref}>{navLabel}</Link>
+          <a href={navHref}>{navLabel}</a>
         </Button>
       </div>
     </div>

--- a/app/_components/ErrorPageShell.tsx
+++ b/app/_components/ErrorPageShell.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { LogInIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button/Button";
+import { cn } from "@/lib/utils/cn";
+
+import {
+  isNavItemActive,
+  NAV_ITEMS,
+} from "../(protected)/_components/nav-items";
+import { HeaderActions } from "./HeaderActions";
+
+const PROTECTED_PATH_PREFIXES = ["/dashboard", "/applications"] as const;
+
+type ErrorPageShellProps = {
+  children: React.ReactNode;
+  pathname: string;
+};
+
+export function ErrorPageShell({ children, pathname }: ErrorPageShellProps) {
+  const isProtectedPath = getIsProtectedPath(pathname);
+
+  return (
+    <div className="min-h-screen bg-muted/30">
+      {isProtectedPath ? (
+        <ProtectedErrorHeader pathname={pathname} />
+      ) : (
+        <PublicErrorHeader />
+      )}
+      <main className={cn(isProtectedPath && "pt-16")}>{children}</main>
+    </div>
+  );
+}
+
+function getIsProtectedPath(pathname: string) {
+  return PROTECTED_PATH_PREFIXES.some((prefix) => {
+    return pathname === prefix || pathname.startsWith(`${prefix}/`);
+  });
+}
+
+function ProtectedErrorHeader({ pathname }: { pathname: string }) {
+  return (
+    <header className="fixed inset-x-0 top-0 z-40 border-b border-border bg-background/80 backdrop-blur-sm">
+      <div className="flex h-16 items-center justify-between px-6">
+        <div className="flex items-center gap-6">
+          <Button
+            asChild
+            className="text-xl font-black tracking-tighter text-primary hover:bg-transparent"
+            variant="ghost"
+          >
+            <a href="/dashboard">201</a>
+          </Button>
+          <nav aria-label="주 내비게이션" className="hidden md:flex">
+            <ul className="flex items-center gap-1">
+              {NAV_ITEMS.map(({ href, label }) => {
+                const isActive = isNavItemActive(pathname, href);
+
+                return (
+                  <li key={href}>
+                    <Button
+                      asChild
+                      className={cn(
+                        "text-sm font-medium",
+                        isActive
+                          ? "text-primary"
+                          : "text-muted-foreground hover:text-foreground",
+                      )}
+                      variant="ghost"
+                    >
+                      <a
+                        aria-current={isActive ? "page" : undefined}
+                        href={href}
+                      >
+                        {label}
+                      </a>
+                    </Button>
+                  </li>
+                );
+              })}
+            </ul>
+          </nav>
+        </div>
+        <HeaderActions />
+      </div>
+    </header>
+  );
+}
+
+function PublicErrorHeader() {
+  return (
+    <header className="sticky top-0 z-20 border-b border-border bg-background/90 px-6 py-4 text-foreground backdrop-blur-xl lg:px-10">
+      <div className="mx-auto flex max-w-7xl items-center justify-between gap-4">
+        {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- Error recovery must force a full document navigation. */}
+        <a
+          className="text-base font-bold tracking-[-0.03em] text-foreground"
+          href="/"
+        >
+          201 escape
+        </a>
+        <div className="flex items-center gap-2">
+          <HeaderActions />
+          <Button asChild size="icon" title="로그인" variant="ghost">
+            <a aria-label="로그인" href="/login">
+              <LogInIcon className="size-4" />
+            </a>
+          </Button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/app/_components/HeaderActions.tsx
+++ b/app/_components/HeaderActions.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import GitHubIcon from "@/assets/github.svg";
 import { Button } from "@/components/ui/button/Button";
 

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import { usePathname } from "next/navigation";
+
 import { ErrorPageFallback } from "./_components/ErrorPageFallback";
+import { ErrorPageShell } from "./_components/ErrorPageShell";
 
 export default function RootError({
   error,
@@ -9,14 +12,24 @@ export default function RootError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  const pathname = usePathname();
+  const isProtectedPath =
+    pathname === "/dashboard" ||
+    pathname === "/applications" ||
+    pathname.startsWith("/dashboard/") ||
+    pathname.startsWith("/applications/");
+
   return (
-    <ErrorPageFallback
-      description="일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."
-      error={error}
-      navHref="/dashboard"
-      navLabel="대시보드로 이동"
-      resetAction={reset}
-      title="페이지를 불러오지 못했습니다"
-    />
+    <ErrorPageShell pathname={pathname}>
+      <ErrorPageFallback
+        description="일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."
+        error={error}
+        navHref={isProtectedPath ? "/dashboard" : "/"}
+        navLabel={isProtectedPath ? "대시보드로 이동" : "홈으로 이동"}
+        resetAction={reset}
+        title="페이지를 불러오지 못했습니다"
+        viewport="withoutHeader"
+      />
+    </ErrorPageShell>
   );
 }

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -4,6 +4,8 @@ import { useEffect, useRef } from "react";
 
 import { createErrorReportPayload } from "@/lib/error-report/payload";
 
+import { ErrorPageFallback } from "./_components/ErrorPageFallback";
+
 export default function GlobalError({
   error,
   reset,
@@ -36,23 +38,28 @@ export default function GlobalError({
 
   return (
     <html lang="ko">
-      <body>
-        <div className="flex min-h-screen flex-col items-center justify-center p-4 text-center">
-          <h2 className="mb-4 text-2xl font-bold">문제가 발생했습니다.</h2>
-          <p className="mb-8 text-gray-600">
-            예상치 못한 오류가 발생했습니다.
-            {error.digest && (
-              <span className="mt-1 block text-xs text-gray-400">
-                오류 코드: {error.digest}
-              </span>
-            )}
-          </p>
-          <button
-            className="rounded-lg bg-blue-500 px-4 py-2 text-white transition-colors hover:bg-blue-600"
-            onClick={reset}
-          >
-            다시 시도
-          </button>
+      <body className="bg-muted/30 text-foreground">
+        <div className="min-h-screen">
+          <header className="sticky top-0 z-20 border-b border-border bg-background/90 px-6 py-4 text-foreground backdrop-blur-xl lg:px-10">
+            <div className="mx-auto flex max-w-7xl items-center justify-between gap-4">
+              {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- Global error recovery must bypass client routing. */}
+              <a
+                className="text-base font-bold tracking-[-0.03em] text-foreground"
+                href="/"
+              >
+                201 escape
+              </a>
+            </div>
+          </header>
+          <ErrorPageFallback
+            description="예상치 못한 오류가 발생했습니다. 다시 시도하거나 홈으로 이동해 주세요."
+            error={error}
+            navHref="/"
+            navLabel="홈으로 이동"
+            resetAction={reset}
+            title="문제가 발생했습니다"
+            viewport="withoutHeader"
+          />
         </div>
       </body>
     </html>


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #298

## 📌 작업 내용

- 서버 액션 식별자 불일치 에러에서 재시도를 전체 새로고침으로 처리
- 에러 페이지 이동 버튼을 브라우저 기본 내비게이션으로 변경
- 루트/글로벌 에러 화면에 전용 헤더 셸을 추가해 헤더 누락 방지
- 보호 라우트 에러 레이아웃 높이를 정리해 중복 전체 높이 제거


