### PR TITLE
fix: PostHog 이벤트 수집 경로를 복구하고 상태 변경 이벤트 스키마를 정렬(#342)

### DIFF
--- a/app/(protected)/_components/ApplicationStatusSelector.tsx
+++ b/app/(protected)/_components/ApplicationStatusSelector.tsx
@@ -30,6 +30,11 @@ export type ApplicationStatusSelectorProps = {
   updateStatusAction: UpdateStatusAction;
 };
 
+type StatusMutationInput = {
+  nextStatus: JobStatus;
+  previousStatus: JobStatus;
+};
+
 type UpdateStatusAction = (
   input: UpdateApplicationStatusInput,
 ) => Promise<UpdateApplicationStatusResult>;
@@ -63,12 +68,13 @@ export function ApplicationStatusSelector({
   const mutation = useMutation<
     void,
     Error,
-    JobStatus,
+    StatusMutationInput,
     { previousStatus: JobStatus }
   >({
-    mutationFn: async (nextStatus) => {
+    mutationFn: async ({ nextStatus, previousStatus }) => {
       const result = await updateStatusAction({
         applicationId,
+        previousStatus,
         status: nextStatus,
       });
       if (!result.ok) {
@@ -82,8 +88,7 @@ export function ApplicationStatusSelector({
       }
       setErrorState({ message: error.message, status });
     },
-    onMutate: (nextStatus) => {
-      const previousStatus = currentStatus;
+    onMutate: ({ nextStatus, previousStatus }) => {
       setCurrentStatus(nextStatus);
       setErrorState(null);
       onStatusChangeAction?.(nextStatus);
@@ -103,7 +108,10 @@ export function ApplicationStatusSelector({
       return;
     }
 
-    mutation.mutate(nextStatus as JobStatus);
+    mutation.mutate({
+      nextStatus: nextStatus as JobStatus,
+      previousStatus: currentStatus,
+    });
   }
 
   return (

--- a/lib/actions/__tests__/updateApplicationStatus.test.ts
+++ b/lib/actions/__tests__/updateApplicationStatus.test.ts
@@ -30,6 +30,7 @@ const mockSupabase = {
 
 const VALID_INPUT: UpdateApplicationStatusInput = {
   applicationId: "550e8400-e29b-41d4-a716-446655440000",
+  previousStatus: "SAVED",
   status: "APPLIED",
 };
 
@@ -172,7 +173,7 @@ describe("updateApplicationStatus", () => {
       expect(trackServerEvent).toHaveBeenCalledWith(
         "user-1",
         "application_status_changed",
-        { status: "APPLIED" },
+        { from_status: "SAVED", to_status: "APPLIED" },
       );
     });
 

--- a/lib/actions/updateApplicationStatus.ts
+++ b/lib/actions/updateApplicationStatus.ts
@@ -80,7 +80,12 @@ export async function updateApplicationStatus(
   trackServerEvent(
     authData.user.id,
     ANALYTICS_EVENTS.APPLICATION_STATUS_CHANGED,
-    { status: parsedInput.data.status },
+    parsedInput.data.previousStatus
+      ? {
+          from_status: parsedInput.data.previousStatus,
+          to_status: parsedInput.data.status,
+        }
+      : { to_status: parsedInput.data.status },
   );
 
   return {

--- a/lib/supabase/proxy.ts
+++ b/lib/supabase/proxy.ts
@@ -44,6 +44,7 @@ export async function updateSession(request: NextRequest) {
 
   const isPublicPath =
     pathname === "/" ||
+    pathname.startsWith("/api/events") ||
     pathname.startsWith("/privacy") ||
     pathname.startsWith("/login") ||
     pathname.startsWith("/auth");

--- a/lib/types/application.ts
+++ b/lib/types/application.ts
@@ -14,6 +14,7 @@ const applicationNotesSchema = nullableTextSchema;
 export const updateApplicationStatusInputSchema = z
   .object({
     applicationId: applicationIdSchema,
+    previousStatus: jobStatusSchema.optional(),
     status: jobStatusSchema,
   })
   .strict();


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #342

## 📌 작업 내용

- 인증 프록시에서 `/api/events`를 공개 경로로 허용해 로그인 전 이벤트가 `/login`으로 리다이렉트되지 않도록 수정
- 지원 상태 변경 이벤트에 `from_status`, `to_status`를 포함하도록 바꿔 PostHog 퍼널 설정과 실제 수집 데이터 구조를 일치시킴
- 상태 선택 UI에서 이전 상태를 함께 전달하도록 연결하고 관련 테스트를 갱신해 계측 회귀를 방지
- 로컬 검증에서 `/api/events`가 유효 이벤트에 `204`, 무효 이벤트에 `400`을 반환하는 것까지 확인


