### PR TITLE
release: 모바일 면접 일정 바텀시트 datetime-local overflow 수정

### DIFF
--- a/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
@@ -223,23 +223,28 @@ export function InterviewFormSheet(props: InterviewFormSheetProps) {
                 >
                   일시
                 </label>
-                <input
+                <div
                   className={cn(
-                    INPUT_CLASS,
-                    "mobile-datetime-local-input max-w-full",
+                    "w-full min-w-0 rounded-md border border-input bg-background px-3 py-2",
+                    "focus-within:ring-2 focus-within:ring-ring",
+                    isSaving && "cursor-not-allowed opacity-50",
                   )}
-                  disabled={isSaving}
-                  id="interview-scheduled-at"
-                  onChange={(e) =>
-                    setValues((prev) => ({
-                      ...prev,
-                      scheduledAt: e.target.value,
-                    }))
-                  }
-                  required
-                  type="datetime-local"
-                  value={values.scheduledAt}
-                />
+                >
+                  <input
+                    className="mobile-datetime-local-input block w-full min-w-0 bg-transparent px-0 py-0 text-base text-foreground focus:outline-none disabled:cursor-not-allowed"
+                    disabled={isSaving}
+                    id="interview-scheduled-at"
+                    onChange={(e) =>
+                      setValues((prev) => ({
+                        ...prev,
+                        scheduledAt: e.target.value,
+                      }))
+                    }
+                    required
+                    type="datetime-local"
+                    value={values.scheduledAt}
+                  />
+                </div>
               </div>
 
               <div className="space-y-1.5">


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #326

## 📌 작업 내용

- `InterviewFormSheet`의 `datetime-local` 입력 필드가 모바일 환경에서 바텀시트 너비를 밀어내던 overflow 문제를 수정해 면접 일정 입력 UI가 작은 화면에서도 안정적으로 유지되도록 정리
- 입력 행 레이아웃과 필드 크기 동작을 조정해 날짜/시간 입력 요소가 컨테이너 안에서 자연스럽게 줄어들도록 개선