### PR TITLE
fix: 상세 진입 후 iOS 뒤로가기 시 공고 미리보기 바텀시트 재노출 방지(#335)

### DIFF
--- a/app/(protected)/applications/_components/components/ApplicationPreviewSheet.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationPreviewSheet.tsx
@@ -36,6 +36,7 @@ type ApplicationPreviewSheetProps = {
   application: ApplicationListItem | null;
   isOpen: boolean;
   onCloseAction: () => void;
+  onDetailNavigateAction: () => void;
   onStatusChangeAction: (applicationId: string, nextStatus: JobStatus) => void;
 };
 
@@ -66,6 +67,7 @@ export function ApplicationPreviewSheet({
   application,
   isOpen,
   onCloseAction,
+  onDetailNavigateAction,
   onStatusChangeAction,
 }: ApplicationPreviewSheetProps) {
   const [previewState, setPreviewState] = useState<ApplicationPreviewState>({
@@ -272,7 +274,25 @@ export function ApplicationPreviewSheet({
               asChild
               className="h-11 w-full justify-between rounded-xl px-4"
             >
-              <Link href={`/applications/${application.id}` as Route}>
+              <Link
+                href={`/applications/${application.id}` as Route}
+                onClick={(event) => {
+                  if (
+                    event.defaultPrevented ||
+                    event.button !== 0 ||
+                    event.metaKey ||
+                    event.ctrlKey ||
+                    event.shiftKey ||
+                    event.altKey
+                  ) {
+                    return;
+                  }
+
+                  // iOS Safari bfcache 복원 시 이전 목록 URL의 preview 파라미터로
+                  // 바텀시트가 다시 열리지 않도록 현재 히스토리 엔트리를 정리합니다.
+                  onDetailNavigateAction();
+                }}
+              >
                 {footerButtonContent}
               </Link>
             </Button>

--- a/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
@@ -162,6 +162,16 @@ export function ApplicationsPanel({ dateLabel }: ApplicationsPanelProps) {
     updateParams({ [PREVIEW_PARAM]: "" });
   };
 
+  const handleDetailNavigate = () => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete(PREVIEW_PARAM);
+
+    const query = params.toString();
+    const nextUrl = `${pathname}${query ? `?${query}` : ""}`;
+
+    window.history.replaceState(window.history.state, "", nextUrl);
+  };
+
   const handleStatusChange = (applicationId: string, nextStatus: JobStatus) => {
     queryClient.setQueryData<InfiniteData<GetApplicationsPage>>(
       queryKey,
@@ -232,6 +242,7 @@ export function ApplicationsPanel({ dateLabel }: ApplicationsPanelProps) {
         application={selectedApplication}
         isOpen={isPreviewOpen}
         onCloseAction={handleClosePreview}
+        onDetailNavigateAction={handleDetailNavigate}
         onStatusChangeAction={handleStatusChange}
       />
       <GoToTopFAB


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #335

## 📌 작업 내용

- ApplicationPreviewSheet 상세 링크 클릭 시 현재 목록 히스토리 엔트리에서 preview 쿼리 파라미터를 제거하도록 변경
- iOS Safari bfcache 복원으로 이전 목록 URL이 살아나도 미리보기 바텀시트가 다시 열리지 않도록 수정
- 메타키, 컨트롤키, 보조 클릭 등 새 탭 열기 동작은 기존처럼 유지되도록 클릭 가드 추가

