### PR TITLE
fix: 모바일 바텀시트 버그 수정(#316)

### DIFF
--- a/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
@@ -22,7 +22,7 @@ import { toDatetimeLocalValue } from "@/lib/utils";
 const INTERVIEW_TYPES = Constants.public.Enums.interview_type;
 
 const INPUT_CLASS =
-  "w-full rounded-md border border-input bg-background px-3 py-2 text-base text-foreground placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50";
+  "min-w-0 w-full rounded-md border border-input bg-background px-3 py-2 text-base text-foreground placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50";
 
 export type InterviewFormSheetProps = AddModeProps | EditModeProps;
 

--- a/app/(protected)/applications/_components/components/ApplicationPreviewSheet.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationPreviewSheet.tsx
@@ -272,7 +272,10 @@ export function ApplicationPreviewSheet({
               asChild
               className="h-11 w-full justify-between rounded-xl px-4"
             >
-              <Link href={`/applications/${application.id}` as Route}>
+              <Link
+                href={`/applications/${application.id}` as Route}
+                onClick={onCloseAction}
+              >
                 {footerButtonContent}
               </Link>
             </Button>


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #316

## 📌 작업 내용

- InterviewFormSheet INPUT_CLASS에 min-w-0 추가로 datetime-local 입력 필드 오버플로우 방지
- ApplicationPreviewSheet 상세 링크에 onClick={onCloseAction} 추가로 뒤로가기 시 preview 상태 잔류 방지

