### PR TITLE
fix: 모바일 면접 일정 바텀시트 datetime-local overflow 수정(#326)

### DIFF
--- a/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
@@ -223,23 +223,28 @@ export function InterviewFormSheet(props: InterviewFormSheetProps) {
                 >
                   일시
                 </label>
-                <input
+                <div
                   className={cn(
-                    INPUT_CLASS,
-                    "mobile-datetime-local-input max-w-full",
+                    "w-full min-w-0 rounded-md border border-input bg-background px-3 py-2",
+                    "focus-within:ring-2 focus-within:ring-ring",
+                    isSaving && "cursor-not-allowed opacity-50",
                   )}
-                  disabled={isSaving}
-                  id="interview-scheduled-at"
-                  onChange={(e) =>
-                    setValues((prev) => ({
-                      ...prev,
-                      scheduledAt: e.target.value,
-                    }))
-                  }
-                  required
-                  type="datetime-local"
-                  value={values.scheduledAt}
-                />
+                >
+                  <input
+                    className="mobile-datetime-local-input block w-full min-w-0 bg-transparent px-0 py-0 text-base text-foreground focus:outline-none disabled:cursor-not-allowed"
+                    disabled={isSaving}
+                    id="interview-scheduled-at"
+                    onChange={(e) =>
+                      setValues((prev) => ({
+                        ...prev,
+                        scheduledAt: e.target.value,
+                      }))
+                    }
+                    required
+                    type="datetime-local"
+                    value={values.scheduledAt}
+                  />
+                </div>
               </div>
 
               <div className="space-y-1.5">


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #326

## 📌 작업 내용

- datetime-local 입력을 wrapper 기반 구조로 변경
- 입력 본체의 좌우 padding을 제거해 모바일에서 폭이 튀어나가는 문제를 완화
- 바깥 wrapper가 border, background, focus ring을 담당하도록 정리


