### PR TITLE
release: 면접 일정 입력 모바일 레이아웃 수정 및 공고 포지션 추천 확장

### DIFF
--- a/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
@@ -17,12 +17,16 @@ import { trackEvent } from "@/lib/analytics/client";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { INTERVIEW_TYPE_LABEL } from "@/lib/constants/interview-type";
 import { Constants } from "@/lib/types/supabase";
-import { toDatetimeLocalValue } from "@/lib/utils";
+import { cn, toDatetimeLocalValue } from "@/lib/utils";
 
 const INTERVIEW_TYPES = Constants.public.Enums.interview_type;
-
-const INPUT_CLASS =
-  "min-w-0 w-full rounded-md border border-input bg-background px-3 py-2 text-base text-foreground placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50";
+const INPUT_CLASS = cn(
+  "min-w-0 w-full rounded-md border border-input",
+  "bg-background px-3 py-2 text-base text-foreground",
+  "placeholder:text-muted-foreground",
+  "focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
+  "disabled:cursor-not-allowed disabled:opacity-50",
+);
 
 export type InterviewFormSheetProps = AddModeProps | EditModeProps;
 
@@ -220,7 +224,10 @@ export function InterviewFormSheet(props: InterviewFormSheetProps) {
                   일시
                 </label>
                 <input
-                  className={INPUT_CLASS}
+                  className={cn(
+                    INPUT_CLASS,
+                    "mobile-datetime-local-input max-w-full",
+                  )}
                   disabled={isSaving}
                   id="interview-scheduled-at"
                   onChange={(e) =>

--- a/app/(protected)/applications/_components/add-job/utils/positionTitle.ts
+++ b/app/(protected)/applications/_components/add-job/utils/positionTitle.ts
@@ -1,9 +1,11 @@
 export const COMMON_POSITION_TITLE_SUGGESTIONS = [
   "프론트엔드 엔지니어",
-  "프론트엔드 개발자",
-  "웹 프론트엔드 개발자",
-  "풀스택 엔지니어",
-  "프로덕트 엔지니어",
+  "백엔드 엔지니어",
+  "풀스택 개발자",
+  "프로덕트 매니저",
+  "프로덕트 디자이너",
+  "데이터 엔지니어",
+  "DevOps 엔지니어",
 ] as const;
 
 export const LAST_POSITION_TITLE_STORAGE_KEY = "201-escape:last-position-title";

--- a/app/globals.css
+++ b/app/globals.css
@@ -75,6 +75,28 @@
     --color-input: #31343c;
     --color-ring: #9db58d;
   }
+
+  input[type="datetime-local"].mobile-datetime-local-input {
+    min-width: 0;
+  }
+
+  input[type="datetime-local"].mobile-datetime-local-input::-webkit-date-and-time-value {
+    min-width: 0;
+    text-align: left;
+  }
+
+  input[type="datetime-local"].mobile-datetime-local-input::-webkit-datetime-edit {
+    min-width: 0;
+    padding: 0;
+  }
+
+  input[type="datetime-local"].mobile-datetime-local-input::-webkit-datetime-edit-fields-wrapper {
+    min-width: 0;
+  }
+
+  input[type="datetime-local"].mobile-datetime-local-input::-webkit-calendar-picker-indicator {
+    margin: 0;
+  }
 }
 
 @keyframes slide-up {

--- a/components/ui/bottom-sheet/BottomSheet.tsx
+++ b/components/ui/bottom-sheet/BottomSheet.tsx
@@ -54,7 +54,7 @@ function Content({
       tabIndex={-1}
       {...props}
       className={cn(
-        "w-full max-w-md rounded-t-[32px] bg-background shadow-2xl",
+        "w-full max-w-md min-w-0 rounded-t-[32px] bg-background shadow-2xl",
         "pointer-events-auto relative flex flex-col",
         "max-h-[92vh] min-h-[40vh]",
         "pb-[env(safe-area-inset-bottom)]",


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #321, #323

## 📌 작업 내용

- 모바일에서 `datetime-local` 입력 필드가 바텀시트 레이아웃을 밀어내던 문제를 수정해 면접 일정 입력 UI를 안정화
- 공고 추가 시 기본 추천 포지션 목록에 백엔드, 풀스택, PM, 프로덕트 디자이너, 데이터 엔지니어, DevOps 엔지니어를 반영해 추천 범위를 현실적으로 확장