### PR TITLE
release: 모바일 바텀시트 버그 수정 및 README 미리보기 이미지 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,21 @@
   <tr>
     <td align="center"><strong>KPI 요약</strong></td>
     <td align="center"><strong>주요 비율</strong></td>
+  </tr>
+  <tr>
+    <td><img src="./docs/images/readme/dashboard_kpis.png" alt="지원 완료 건수와 단계별 KPI 요약을 보여주는 대시보드 화면" width="340" /></td>
+    <td><img src="./docs/images/readme/dashboard_kpis2.png" alt="서류 통과율, 최종 합격률, 저장 공고 비중을 보여주는 핵심 비율 카드 화면" width="340" /></td>
+  </tr>
+</table>
+
+<table>
+  <tr>
     <td align="center"><strong>단계별 퍼널</strong></td>
     <td align="center"><strong>월간 지원 추이</strong></td>
   </tr>
   <tr>
-    <td><img src="./docs/images/readme/dashboard_kpis.png" alt="지원 완료 건수와 단계별 KPI 요약을 보여주는 대시보드 화면" width="220" /></td>
-    <td><img src="./docs/images/readme/dashboard_kpis2.png" alt="서류 통과율, 최종 합격률, 저장 공고 비중을 보여주는 핵심 비율 카드 화면" width="220" /></td>
-    <td><img src="./docs/images/readme/dashboard_funnel.png" alt="지원 기준 단계별 잔존 비율을 보여주는 퍼널 화면" width="220" /></td>
-    <td><img src="./docs/images/readme/dashboard_monthly_trend.png" alt="최근 12개월 지원 추이와 최근 흐름 메모를 보여주는 대시보드 화면" width="220" /></td>
+    <td><img src="./docs/images/readme/dashboard_funnel.png" alt="지원 기준 단계별 잔존 비율을 보여주는 퍼널 화면" width="340" /></td>
+    <td><img src="./docs/images/readme/dashboard_monthly_trend.png" alt="최근 12개월 지원 추이와 최근 흐름 메모를 보여주는 대시보드 화면" width="340" /></td>
   </tr>
 </table>
 
@@ -60,14 +67,21 @@
   <tr>
     <td align="center"><strong>지원 목록</strong></td>
     <td align="center"><strong>검색</strong></td>
+  </tr>
+  <tr>
+    <td><img src="./docs/images/readme/application_list.png" alt="상태 탭과 정렬을 포함한 지원 목록 화면" width="340" /></td>
+    <td><img src="./docs/images/readme/application_search.gif" alt="회사명 검색으로 지원 목록을 빠르게 좁히는 화면" width="340" /></td>
+  </tr>
+</table>
+
+<table>
+  <tr>
     <td align="center"><strong>미리보기 시트</strong></td>
     <td align="center"><strong>공고 추가</strong></td>
   </tr>
   <tr>
-    <td><img src="./docs/images/readme/application_list.png" alt="상태 탭과 정렬을 포함한 지원 목록 화면" width="220" /></td>
-    <td><img src="./docs/images/readme/application_search.gif" alt="회사명 검색으로 지원 목록을 빠르게 좁히는 화면" width="220" /></td>
-    <td><img src="./docs/images/readme/application_previewsheet.gif" alt="지원 상태와 핵심 정보를 미리보기 시트로 확인하는 화면" width="220" /></td>
-    <td><img src="./docs/images/readme/application_add_application.gif" alt="회사명, 포지션, 공고 URL을 입력해 새 공고를 추가하는 화면" width="220" /></td>
+    <td><img src="./docs/images/readme/application_previewsheet.gif" alt="지원 상태와 핵심 정보를 미리보기 시트로 확인하는 화면" width="340" /></td>
+    <td><img src="./docs/images/readme/application_add_application.gif" alt="회사명, 포지션, 공고 URL을 입력해 새 공고를 추가하는 화면" width="340" /></td>
   </tr>
 </table>
 
@@ -79,12 +93,19 @@
   <tr>
     <td align="center"><strong>상세 정보</strong></td>
     <td align="center"><strong>면접 일정 추가</strong></td>
+  </tr>
+  <tr>
+    <td><img src="./docs/images/readme/application_detail.png" alt="지원 상태 변경과 기본 정보를 관리하는 지원 상세 화면" width="340" /></td>
+    <td><img src="./docs/images/readme/application_detail_add_interview.gif" alt="지원 상세 화면에서 면접 일정을 추가하는 흐름" width="340" /></td>
+  </tr>
+</table>
+
+<table>
+  <tr>
     <td align="center"><strong>개인 메모 추가</strong></td>
   </tr>
   <tr>
-    <td><img src="./docs/images/readme/application_detail.png" alt="지원 상태 변경과 기본 정보를 관리하는 지원 상세 화면" width="220" /></td>
-    <td><img src="./docs/images/readme/application_detail_add_interview.gif" alt="지원 상세 화면에서 면접 일정을 추가하는 흐름" width="220" /></td>
-    <td><img src="./docs/images/readme/application_detail_add_memo.gif" alt="지원 상세 화면에서 개인 메모를 남기는 흐름" width="220" /></td>
+    <td><img src="./docs/images/readme/application_detail_add_memo.gif" alt="지원 상세 화면에서 개인 메모를 남기는 흐름" width="340" /></td>
   </tr>
 </table>
 

--- a/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
@@ -22,7 +22,7 @@ import { toDatetimeLocalValue } from "@/lib/utils";
 const INTERVIEW_TYPES = Constants.public.Enums.interview_type;
 
 const INPUT_CLASS =
-  "w-full rounded-md border border-input bg-background px-3 py-2 text-base text-foreground placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50";
+  "min-w-0 w-full rounded-md border border-input bg-background px-3 py-2 text-base text-foreground placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50";
 
 export type InterviewFormSheetProps = AddModeProps | EditModeProps;
 

--- a/app/(protected)/applications/_components/components/ApplicationPreviewSheet.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationPreviewSheet.tsx
@@ -272,7 +272,10 @@ export function ApplicationPreviewSheet({
               asChild
               className="h-11 w-full justify-between rounded-xl px-4"
             >
-              <Link href={`/applications/${application.id}` as Route}>
+              <Link
+                href={`/applications/${application.id}` as Route}
+                onClick={onCloseAction}
+              >
                 {footerButtonContent}
               </Link>
             </Button>


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #316, #318

## 📌 작업 내용

- `InterviewFormSheet` 입력 필드에 `min-w-0`를 추가해 모바일에서 `datetime-local` 입력이 바텀시트 너비를 밀어내던 오버플로우를 수정
- `ApplicationPreviewSheet` 상세 링크 클릭 시 `onCloseAction`을 실행해 뒤로가기 후 preview 상태가 남는 문제를 정리
- README 대시보드·지원 목록·지원 상세 섹션 미리보기 이미지를 2열 구성에 맞게 재배치하고 이미지 너비를 확대해 가독성을 개선
