### PR TITLE
refactor: 대시보드 데이터 페칭을 단일 액션으로 통합(#302)

### DIFF
--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1,24 +1,17 @@
-import { getChartData, getStatCounts } from "@/lib/actions";
+import { getDashboardData } from "@/lib/actions";
 import { formatKoreanDate } from "@/lib/utils";
 
 import { DashboardCharts } from "./_components/dashboard-view/DashboardCharts";
 import { DashboardOverview } from "./_components/dashboard-view/DashboardOverview";
 
 export default async function DashboardPage() {
-  const [statsResult, chartResult] = await Promise.all([
-    getStatCounts(),
-    getChartData(),
-  ]);
+  const dashboardResult = await getDashboardData();
 
-  if (!statsResult.ok) {
-    throw new Error(statsResult.reason);
+  if (!dashboardResult.ok) {
+    throw new Error(dashboardResult.reason);
   }
 
-  if (!chartResult.ok) {
-    throw new Error(chartResult.reason);
-  }
-
-  const { funnel, monthly } = chartResult.data;
+  const { funnel, monthly, stats } = dashboardResult.data;
 
   return (
     <main className="min-h-screen bg-background pb-20">
@@ -76,7 +69,7 @@ export default async function DashboardPage() {
       </section>
 
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 py-10 sm:px-6 lg:gap-20 lg:px-8 lg:py-12">
-        <DashboardOverview stats={statsResult.data} />
+        <DashboardOverview stats={stats} />
         <DashboardCharts funnel={funnel} monthly={monthly} />
       </div>
     </main>

--- a/lib/actions/getChartData.ts
+++ b/lib/actions/getChartData.ts
@@ -8,7 +8,10 @@ import type {
   MonthlyCount,
 } from "@/lib/types/application";
 
-import { DOCS_PASSED_STATUSES } from "@/lib/constants/application-status";
+import {
+  DOCS_PASSED_STATUSES,
+  INTERVIEW_STATUSES,
+} from "@/lib/constants/application-status";
 
 import { createClient, createClientWithToken } from "../supabase/server";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
@@ -50,7 +53,7 @@ const getCachedChartData = unstable_cache(
         .from("applications")
         .select("*", { count: "exact", head: true })
         .eq("user_id", userId)
-        .in("status", ["INTERVIEWING", "OFFERED"]),
+        .in("status", INTERVIEW_STATUSES),
       supabase
         .from("applications")
         .select("*", { count: "exact", head: true })

--- a/lib/actions/getDashboardData.ts
+++ b/lib/actions/getDashboardData.ts
@@ -1,0 +1,165 @@
+"use server";
+
+import { unstable_cache } from "next/cache";
+
+import type {
+  DashboardData,
+  GetDashboardDataResult,
+  MonthlyCount,
+  StatCounts,
+} from "@/lib/types/application";
+import type { JobStatus } from "@/lib/types/job";
+
+import {
+  DOCS_PASSED_STATUSES,
+  DOCS_STATUSES,
+} from "@/lib/constants/application-status";
+
+import { createClient, createClientWithToken } from "../supabase/server";
+import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
+import { reportQueryError } from "./_reportQueryError";
+
+const ERROR_MESSAGES = {
+  AUTH_REQUIRED: "로그인이 필요합니다.",
+} as const;
+
+type DashboardApplicationRow = {
+  applied_at: null | string;
+  status: JobStatus;
+};
+
+// cookies()를 사용하지 않으므로 unstable_cache 안에서 안전하게 실행됩니다.
+const getCachedDashboardData = unstable_cache(
+  async (userId: string, accessToken: string): Promise<DashboardData> => {
+    const supabase = createClientWithToken(accessToken);
+
+    const { data, error } = await supabase
+      .from("applications")
+      .select("applied_at, status")
+      .eq("user_id", userId);
+
+    if (error) {
+      const code =
+        error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
+      const reason = normalizeQueryError(error);
+
+      if (code === "QUERY_ERROR") {
+        reportQueryError("getDashboardData", reason);
+      }
+
+      throw new Error(reason);
+    }
+
+    return buildDashboardData(data ?? []);
+  },
+  ["dashboard-data"],
+  { revalidate: 60 },
+);
+
+export async function getDashboardData(): Promise<GetDashboardDataResult> {
+  const supabase = await createClient();
+  const { data: authData, error: authError } = await supabase.auth.getUser();
+
+  if (authError || !authData.user) {
+    return {
+      code: "AUTH_REQUIRED",
+      ok: false,
+      reason: ERROR_MESSAGES.AUTH_REQUIRED,
+    };
+  }
+
+  const { data: sessionData } = await supabase.auth.getSession();
+  const accessToken = sessionData.session?.access_token;
+
+  if (!accessToken) {
+    return {
+      code: "AUTH_REQUIRED",
+      ok: false,
+      reason: ERROR_MESSAGES.AUTH_REQUIRED,
+    };
+  }
+
+  try {
+    const data = await getCachedDashboardData(authData.user.id, accessToken);
+
+    return { data, ok: true };
+  } catch (e) {
+    const reason = e instanceof Error ? e.message : "알 수 없는 오류";
+
+    return { code: "QUERY_ERROR", ok: false, reason };
+  }
+}
+
+function buildDashboardData(rows: DashboardApplicationRow[]): DashboardData {
+  const cutoffStr = getMonthlyCutoffStr();
+  const monthlyMap = new Map<string, number>();
+  let applied = 0;
+  let docs = 0;
+  let docsPassed = 0;
+  let interviewing = 0;
+  let offered = 0;
+  let saved = 0;
+
+  for (const row of rows) {
+    const { applied_at, status } = row;
+
+    if (status === "SAVED") {
+      saved++;
+    } else {
+      applied++;
+    }
+
+    if ((DOCS_STATUSES as readonly string[]).includes(status)) {
+      docs++;
+    }
+
+    if ((DOCS_PASSED_STATUSES as readonly string[]).includes(status)) {
+      docsPassed++;
+    }
+
+    if (status === "INTERVIEWING") {
+      interviewing++;
+    }
+
+    if (status === "OFFERED") {
+      offered++;
+    }
+
+    if (!applied_at || applied_at < cutoffStr) {
+      continue;
+    }
+
+    const month = applied_at.slice(0, 7);
+    monthlyMap.set(month, (monthlyMap.get(month) ?? 0) + 1);
+  }
+
+  const stats: StatCounts = {
+    applied,
+    docs,
+    docsPassed,
+    interviewing,
+    offered,
+    saved,
+    total: rows.length,
+  };
+
+  const monthly: MonthlyCount[] = Array.from(monthlyMap.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([month, count]) => ({ count, month }));
+
+  const funnel = [
+    { count: applied, label: "지원" },
+    { count: docsPassed, label: "서류 통과" },
+    { count: interviewing + offered, label: "면접" },
+    { count: offered, label: "합격" },
+  ];
+
+  return { funnel, monthly, stats };
+}
+
+function getMonthlyCutoffStr(): string {
+  const d = new Date();
+  d.setFullYear(d.getFullYear() - 1);
+
+  return d.toISOString().slice(0, 10);
+}

--- a/lib/actions/index.ts
+++ b/lib/actions/index.ts
@@ -4,6 +4,7 @@ export { getApplicationDetail } from "./getApplicationDetail";
 export { getApplications } from "./getApplications";
 export { getApplicationsStats } from "./getApplicationsStats";
 export { getChartData } from "./getChartData";
+export { getDashboardData } from "./getDashboardData";
 export { getInterviews } from "./getInterviews";
 export { getStatCounts } from "./getStatCounts";
 export { saveJobApplication } from "./saveJobApplication";

--- a/lib/constants/application-status.ts
+++ b/lib/constants/application-status.ts
@@ -20,6 +20,11 @@ export const DOCS_PASSED_STATUSES = [
   "OFFERED",
 ] as const satisfies readonly JobStatus[];
 
+export const INTERVIEW_STATUSES = [
+  "INTERVIEWING",
+  "OFFERED",
+] as const satisfies readonly JobStatus[];
+
 export const APPLICATION_STATUS_META: Record<
   JobStatus,
   { badgeClassName: string; color: string; label: string }

--- a/lib/types/application.ts
+++ b/lib/types/application.ts
@@ -80,6 +80,8 @@ export type ChartData = {
   monthly: MonthlyCount[];
 };
 
+export type DashboardData = ChartData & { stats: StatCounts };
+
 export type DeleteApplicationErrorCode =
   | "AUTH_REQUIRED"
   | "NOT_FOUND"
@@ -139,6 +141,12 @@ export type GetChartDataErrorCode = "AUTH_REQUIRED" | "QUERY_ERROR";
 export type GetChartDataResult =
   | { code: GetChartDataErrorCode; ok: false; reason: string }
   | { data: ChartData; ok: true };
+
+export type GetDashboardDataErrorCode = "AUTH_REQUIRED" | "QUERY_ERROR";
+
+export type GetDashboardDataResult =
+  | { code: GetDashboardDataErrorCode; ok: false; reason: string }
+  | { data: DashboardData; ok: true };
 
 export type GetStatCountsErrorCode = "AUTH_REQUIRED" | "QUERY_ERROR";
 


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #302

## 📌 작업 내용

- getDashboardData 서버 액션 추가: 기존 getStatCounts + getChartData 두 번의 쿼리를 단일 쿼리로 대체
- applications 전체 행을 한 번에 읽어 메모리에서 stats/funnel/monthly를 모두 계산
- DashboardData, GetDashboardDataResult 타입 및 GetDashboardDataErrorCode 추가
- INTERVIEW_STATUSES 상수 추가하고 getChartData 내 인라인 배열을 상수로 교체
- dashboard/page.tsx를 getDashboardData 단일 호출로 단순화


