### PR TITLE
refactor: 랜딩 UI를 정리하고 대시보드/지원 화면 지연 마운트를 도입(#306)

### DIFF
--- a/app/(protected)/applications/_components/ApplicationsView.tsx
+++ b/app/(protected)/applications/_components/ApplicationsView.tsx
@@ -1,30 +1,46 @@
-import {
-  dehydrate,
-  HydrationBoundary,
-  QueryClient,
-} from "@tanstack/react-query";
-import { Suspense } from "react";
+import { FileTextIcon, LockKeyholeIcon } from "lucide-react";
 
-import { ApplicationsProviders } from "@/app/(protected)/applications/ApplicationsProviders";
-import { Skeleton } from "@/components/ui";
+import { Button } from "@/components/ui";
 import { getApplications } from "@/lib/actions";
 import { formatKoreanDate } from "@/lib/utils";
 
-import { AddJobTrigger } from "./add-job";
+import { LazyAddJobTrigger } from "./add-job/LazyAddJobTrigger";
 import { ApplicationsPanel } from "./components/ApplicationsPanel";
 import {
-  buildApplicationsQueryKey,
-  getApplicationsNextPageParam,
+  buildApplicationsRequestKey,
   getPeriodDateRange,
   PAGE_SIZE,
   parsePeriodParam,
   parseSortParam,
+  parseTabParam,
   PERIOD_PARAM,
   SEARCH_PARAM,
   SORT_PARAM,
+  TAB_PARAM,
 } from "./constants";
 
+type ApplicationsViewErrorProps = {
+  code: "AUTH_REQUIRED" | "QUERY_ERROR";
+};
+
 type SearchParams = Record<string, string | string[] | undefined>;
+
+const APPLICATIONS_ERROR_META = {
+  AUTH_REQUIRED: {
+    ctaHref: "/login",
+    ctaLabel: "로그인하러 가기",
+    description: "지원 목록을 보려면 로그인 상태가 필요합니다.",
+    icon: LockKeyholeIcon,
+    title: "로그인이 필요합니다",
+  },
+  QUERY_ERROR: {
+    ctaHref: "/dashboard",
+    ctaLabel: "대시보드로 이동",
+    description: "목록을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.",
+    icon: FileTextIcon,
+    title: "지원 목록을 불러오지 못했습니다",
+  },
+} as const;
 
 export async function ApplicationsView({
   searchParams,
@@ -36,96 +52,70 @@ export async function ApplicationsView({
     getString(searchParams[PERIOD_PARAM]) || null,
   );
   const sort = parseSortParam(getString(searchParams[SORT_PARAM]) || null);
+  const tab = parseTabParam(getString(searchParams[TAB_PARAM]) || null);
   const dateRange = getPeriodDateRange(period);
   const dateLabel = formatKoreanDate(new Date());
-
-  const queryClient = new QueryClient();
-
-  await queryClient.prefetchInfiniteQuery({
-    getNextPageParam: getApplicationsNextPageParam,
-    initialPageParam: 0,
-    pages: 1,
-    queryFn: async ({ pageParam }: { pageParam: number }) => {
-      const result = await getApplications({
-        limit: PAGE_SIZE,
-        offset: pageParam,
-        periodEnd: dateRange?.end,
-        periodStart: dateRange?.start,
-        search: search || undefined,
-        sort,
-      });
-
-      if (!result.ok) {
-        throw new Error(result.reason);
-      }
-
-      return result.data;
-    },
-    queryKey: buildApplicationsQueryKey({ period, search, sort }),
+  const result = await getApplications({
+    limit: PAGE_SIZE,
+    offset: 0,
+    periodEnd: dateRange?.end,
+    periodStart: dateRange?.start,
+    search: search || undefined,
+    sort,
   });
+
+  if (!result.ok) {
+    return <ApplicationsViewError code={result.code} />;
+  }
+
+  const requestKey = buildApplicationsRequestKey({ period, search, sort });
 
   return (
     <main className="min-h-screen bg-background pb-20">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 pt-0 pb-10 sm:px-6 lg:gap-20 lg:px-8 lg:pb-12">
-        <ApplicationsProviders>
-          <HydrationBoundary state={dehydrate(queryClient)}>
-            <Suspense fallback={<ApplicationsViewSkeleton />}>
-              <ApplicationsPanel dateLabel={dateLabel} />
-            </Suspense>
-          </HydrationBoundary>
-        </ApplicationsProviders>
+        <ApplicationsPanel
+          dateLabel={dateLabel}
+          initialApplications={result.data.items}
+          initialHasNextPage={result.data.hasMore}
+          key={requestKey}
+          period={period}
+          search={search}
+          sort={sort}
+          tab={tab}
+        />
       </div>
-      <AddJobTrigger />
+      <LazyAddJobTrigger />
     </main>
   );
 }
 
-function ApplicationsViewSkeleton() {
+function ApplicationsViewError({ code }: ApplicationsViewErrorProps) {
+  const meta = APPLICATIONS_ERROR_META[code];
+  const Icon = meta.icon;
+
   return (
-    <div
-      aria-busy="true"
-      aria-label="지원 목록을 불러오는 중입니다"
-      role="status"
-    >
-      <section className="overflow-hidden rounded-3xl bg-muted/30">
-        <div className="px-5 py-8 sm:px-6 lg:px-8 lg:py-10">
-          <div className="grid gap-6 lg:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.9fr)] lg:items-end">
+    <main className="min-h-screen bg-background pb-20">
+      <div className="mx-auto flex w-full max-w-3xl flex-col px-4 py-10 sm:px-6 lg:px-8">
+        <section className="rounded-4xl border border-border/60 bg-background px-6 py-10 text-center shadow-[0_36px_120px_-64px_rgba(23,23,23,0.45)] sm:px-8">
+          <div className="mx-auto flex max-w-md flex-col items-center gap-5">
+            <div className="flex size-12 items-center justify-center text-muted-foreground">
+              <Icon aria-hidden="true" className="size-6" />
+            </div>
             <div className="space-y-3">
-              <Skeleton className="h-4 w-32 rounded-full" />
-              <Skeleton className="h-12 w-40 rounded-full" />
-              <Skeleton className="h-5 w-full max-w-2xl rounded-full" />
-              <Skeleton className="h-5 w-5/6 max-w-xl rounded-full" />
-              <Skeleton className="h-5 w-full max-w-lg rounded-full" />
+              <h1 className="text-[28px] leading-tight font-semibold tracking-[-0.02em] text-foreground">
+                {meta.title}
+              </h1>
+              <p className="text-sm leading-6 text-muted-foreground">
+                {meta.description}
+              </p>
             </div>
-
-            <div className="grid grid-cols-3 gap-3">
-              {Array.from({ length: 3 }).map((_, i) => (
-                <div className="rounded-2xl bg-background/70 px-4 py-4" key={i}>
-                  <Skeleton className="h-4 w-12 rounded-full" />
-                  <Skeleton className="mt-2 h-8 w-12 rounded-full" />
-                </div>
-              ))}
-            </div>
+            <Button asChild className="h-10 px-4 text-sm">
+              <a href={meta.ctaHref}>{meta.ctaLabel}</a>
+            </Button>
           </div>
-        </div>
-      </section>
-
-      <div className="overflow-hidden rounded-3xl border border-border/70 bg-background">
-        <div className="space-y-4 border-b border-border/70 px-5 py-5 sm:px-6">
-          <Skeleton className="h-10 w-full rounded-2xl" />
-          <div className="flex gap-2">
-            <Skeleton className="h-9 w-18 rounded-full" />
-            <Skeleton className="h-9 w-28 rounded-full" />
-            <Skeleton className="h-9 w-22 rounded-full" />
-          </div>
-        </div>
-        <div className="space-y-1 px-4 pb-6 sm:px-5">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <Skeleton className="h-26 w-full rounded-2xl" key={i} />
-          ))}
-        </div>
+        </section>
       </div>
-    </div>
+    </main>
   );
 }
 

--- a/app/(protected)/applications/_components/add-job/LazyAddJobTrigger.tsx
+++ b/app/(protected)/applications/_components/add-job/LazyAddJobTrigger.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import { useIdleMount } from "@/hooks/useIdleMount";
+
+const AddJobTrigger = dynamic(
+  () => import("./AddJobTrigger").then((module) => module.AddJobTrigger),
+  { ssr: false },
+);
+
+export function LazyAddJobTrigger() {
+  const shouldMount = useIdleMount({
+    fallbackDelayMs: 800,
+    timeoutMs: 1500,
+  });
+
+  if (!shouldMount) {
+    return null;
+  }
+
+  return <AddJobTrigger />;
+}

--- a/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
@@ -1,19 +1,14 @@
 "use client";
 
-import type { InfiniteData } from "@tanstack/react-query";
 import type { Route } from "next";
 
-import {
-  useQueryClient,
-  useSuspenseInfiniteQuery,
-} from "@tanstack/react-query";
 import dynamic from "next/dynamic";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
-import type { GetApplicationsPage } from "@/lib/types/application";
 import type { JobStatus } from "@/lib/types/job";
 
+import { Button } from "@/components/ui/button/Button";
 import { getApplications } from "@/lib/actions";
 
 import type { PeriodPreset, SortValue, TabValue } from "../constants";
@@ -22,13 +17,8 @@ import type { ApplicationTabsHandle } from "./ApplicationTabs";
 
 import { ApplicationsPageHeader } from "../ApplicationsPageHeader";
 import {
-  buildApplicationsQueryKey,
-  getApplicationsNextPageParam,
   getPeriodDateRange,
   PAGE_SIZE,
-  parsePeriodParam,
-  parseSortParam,
-  parseTabParam,
   PERIOD_PARAM,
   PREVIEW_PARAM,
   SEARCH_PARAM,
@@ -49,63 +39,46 @@ const ApplicationPreviewSheet = dynamic(
 
 type ApplicationsPanelProps = {
   dateLabel: string;
+  initialApplications: ApplicationListItem[];
+  initialHasNextPage: boolean;
+  period: PeriodPreset;
+  search: string;
+  sort: SortValue;
+  tab: TabValue;
 };
 
-export function ApplicationsPanel({ dateLabel }: ApplicationsPanelProps) {
+export function ApplicationsPanel({
+  dateLabel,
+  initialApplications,
+  initialHasNextPage,
+  period,
+  search,
+  sort,
+  tab,
+}: ApplicationsPanelProps) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const queryClient = useQueryClient();
 
   const tabsRef = useRef<ApplicationTabsHandle>(null);
+  const isFetchingNextPageRef = useRef(false);
+  const [applications, setApplications] =
+    useState<ApplicationListItem[]>(initialApplications);
+  const [hasNextPage, setHasNextPage] = useState(initialHasNextPage);
+  const [isFetchingNextPage, setIsFetchingNextPage] = useState(false);
   const [isListScrolled, setIsListScrolled] = useState(false);
+  const [paginationErrorMessage, setPaginationErrorMessage] = useState<
+    null | string
+  >(null);
   const [previewApplicationId, setPreviewApplicationId] = useState<
     null | string
   >(null);
   const [shouldRenderPreviewSheet, setShouldRenderPreviewSheet] =
     useState(false);
 
-  const search = searchParams.get(SEARCH_PARAM) ?? "";
-  const period = parsePeriodParam(searchParams.get(PERIOD_PARAM));
-  const sort = parseSortParam(searchParams.get(SORT_PARAM));
-  const tab = parseTabParam(searchParams.get(TAB_PARAM));
-
-  const queryKey = buildApplicationsQueryKey({ period, search, sort });
-  const dateRange = useMemo(() => getPeriodDateRange(period), [period]);
-
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useSuspenseInfiniteQuery({
-      getNextPageParam: getApplicationsNextPageParam,
-      initialPageParam: 0,
-      queryFn: async ({ pageParam }: { pageParam: number }) => {
-        const result = await getApplications({
-          limit: PAGE_SIZE,
-          offset: pageParam,
-          periodEnd: dateRange?.end,
-          periodStart: dateRange?.start,
-          search: search || undefined,
-          sort,
-        });
-        if (!result.ok) {
-          throw new Error(result.reason);
-        }
-        return result.data;
-      },
-      queryKey,
-    });
-
-  const applications: ApplicationListItem[] = data.pages.reduce<
-    ApplicationListItem[]
-  >((items, page) => {
-    items.push(...page.items);
-
-    return items;
-  }, []);
-
-  const selectedApplicationId = previewApplicationId;
-  const isPreviewOpen = selectedApplicationId !== null;
+  const isPreviewOpen = previewApplicationId !== null;
   const selectedApplication =
-    applications.find((a) => a.id === selectedApplicationId) ?? null;
+    applications.find((a) => a.id === previewApplicationId) ?? null;
 
   useEffect(() => {
     const previewParam = searchParams.get(PREVIEW_PARAM);
@@ -186,31 +159,51 @@ export function ApplicationsPanel({ dateLabel }: ApplicationsPanelProps) {
   };
 
   const handleStatusChange = (applicationId: string, nextStatus: JobStatus) => {
-    queryClient.setQueryData<InfiniteData<GetApplicationsPage>>(
-      queryKey,
-      (old) => {
-        if (!old) {
-          return old;
-        }
-        return {
-          ...old,
-          pages: old.pages.map((page) => ({
-            ...page,
-            items: page.items.map((item) =>
-              item.id === applicationId
-                ? { ...item, status: nextStatus }
-                : item,
-            ),
-          })),
-        };
-      },
+    setApplications((currentApplications) =>
+      currentApplications.map((item) =>
+        item.id === applicationId ? { ...item, status: nextStatus } : item,
+      ),
     );
   };
 
-  const handleNearEnd = () => {
-    if (hasNextPage && !isFetchingNextPage) {
-      fetchNextPage();
+  async function loadNextPage() {
+    if (isFetchingNextPageRef.current || !hasNextPage) {
+      return;
     }
+
+    isFetchingNextPageRef.current = true;
+    setIsFetchingNextPage(true);
+    setPaginationErrorMessage(null);
+
+    try {
+      const dateRange = getPeriodDateRange(period);
+      const result = await getApplications({
+        limit: PAGE_SIZE,
+        offset: applications.length,
+        periodEnd: dateRange?.end,
+        periodStart: dateRange?.start,
+        search: search || undefined,
+        sort,
+      });
+
+      if (!result.ok) {
+        setPaginationErrorMessage(result.reason);
+        return;
+      }
+
+      setApplications((currentApplications) => [
+        ...currentApplications,
+        ...result.data.items,
+      ]);
+      setHasNextPage(result.data.hasMore);
+    } finally {
+      setIsFetchingNextPage(false);
+      isFetchingNextPageRef.current = false;
+    }
+  }
+
+  const handleNearEnd = () => {
+    void loadNextPage();
   };
 
   return (
@@ -249,6 +242,25 @@ export function ApplicationsPanel({ dateLabel }: ApplicationsPanelProps) {
           ref={tabsRef}
           tab={tab}
         />
+        {paginationErrorMessage && (
+          <div className="border-t border-border/70 bg-background px-5 py-4 sm:px-6">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm leading-6 text-muted-foreground">
+                다음 항목을 불러오지 못했습니다. 네트워크 상태를 확인한 뒤 다시
+                시도해 주세요.
+              </p>
+              <Button
+                className="shrink-0 rounded-full font-semibold hover:border-primary/30 hover:text-primary"
+                onClick={() => {
+                  void loadNextPage();
+                }}
+                variant="outline"
+              >
+                다시 시도
+              </Button>
+            </div>
+          </div>
+        )}
       </section>
 
       {(shouldRenderPreviewSheet || isPreviewOpen) && (

--- a/app/(protected)/applications/_components/constants.ts
+++ b/app/(protected)/applications/_components/constants.ts
@@ -1,5 +1,3 @@
-import type { GetApplicationsPage } from "@/lib/types/application";
-
 import { APPLICATION_STATUS_META } from "@/lib/constants/application-status";
 import { PLATFORM_LABEL } from "@/lib/constants/job-platform";
 import { JobStatus } from "@/lib/types/job";
@@ -93,6 +91,18 @@ export const SORT_LABELS: Record<SortValue, string> = {
 };
 
 /**
+ * 서버가 새 첫 페이지를 준비해야 하는 필터 조합을 문자열 키로 직렬화합니다.
+ * 탭은 같은 데이터 집합을 재사용하므로 키에 포함하지 않습니다.
+ */
+export function buildApplicationsRequestKey(params: {
+  period: PeriodPreset;
+  search: string;
+  sort: SortValue;
+}) {
+  return JSON.stringify(params);
+}
+
+/**
  * URL 파라미터를 PeriodPreset으로 파싱합니다.
  * 유효하지 않은 값은 "all"로 폴백합니다.
  */
@@ -120,33 +130,4 @@ export function parseTabParam(value: null | string): TabValue {
   return (TAB_VALUES as readonly string[]).includes(value ?? "")
     ? (value as TabValue)
     : "all";
-}
-
-/**
- * useInfiniteQuery / prefetchInfiniteQuery 공통 query key 베이스
- */
-export const APPLICATIONS_QUERY_KEY = ["applications"] as const;
-
-/**
- * 필터가 포함된 query key를 생성합니다.
- * Panel과 View에서 동일한 key를 사용해 HydrationBoundary가 올바르게 작동합니다.
- */
-export function buildApplicationsQueryKey(params: {
-  period: PeriodPreset;
-  search: string;
-  sort: SortValue;
-}) {
-  return [...APPLICATIONS_QUERY_KEY, params] as const;
-}
-
-/**
- * useInfiniteQuery / prefetchInfiniteQuery 공통 getNextPageParam.
- * lastPageParam + 현재 페이지 아이템 수로 다음 오프셋을 O(1)에 계산합니다.
- */
-export function getApplicationsNextPageParam(
-  lastPage: GetApplicationsPage,
-  _allPages: GetApplicationsPage[],
-  lastPageParam: number,
-): number | undefined {
-  return lastPage.hasMore ? lastPageParam + lastPage.items.length : undefined;
 }

--- a/app/(protected)/dashboard/_components/dashboard-view/DashboardCharts.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DashboardCharts.tsx
@@ -2,8 +2,8 @@ import type { FunnelStep, MonthlyCount } from "@/lib/types/application";
 
 import { DashboardFunnelBreakdown } from "./DashboardFunnelBreakdown";
 import { DashboardInsightPanel } from "./DashboardInsightPanel";
-import { FunnelChart } from "./FunnelChart";
-import { MonthlyTrendChart } from "./MonthlyTrendChart";
+import { LazyFunnelChart } from "./LazyFunnelChart";
+import { LazyMonthlyTrendChart } from "./LazyMonthlyTrendChart";
 
 type Props = {
   funnel: FunnelStep[];
@@ -29,7 +29,7 @@ export function DashboardCharts({ funnel, monthly }: Props) {
               </p>
             </div>
           </div>
-          <MonthlyTrendChart data={monthly} />
+          <LazyMonthlyTrendChart data={monthly} />
         </div>
 
         <DashboardInsightPanel funnel={funnel} monthly={monthly} />
@@ -48,7 +48,7 @@ export function DashboardCharts({ funnel, monthly }: Props) {
               전체 지원 수를 기준으로 각 단계에 몇 건이 남아 있는지 확인합니다.
             </p>
           </div>
-          <FunnelChart data={funnel} />
+          <LazyFunnelChart data={funnel} />
         </div>
 
         <DashboardFunnelBreakdown data={funnel} />

--- a/app/(protected)/dashboard/_components/dashboard-view/LazyFunnelChart.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/LazyFunnelChart.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import type { FunnelStep } from "@/lib/types/application";
+
+import { Skeleton } from "@/components/ui";
+import { useIdleMount } from "@/hooks/useIdleMount";
+
+import { FUNNEL_CHART_HEIGHT } from "./constants";
+
+const FunnelChart = dynamic(
+  () => import("./FunnelChart").then((module) => module.FunnelChart),
+  {
+    loading: () => <FunnelChartFallback />,
+    ssr: false,
+  },
+);
+
+type LazyFunnelChartProps = {
+  data: FunnelStep[];
+};
+
+export function LazyFunnelChart({ data }: LazyFunnelChartProps) {
+  const shouldMount = useIdleMount({ timeoutMs: 1500 });
+
+  if (!shouldMount) {
+    return <FunnelChartFallback />;
+  }
+
+  return <FunnelChart data={data} />;
+}
+
+function FunnelChartFallback() {
+  return (
+    <div
+      aria-busy="true"
+      aria-label="단계별 전환 차트를 준비하는 중입니다"
+      className="space-y-4 rounded-3xl bg-background/70 px-4 py-4"
+      role="status"
+      style={{ minHeight: FUNNEL_CHART_HEIGHT }}
+    >
+      {Array.from({ length: 4 }).map((_, index) => (
+        <div
+          className="grid grid-cols-[72px_1fr] items-center gap-4"
+          key={index}
+        >
+          <Skeleton className="h-5 w-14 rounded-full" />
+          <Skeleton className="h-10 w-full rounded-xl" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/(protected)/dashboard/_components/dashboard-view/LazyMonthlyTrendChart.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/LazyMonthlyTrendChart.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import type { MonthlyCount } from "@/lib/types/application";
+
+import { Skeleton } from "@/components/ui";
+import { useIdleMount } from "@/hooks/useIdleMount";
+
+import { MONTHLY_CHART_HEIGHT } from "./constants";
+
+const MonthlyTrendChart = dynamic(
+  () =>
+    import("./MonthlyTrendChart").then((module) => module.MonthlyTrendChart),
+  {
+    loading: () => <MonthlyTrendChartFallback />,
+    ssr: false,
+  },
+);
+
+type LazyMonthlyTrendChartProps = {
+  data: MonthlyCount[];
+};
+
+export function LazyMonthlyTrendChart({ data }: LazyMonthlyTrendChartProps) {
+  const shouldMount = useIdleMount({ timeoutMs: 1500 });
+
+  if (!shouldMount) {
+    return <MonthlyTrendChartFallback />;
+  }
+
+  return <MonthlyTrendChart data={data} />;
+}
+
+function MonthlyTrendChartFallback() {
+  return (
+    <div
+      aria-busy="true"
+      aria-label="월별 추이 차트를 준비하는 중입니다"
+      className="rounded-3xl bg-background/70 px-2 py-3 sm:px-3"
+      role="status"
+      style={{ height: MONTHLY_CHART_HEIGHT }}
+    >
+      <div className="grid h-full grid-rows-[1fr_auto] gap-4">
+        <Skeleton className="h-full w-full rounded-3xl" />
+        <div className="grid grid-cols-6 gap-2">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <Skeleton className="h-4 w-full rounded-full" key={index} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/_components/HeaderActions.tsx
+++ b/app/_components/HeaderActions.tsx
@@ -1,16 +1,14 @@
-"use client";
-
 import GitHubIcon from "@/assets/github.svg";
 import { Button } from "@/components/ui/button/Button";
 
-import { ThemeToggle } from "./ThemeToggle";
+import { LazyThemeToggle } from "./LazyThemeToggle";
 
 const GITHUB_REPOSITORY_URL = "https://github.com/quartzs2/201-escape";
 
 export function HeaderActions() {
   return (
     <div className="flex items-center gap-2">
-      <ThemeToggle />
+      <LazyThemeToggle />
       <Button asChild size="icon" variant="ghost">
         <a
           aria-label="GitHub 저장소"

--- a/app/_components/LazyThemeToggle.tsx
+++ b/app/_components/LazyThemeToggle.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import { useIdleMount } from "@/hooks/useIdleMount";
+
+const ThemeToggle = dynamic(
+  () => import("./ThemeToggle").then((module) => module.ThemeToggle),
+  { ssr: false },
+);
+
+export function LazyThemeToggle() {
+  const shouldMount = useIdleMount();
+
+  if (!shouldMount) {
+    return <div aria-hidden="true" className="h-9 w-9 shrink-0" />;
+  }
+
+  return <ThemeToggle />;
+}

--- a/app/_components/PublicHeader.module.css
+++ b/app/_components/PublicHeader.module.css
@@ -1,0 +1,41 @@
+.root {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  padding: 1rem 1.5rem;
+  color: var(--color-foreground);
+  border-bottom: 1px solid var(--color-border);
+  background: color-mix(in srgb, var(--color-background) 90%, transparent);
+  backdrop-filter: blur(20px);
+}
+
+.inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  width: 100%;
+  max-width: 80rem;
+  margin: 0 auto;
+}
+
+.brand {
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  color: var(--color-foreground);
+  text-decoration: none;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+@media (min-width: 1024px) {
+  .root {
+    padding-right: 2.5rem;
+    padding-left: 2.5rem;
+  }
+}

--- a/app/_components/PublicHeader.tsx
+++ b/app/_components/PublicHeader.tsx
@@ -3,20 +3,18 @@ import { LogInIcon } from "lucide-react";
 import { Button } from "@/components/ui/button/Button";
 
 import { HeaderActions } from "./HeaderActions";
+import styles from "./PublicHeader.module.css";
 
 export function PublicHeader() {
   return (
-    <header className="sticky top-0 z-20 border-b border-border bg-background/90 px-6 py-4 text-foreground backdrop-blur-xl lg:px-10">
-      <div className="mx-auto flex max-w-7xl items-center justify-between gap-4">
+    <header className={styles.root}>
+      <div className={styles.inner}>
         {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- Public entrypoints intentionally avoid client navigation JS. */}
-        <a
-          className="text-base font-bold tracking-[-0.03em] text-foreground"
-          href="/"
-        >
+        <a className={styles.brand} href="/">
           201 escape
         </a>
 
-        <div className="flex items-center gap-2">
+        <div className={styles.actions}>
           <HeaderActions />
           <Button asChild size="icon" title="로그인" variant="ghost">
             <a aria-label="로그인" href="/login">

--- a/app/_components/landing/FeaturesSection.module.css
+++ b/app/_components/landing/FeaturesSection.module.css
@@ -1,0 +1,92 @@
+.section {
+  padding: 4rem 0;
+  color: var(--color-foreground);
+  border-top: 1px solid var(--color-border);
+  background: var(--color-background);
+}
+
+.shell {
+  width: 100%;
+  max-width: 80rem;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.header {
+  max-width: 42rem;
+}
+
+.eyebrow {
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.24em;
+  color: var(--color-muted-foreground);
+  text-transform: uppercase;
+}
+
+.title {
+  margin-top: 1rem;
+  font-size: 2rem;
+  font-weight: 900;
+  line-height: 1.08;
+  letter-spacing: -0.05em;
+  text-wrap: balance;
+}
+
+.description {
+  margin-top: 1.25rem;
+  font-size: 1rem;
+  line-height: 1.75;
+  color: var(--color-muted-foreground);
+}
+
+.list {
+  display: grid;
+  gap: 2rem;
+  margin-top: 2.5rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.itemIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  color: var(--color-primary);
+  background: var(--color-secondary);
+  border-radius: 999px;
+}
+
+.itemTitle {
+  margin-top: 1rem;
+  font-size: 1.125rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  color: var(--color-foreground);
+}
+
+.itemDescription {
+  margin-top: 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: var(--color-muted-foreground);
+}
+
+@media (min-width: 768px) {
+  .list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .section {
+    padding: 4.5rem 0;
+  }
+
+  .shell {
+    padding-right: 2.5rem;
+    padding-left: 2.5rem;
+  }
+}

--- a/app/_components/landing/FeaturesSection.tsx
+++ b/app/_components/landing/FeaturesSection.tsx
@@ -1,36 +1,26 @@
+import styles from "./FeaturesSection.module.css";
 import { landingFeatures } from "./utils/content";
 
 export function FeaturesSection() {
   return (
-    <section
-      className="border-t border-border bg-background py-16 text-foreground lg:py-18"
-      id="features"
-    >
-      <div className="mx-auto max-w-7xl px-6 lg:px-10">
-        <header className="max-w-2xl">
-          <p className="text-sm font-semibold tracking-[0.24em] text-muted-foreground uppercase">
-            기능
-          </p>
-          <h2 className="mt-4 text-[2rem] leading-[1.08] font-black tracking-[-0.05em] text-balance sm:text-[2.6rem]">
-            필요한 기능만 간단하게 담았습니다.
-          </h2>
-          <p className="mt-5 text-base leading-7 text-muted-foreground">
+    <section className={styles.section} id="features">
+      <div className={styles.shell}>
+        <header className={styles.header}>
+          <p className={styles.eyebrow}>기능</p>
+          <h2 className={styles.title}>필요한 기능만 간단하게 담았습니다.</h2>
+          <p className={styles.description}>
             공고, 일정, 현황처럼 자주 보는 정보만 담았습니다.
           </p>
         </header>
 
-        <ul className="mt-10 grid gap-8 border-t border-border pt-8 md:grid-cols-3">
+        <ul className={styles.list}>
           {landingFeatures.map(({ description, icon: Icon, title }) => (
             <li key={title}>
-              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-secondary text-primary">
+              <div className={styles.itemIcon}>
                 <Icon aria-hidden="true" className="size-5" />
               </div>
-              <h3 className="mt-4 text-lg font-bold tracking-[-0.03em] text-foreground">
-                {title}
-              </h3>
-              <p className="mt-3 text-sm leading-6 text-muted-foreground">
-                {description}
-              </p>
+              <h3 className={styles.itemTitle}>{title}</h3>
+              <p className={styles.itemDescription}>{description}</p>
             </li>
           ))}
         </ul>

--- a/app/_components/landing/FinalCtaSection.module.css
+++ b/app/_components/landing/FinalCtaSection.module.css
@@ -1,0 +1,76 @@
+.section {
+  padding: 4rem 0;
+  color: var(--color-foreground);
+  border-top: 1px solid var(--color-border);
+  background: var(--color-background);
+}
+
+.shell {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  width: 100%;
+  max-width: 80rem;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.content {
+  max-width: 36rem;
+}
+
+.eyebrow {
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.24em;
+  color: var(--color-primary);
+  text-transform: uppercase;
+}
+
+.title {
+  margin-top: 1rem;
+  font-size: 2rem;
+  font-weight: 900;
+  line-height: 1.08;
+  letter-spacing: -0.05em;
+  text-wrap: balance;
+}
+
+.description {
+  margin-top: 1rem;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: var(--color-muted-foreground);
+}
+
+.button {
+  width: 100%;
+  height: 3.25rem;
+  padding: 0 1.75rem;
+  font-size: 0.875rem;
+  font-weight: 700;
+  border-radius: 999px;
+}
+
+@media (min-width: 640px) {
+  .shell {
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: space-between;
+  }
+
+  .button {
+    width: auto;
+  }
+}
+
+@media (min-width: 1024px) {
+  .section {
+    padding: 4.5rem 0;
+  }
+
+  .shell {
+    padding-right: 2.5rem;
+    padding-left: 2.5rem;
+  }
+}

--- a/app/_components/landing/FinalCtaSection.tsx
+++ b/app/_components/landing/FinalCtaSection.tsx
@@ -2,26 +2,23 @@ import { ArrowRightIcon } from "lucide-react";
 
 import { Button } from "@/components/ui/button/Button";
 
+import styles from "./FinalCtaSection.module.css";
+
 export function FinalCtaSection() {
   return (
-    <section className="border-t border-border bg-background py-16 text-foreground lg:py-18">
-      <div className="mx-auto flex max-w-7xl flex-col gap-6 px-6 sm:flex-row sm:items-end sm:justify-between lg:px-10">
-        <div className="max-w-xl">
-          <p className="text-sm font-semibold tracking-[0.24em] text-primary uppercase">
-            시작하기
-          </p>
-          <h2 className="mt-4 text-[2rem] leading-[1.08] font-black tracking-[-0.05em] text-balance sm:text-[2.6rem]">
+    <section className={styles.section}>
+      <div className={styles.shell}>
+        <div className={styles.content}>
+          <p className={styles.eyebrow}>시작하기</p>
+          <h2 className={styles.title}>
             흩어진 지원 기록을 한곳에 모아보세요.
           </h2>
-          <p className="mt-4 text-sm leading-6 text-muted-foreground">
+          <p className={styles.description}>
             지금 바로 로그인해서 공고와 일정을 정리할 수 있습니다.
           </p>
         </div>
 
-        <Button
-          asChild
-          className="h-[3.25rem] w-full rounded-full px-7 text-sm font-bold sm:w-auto"
-        >
+        <Button asChild className={styles.button}>
           <a href="/login">
             로그인하고 시작하기
             <ArrowRightIcon className="size-4" />

--- a/app/_components/landing/HeroSection.module.css
+++ b/app/_components/landing/HeroSection.module.css
@@ -1,0 +1,84 @@
+.section {
+  background: var(--color-background);
+}
+
+.shell {
+  display: flex;
+  align-items: center;
+  min-height: calc(100svh - 4.5rem);
+  width: 100%;
+  max-width: 80rem;
+  margin: 0 auto;
+  padding: 5rem 1.5rem;
+}
+
+.content {
+  max-width: 42rem;
+}
+
+.fadeUp {
+  animation: var(--animate-fade-up);
+}
+
+.eyebrow {
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.24em;
+  color: var(--color-primary);
+  text-transform: uppercase;
+}
+
+.intro {
+  margin-top: 1rem;
+  font-size: 0.875rem;
+  color: var(--color-muted-foreground);
+}
+
+.title {
+  margin-top: 1.25rem;
+  font-size: 2.7rem;
+  font-weight: 900;
+  line-height: 1.02;
+  letter-spacing: -0.05em;
+  color: var(--color-foreground);
+  text-wrap: balance;
+}
+
+.summary {
+  max-width: 36rem;
+  margin-top: 1.5rem;
+  font-size: 1rem;
+  line-height: 1.75;
+  color: var(--color-muted-foreground);
+}
+
+.list {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 2.5rem;
+  padding-top: 1.5rem;
+  font-size: 0.875rem;
+  color: var(--color-muted-foreground);
+  border-top: 1px solid var(--color-border);
+}
+
+@media (min-width: 640px) {
+  .title {
+    font-size: 3.6rem;
+  }
+
+  .list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .shell {
+    padding-right: 2.5rem;
+    padding-left: 2.5rem;
+  }
+
+  .title {
+    font-size: 4.2rem;
+  }
+}

--- a/app/_components/landing/HeroSection.tsx
+++ b/app/_components/landing/HeroSection.tsx
@@ -1,3 +1,5 @@
+import styles from "./HeroSection.module.css";
+
 const HERO_ANIMATION_DELAYS = {
   heading: "140ms",
   intro: "80ms",
@@ -7,27 +9,25 @@ const HERO_ANIMATION_DELAYS = {
 
 export function HeroSection() {
   return (
-    <section className="bg-background">
-      <div className="mx-auto flex min-h-[calc(100svh-4.5rem)] max-w-7xl items-center px-6 py-20 lg:px-10">
-        <div className="max-w-2xl">
-          <p className="animate-fade-up text-sm font-semibold tracking-[0.24em] text-primary uppercase">
-            201 escape
-          </p>
+    <section className={styles.section}>
+      <div className={styles.shell}>
+        <div className={styles.content}>
+          <p className={`${styles.fadeUp} ${styles.eyebrow}`}>201 escape</p>
           <p
-            className="mt-4 animate-fade-up text-sm text-muted-foreground"
+            className={`${styles.fadeUp} ${styles.intro}`}
             style={{ animationDelay: HERO_ANIMATION_DELAYS.intro }}
           >
             공고, 지원 단계, 면접 일정을 한곳에서 정리합니다.
           </p>
           <h1
-            className="mt-5 animate-fade-up text-[2.7rem] leading-[1.02] font-black tracking-[-0.05em] text-balance text-foreground sm:text-[3.6rem] lg:text-[4.2rem]"
+            className={`${styles.fadeUp} ${styles.title}`}
             style={{ animationDelay: HERO_ANIMATION_DELAYS.heading }}
           >
             지원 흐름을
             <br />더 쉽게 정리하세요.
           </h1>
           <p
-            className="mt-6 max-w-xl animate-fade-up text-base leading-7 text-muted-foreground"
+            className={`${styles.fadeUp} ${styles.summary}`}
             style={{ animationDelay: HERO_ANIMATION_DELAYS.summary }}
           >
             저장한 공고와 현재 상태, 예정된 면접 일정을 한 화면에서 확인할 수
@@ -35,7 +35,7 @@ export function HeroSection() {
           </p>
 
           <ul
-            className="mt-10 grid animate-fade-up gap-3 border-t border-border pt-6 text-sm text-muted-foreground sm:grid-cols-3"
+            className={`${styles.fadeUp} ${styles.list}`}
             style={{ animationDelay: HERO_ANIMATION_DELAYS.list }}
           >
             <li>공고를 저장하고 단계별로 관리</li>

--- a/app/login/page.module.css
+++ b/app/login/page.module.css
@@ -1,0 +1,128 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100dvh;
+  background: color-mix(in srgb, var(--color-muted) 30%, transparent);
+}
+
+.body {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  padding: 0 1.25rem 5rem;
+}
+
+.card {
+  width: 100%;
+  max-width: 24rem;
+  padding: 2.5rem;
+  background: var(--color-background);
+  border: 1px solid color-mix(in srgb, var(--color-border) 50%, transparent);
+  border-radius: 2rem;
+  box-shadow: 0 24px 80px -48px rgb(0 0 0 / 0.24);
+}
+
+.cardHeader {
+  margin-bottom: 2.5rem;
+  text-align: center;
+}
+
+.eyebrow {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  color: var(--color-primary);
+  text-transform: uppercase;
+}
+
+.title {
+  margin-top: 0.75rem;
+  font-size: 2rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: var(--color-foreground);
+}
+
+.subtitle {
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-muted-foreground);
+}
+
+.content {
+  display: grid;
+  gap: 1rem;
+}
+
+.googleButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 1rem;
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--color-foreground);
+  cursor: pointer;
+  background: var(--color-background);
+  border: 1px solid color-mix(in srgb, var(--color-border) 60%, transparent);
+  border-radius: 1rem;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.googleButton:hover {
+  background: color-mix(in srgb, var(--color-muted) 30%, transparent);
+  border-color: color-mix(in srgb, var(--color-primary) 20%, transparent);
+}
+
+.googleButton:active {
+  transform: scale(0.98);
+}
+
+.googleButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.googleIcon {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.errorMessage {
+  padding: 0 0.25rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-align: center;
+  color: var(--color-destructive);
+}
+
+.policy {
+  display: flex;
+  justify-content: center;
+  padding: 0 0.25rem;
+}
+
+.policyText {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0 0.25rem;
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+  text-align: center;
+  color: var(--color-muted-foreground);
+}
+
+.policyLink {
+  font-weight: 600;
+  color: var(--color-primary);
+  text-underline-offset: 4px;
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -10,6 +10,7 @@ import { trackEvent } from "@/lib/analytics/client";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 import { PublicHeader } from "../_components/PublicHeader";
+import styles from "./page.module.css";
 
 const PRIVACY_PAGE_HREF = "/privacy" as Route;
 
@@ -52,46 +53,37 @@ function LoginPageContent() {
 
   return (
     <>
-      <div className="flex h-dvh flex-col bg-muted/30">
+      <div className={styles.page}>
         <PublicHeader />
-        <div className="flex flex-1 flex-col items-center justify-center px-5 pb-20">
-          <div className="w-full max-w-sm rounded-[32px] border border-border/50 bg-background p-10 shadow-xl shadow-black/[0.03]">
-            <header className="mb-10 text-center">
-              <span className="text-[11px] font-bold tracking-[0.2em] text-primary uppercase">
-                Welcome
-              </span>
-              <h1 className="mt-3 text-[32px] font-extrabold tracking-tight text-foreground">
-                로그인
-              </h1>
-              <p className="mt-2 text-sm font-medium text-muted-foreground">
+        <div className={styles.body}>
+          <div className={styles.card}>
+            <header className={styles.cardHeader}>
+              <span className={styles.eyebrow}>Welcome</span>
+              <h1 className={styles.title}>로그인</h1>
+              <p className={styles.subtitle}>
                 201 escape에 오신 것을 환영합니다.
               </p>
             </header>
 
-            <div className="space-y-4">
+            <div className={styles.content}>
               <button
-                className="flex w-full cursor-pointer items-center justify-center gap-3 rounded-2xl border border-border/60 bg-background px-4 py-4 text-[15px] font-bold text-foreground transition-all hover:border-primary/20 hover:bg-muted/30 active:scale-[0.98]"
+                className={styles.googleButton}
                 disabled={isLoading}
                 onClick={handleGoogleLogin}
                 type="button"
               >
-                <GoogleIcon className="h-5 w-5" />
+                <GoogleIcon className={styles.googleIcon} />
                 <span>{isLoading ? "로그인 중..." : "Google로 계속하기"}</span>
               </button>
 
               {errorMessage && (
-                <p className="px-1 text-center text-sm font-medium text-destructive">
-                  {errorMessage}
-                </p>
+                <p className={styles.errorMessage}>{errorMessage}</p>
               )}
 
-              <div className="flex justify-center px-1">
-                <p className="inline-flex flex-wrap items-center justify-center gap-x-1 text-center text-xs leading-5 text-muted-foreground">
+              <div className={styles.policy}>
+                <p className={styles.policyText}>
                   <span>계속 진행하면</span>
-                  <Link
-                    className="font-semibold text-primary underline underline-offset-4"
-                    href={PRIVACY_PAGE_HREF}
-                  >
+                  <Link className={styles.policyLink} href={PRIVACY_PAGE_HREF}>
                     개인정보처리방침
                   </Link>
                   <span>에 동의한 것으로 간주됩니다.</span>

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from "./useDrag";
+export * from "./useIdleMount";
 export * from "./useIsMounted";
 export * from "./useScrollLock";

--- a/hooks/useIdleMount.ts
+++ b/hooks/useIdleMount.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type UseIdleMountOptions = {
+  fallbackDelayMs?: number;
+  timeoutMs?: number;
+};
+
+export function useIdleMount(options: UseIdleMountOptions = {}) {
+  const { fallbackDelayMs = 400, timeoutMs = 1200 } = options;
+  const [shouldMount, setShouldMount] = useState(false);
+
+  useEffect(() => {
+    const requestIdle = window.requestIdleCallback;
+
+    if (requestIdle) {
+      const idleId = requestIdle(
+        () => {
+          setShouldMount(true);
+        },
+        { timeout: timeoutMs },
+      );
+
+      return () => {
+        window.cancelIdleCallback(idleId);
+      };
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setShouldMount(true);
+    }, fallbackDelayMs);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [fallbackDelayMs, timeoutMs]);
+
+  return shouldMount;
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #306

## 📌 작업 내용

- 랜딩, 로그인, 공용 헤더 스타일을 CSS Module 기반으로 재구성
- 테마 토글, 차트, 공고 추가 트리거를 idle 시점에 동적 마운트
- 지원 목록 첫 페이지를 서버에서 로드하고 페이징/에러 상태를 명시적으로 처리


