### PR TITLE
chore: 공고 추가 포지션 추천 목록 업데이트(#323)

### DIFF
--- a/app/(protected)/applications/_components/add-job/utils/positionTitle.ts
+++ b/app/(protected)/applications/_components/add-job/utils/positionTitle.ts
@@ -1,9 +1,11 @@
 export const COMMON_POSITION_TITLE_SUGGESTIONS = [
   "프론트엔드 엔지니어",
-  "프론트엔드 개발자",
-  "웹 프론트엔드 개발자",
-  "풀스택 엔지니어",
-  "프로덕트 엔지니어",
+  "백엔드 엔지니어",
+  "풀스택 개발자",
+  "프로덕트 매니저",
+  "프로덕트 디자이너",
+  "데이터 엔지니어",
+  "DevOps 엔지니어",
 ] as const;
 
 export const LAST_POSITION_TITLE_STORAGE_KEY = "201-escape:last-position-title";


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #323

## 📌 작업 내용

- 포지션 기본 추천 목록에서 프론트엔드 외 직군 구성을 현실적으로 조정
- 백엔드 엔지니어, 풀스택 개발자, 프로덕트 매니저, 프로덕트 디자이너 추가
- 데이터 엔지니어, DevOps 엔지니어를 추가해 추천 범위 확장


