### PR TITLE
fix: Supabase OAuth 콜백을 현재 origin 기준으로 리다이렉트하도록 수정(#329)

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -13,13 +13,7 @@ export async function GET(request: Request) {
     const supabase = await createClient();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
-      const forwardedHost = request.headers.get("x-forwarded-host");
-      const host = forwardedHost ?? new URL(request.url).hostname;
-      const isLocalhost = host.split(":")[0] === "localhost";
-      const redirectOrigin = isLocalhost
-        ? `http://localhost:3000`
-        : `https://${host}`;
-      return NextResponse.redirect(`${redirectOrigin}${next}`);
+      return NextResponse.redirect(`${origin}${next}`);
     }
   }
 


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #329

## 📌 작업 내용

- auth callback 라우트에서 x-forwarded-host 우선 사용을 제거
- OAuth code exchange 성공 후 request.url origin 기준으로 리다이렉트하도록 단순화
- Vercel preview 환경에서 로그인 후 프로덕션 도메인으로 이동하던 문제 수정


