### PR TITLE
perf: 지원 목록 초기 응답 경로와 클라이언트 번들 최적화(#347)

### DIFF
--- a/app/(protected)/applications/_components/ApplicationsView.tsx
+++ b/app/(protected)/applications/_components/ApplicationsView.tsx
@@ -1,20 +1,9 @@
-import {
-  dehydrate,
-  HydrationBoundary,
-  QueryClient,
-} from "@tanstack/react-query";
-import { Suspense } from "react";
-
-import { ApplicationsProviders } from "@/app/(protected)/applications/ApplicationsProviders";
-import { Skeleton } from "@/components/ui";
 import { getApplications } from "@/lib/actions";
 import { formatKoreanDate } from "@/lib/utils";
 
 import { AddJobTrigger } from "./add-job";
 import { ApplicationsPanel } from "./components/ApplicationsPanel";
 import {
-  buildApplicationsQueryKey,
-  getApplicationsNextPageParam,
   getPeriodDateRange,
   PAGE_SIZE,
   parsePeriodParam,
@@ -38,94 +27,31 @@ export async function ApplicationsView({
   const sort = parseSortParam(getString(searchParams[SORT_PARAM]) || null);
   const dateRange = getPeriodDateRange(period);
   const dateLabel = formatKoreanDate(new Date());
-
-  const queryClient = new QueryClient();
-
-  await queryClient.prefetchInfiniteQuery({
-    getNextPageParam: getApplicationsNextPageParam,
-    initialPageParam: 0,
-    pages: 1,
-    queryFn: async ({ pageParam }: { pageParam: number }) => {
-      const result = await getApplications({
-        limit: PAGE_SIZE,
-        offset: pageParam,
-        periodEnd: dateRange?.end,
-        periodStart: dateRange?.start,
-        search: search || undefined,
-        sort,
-      });
-
-      if (!result.ok) {
-        throw new Error(result.reason);
-      }
-
-      return result.data;
-    },
-    queryKey: buildApplicationsQueryKey({ period, search, sort }),
+  const panelKey = JSON.stringify({ period, search, sort });
+  const initialPageResult = await getApplications({
+    limit: PAGE_SIZE,
+    offset: 0,
+    periodEnd: dateRange?.end,
+    periodStart: dateRange?.start,
+    search: search || undefined,
+    sort,
   });
+
+  if (!initialPageResult.ok) {
+    throw new Error(initialPageResult.reason);
+  }
 
   return (
     <main className="min-h-screen bg-background pb-20">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 pt-0 pb-10 sm:px-6 lg:gap-20 lg:px-8 lg:pb-12">
-        <ApplicationsProviders>
-          <HydrationBoundary state={dehydrate(queryClient)}>
-            <Suspense fallback={<ApplicationsViewSkeleton />}>
-              <ApplicationsPanel dateLabel={dateLabel} />
-            </Suspense>
-          </HydrationBoundary>
-        </ApplicationsProviders>
+        <ApplicationsPanel
+          dateLabel={dateLabel}
+          initialPage={initialPageResult.data}
+          key={panelKey}
+        />
       </div>
       <AddJobTrigger />
     </main>
-  );
-}
-
-function ApplicationsViewSkeleton() {
-  return (
-    <div
-      aria-busy="true"
-      aria-label="지원 목록을 불러오는 중입니다"
-      role="status"
-    >
-      <section className="overflow-hidden rounded-3xl bg-muted/30">
-        <div className="px-5 py-8 sm:px-6 lg:px-8 lg:py-10">
-          <div className="grid gap-6 lg:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.9fr)] lg:items-end">
-            <div className="space-y-3">
-              <Skeleton className="h-4 w-32 rounded-full" />
-              <Skeleton className="h-12 w-40 rounded-full" />
-              <Skeleton className="h-5 w-full max-w-2xl rounded-full" />
-              <Skeleton className="h-5 w-5/6 max-w-xl rounded-full" />
-              <Skeleton className="h-5 w-full max-w-lg rounded-full" />
-            </div>
-
-            <div className="grid grid-cols-3 gap-3">
-              {Array.from({ length: 3 }).map((_, i) => (
-                <div className="rounded-2xl bg-background/70 px-4 py-4" key={i}>
-                  <Skeleton className="h-4 w-12 rounded-full" />
-                  <Skeleton className="mt-2 h-8 w-12 rounded-full" />
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <div className="overflow-hidden rounded-3xl border border-border/70 bg-background">
-        <div className="space-y-4 border-b border-border/70 px-5 py-5 sm:px-6">
-          <Skeleton className="h-10 w-full rounded-2xl" />
-          <div className="flex gap-2">
-            <Skeleton className="h-9 w-18 rounded-full" />
-            <Skeleton className="h-9 w-28 rounded-full" />
-            <Skeleton className="h-9 w-22 rounded-full" />
-          </div>
-        </div>
-        <div className="space-y-1 px-4 pb-6 sm:px-5">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <Skeleton className="h-26 w-full rounded-2xl" key={i} />
-          ))}
-        </div>
-      </div>
-    </div>
   );
 }
 

--- a/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
@@ -1,30 +1,27 @@
 "use client";
 
-import type { InfiniteData } from "@tanstack/react-query";
 import type { Route } from "next";
 
-import {
-  useQueryClient,
-  useSuspenseInfiniteQuery,
-} from "@tanstack/react-query";
+import { AlertCircleIcon } from "lucide-react";
 import dynamic from "next/dynamic";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useMemo, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { flushSync } from "react-dom";
 
-import type { GetApplicationsPage } from "@/lib/types/application";
+import type {
+  ApplicationListItem,
+  GetApplicationsPage,
+} from "@/lib/types/application";
 import type { JobStatus } from "@/lib/types/job";
 
+import { Button } from "@/components/ui";
 import { getApplications } from "@/lib/actions";
 
 import type { PeriodPreset, SortValue, TabValue } from "../constants";
-import type { ApplicationListItem } from "../types";
 import type { ApplicationTabsHandle } from "./ApplicationTabs";
 
 import { ApplicationsPageHeader } from "../ApplicationsPageHeader";
 import {
-  buildApplicationsQueryKey,
-  getApplicationsNextPageParam,
   getPeriodDateRange,
   PAGE_SIZE,
   parsePeriodParam,
@@ -50,17 +47,24 @@ const ApplicationPreviewSheet = dynamic(
 
 type ApplicationsPanelProps = {
   dateLabel: string;
+  initialPage: GetApplicationsPage;
 };
 
-export function ApplicationsPanel({ dateLabel }: ApplicationsPanelProps) {
+export function ApplicationsPanel({
+  dateLabel,
+  initialPage,
+}: ApplicationsPanelProps) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const queryClient = useQueryClient();
 
   const tabsRef = useRef<ApplicationTabsHandle>(null);
+  const paginationSequenceRef = useRef(0);
+  const [isFetchingNextPage, setIsFetchingNextPage] = useState(false);
   const [isListScrolled, setIsListScrolled] = useState(false);
   const [isNavigatingFromPreview, setIsNavigatingFromPreview] = useState(false);
+  const [pages, setPages] = useState<GetApplicationsPage[]>([initialPage]);
+  const [paginationError, setPaginationError] = useState<null | string>(null);
 
   const search = searchParams.get(SEARCH_PARAM) ?? "";
   const period = parsePeriodParam(searchParams.get(PERIOD_PARAM));
@@ -68,47 +72,21 @@ export function ApplicationsPanel({ dateLabel }: ApplicationsPanelProps) {
   const tab = parseTabParam(searchParams.get(TAB_PARAM));
   const previewApplicationId = searchParams.get(PREVIEW_PARAM);
 
-  const queryKey = buildApplicationsQueryKey({ period, search, sort });
-  const dateRange = useMemo(() => getPeriodDateRange(period), [period]);
-
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useSuspenseInfiniteQuery({
-      getNextPageParam: getApplicationsNextPageParam,
-      initialPageParam: 0,
-      queryFn: async ({ pageParam }: { pageParam: number }) => {
-        const result = await getApplications({
-          limit: PAGE_SIZE,
-          offset: pageParam,
-          periodEnd: dateRange?.end,
-          periodStart: dateRange?.start,
-          search: search || undefined,
-          sort,
-        });
-        if (!result.ok) {
-          throw new Error(result.reason);
-        }
-        return result.data;
-      },
-      queryKey,
-    });
-
-  const applications: ApplicationListItem[] = data.pages.reduce<
-    ApplicationListItem[]
-  >((items, page) => {
-    items.push(...page.items);
-
-    return items;
-  }, []);
-
-  const selectedApplicationId = previewApplicationId;
-  const isPreviewOpen = selectedApplicationId !== null;
+  const dateRange = getPeriodDateRange(period);
+  const applications = pages.flatMap((page) => page.items);
+  const hasNextPage = pages[pages.length - 1]?.hasMore ?? false;
   const selectedApplication =
-    applications.find((a) => a.id === selectedApplicationId) ?? null;
+    applications.find(
+      (application) => application.id === previewApplicationId,
+    ) ?? null;
   const shouldRenderPreview =
-    isPreviewOpen && !isNavigatingFromPreview && selectedApplication !== null;
+    previewApplicationId !== null &&
+    !isNavigatingFromPreview &&
+    selectedApplication !== null;
 
-  const updateParams = (updates: Record<string, string>) => {
+  function updateParams(updates: Record<string, string>) {
     const params = new URLSearchParams(searchParams.toString());
+
     for (const [key, value] of Object.entries(updates)) {
       if (value) {
         params.set(key, value);
@@ -116,32 +94,33 @@ export function ApplicationsPanel({ dateLabel }: ApplicationsPanelProps) {
         params.delete(key);
       }
     }
+
     const query = params.toString();
     router.replace(
       `${pathname}${query ? `?${query}` : ""}` as unknown as Route,
       { scroll: false },
     );
-  };
+  }
 
-  const handleSearchSubmit = (nextSearch: string) => {
+  function handleSearchSubmit(nextSearch: string) {
     updateParams({ [PREVIEW_PARAM]: "", [SEARCH_PARAM]: nextSearch });
-  };
+  }
 
-  const handlePeriodChange = (nextPeriod: PeriodPreset) => {
+  function handlePeriodChange(nextPeriod: PeriodPreset) {
     updateParams({
       [PERIOD_PARAM]: nextPeriod === "all" ? "" : nextPeriod,
       [PREVIEW_PARAM]: "",
     });
-  };
+  }
 
-  const handleSortChange = (nextSort: SortValue) => {
+  function handleSortChange(nextSort: SortValue) {
     updateParams({
       [PREVIEW_PARAM]: "",
       [SORT_PARAM]: nextSort === "applied_at_desc" ? "" : nextSort,
     });
-  };
+  }
 
-  const handleResetFilters = () => {
+  function handleResetFilters() {
     updateParams({
       [PERIOD_PARAM]: "",
       [PREVIEW_PARAM]: "",
@@ -149,26 +128,26 @@ export function ApplicationsPanel({ dateLabel }: ApplicationsPanelProps) {
       [SORT_PARAM]: "",
       [TAB_PARAM]: "",
     });
-  };
+  }
 
-  const handleTabChange = (nextTab: TabValue) => {
+  function handleTabChange(nextTab: TabValue) {
     updateParams({
       [PREVIEW_PARAM]: "",
       [TAB_PARAM]: nextTab === "all" ? "" : nextTab,
     });
-  };
+  }
 
-  const handleSelectApplication = (application: ApplicationListItem) => {
+  function handleSelectApplication(application: ApplicationListItem) {
     setIsNavigatingFromPreview(false);
     updateParams({ [PREVIEW_PARAM]: application.id });
-  };
+  }
 
-  const handleClosePreview = () => {
+  function handleClosePreview() {
     setIsNavigatingFromPreview(false);
     updateParams({ [PREVIEW_PARAM]: "" });
-  };
+  }
 
-  const handleDetailNavigate = () => {
+  function handleDetailNavigate() {
     // iOS Safari bfcache가 "열린 시트" 상태를 스냅샷하지 않도록 상세 이동 직전에 프리뷰를 즉시 제거합니다.
     flushSync(() => {
       setIsNavigatingFromPreview(true);
@@ -181,42 +160,62 @@ export function ApplicationsPanel({ dateLabel }: ApplicationsPanelProps) {
     const nextUrl = `${pathname}${query ? `?${query}` : ""}`;
 
     window.history.replaceState(window.history.state, "", nextUrl);
-  };
+  }
 
-  const handleStatusChange = (applicationId: string, nextStatus: JobStatus) => {
-    queryClient.setQueryData<InfiniteData<GetApplicationsPage>>(
-      queryKey,
-      (old) => {
-        if (!old) {
-          return old;
-        }
-        return {
-          ...old,
-          pages: old.pages.map((page) => ({
-            ...page,
-            items: page.items.map((item) =>
-              item.id === applicationId
-                ? { ...item, status: nextStatus }
-                : item,
-            ),
-          })),
-        };
-      },
+  function handleStatusChange(applicationId: string, nextStatus: JobStatus) {
+    setPages((currentPages) =>
+      currentPages.map((page) => ({
+        ...page,
+        items: page.items.map((item) => {
+          if (item.id !== applicationId) {
+            return item;
+          }
+
+          return { ...item, status: nextStatus };
+        }),
+      })),
     );
-  };
+  }
 
-  const handleNearEnd = () => {
-    if (hasNextPage && !isFetchingNextPage) {
-      fetchNextPage();
+  async function handleNearEnd() {
+    if (isFetchingNextPage || !hasNextPage) {
+      return;
     }
-  };
+
+    const activeSequence = paginationSequenceRef.current;
+
+    setIsFetchingNextPage(true);
+    setPaginationError(null);
+
+    const result = await getApplications({
+      limit: PAGE_SIZE,
+      offset: applications.length,
+      periodEnd: dateRange?.end,
+      periodStart: dateRange?.start,
+      search: search || undefined,
+      sort,
+    });
+
+    if (paginationSequenceRef.current !== activeSequence) {
+      return;
+    }
+
+    if (!result.ok) {
+      setPaginationError(result.reason);
+      setIsFetchingNextPage(false);
+      return;
+    }
+
+    setPages((currentPages) => [...currentPages, result.data]);
+    setIsFetchingNextPage(false);
+  }
 
   return (
     <div className="flex flex-col gap-6">
       <ApplicationsPageHeader
         applications={applications}
         dateLabel={dateLabel}
-        hasNextPage={hasNextPage ?? false}
+        hasNextPage={hasNextPage}
         period={period}
         search={search}
         sort={sort}
@@ -238,7 +237,9 @@ export function ApplicationsPanel({ dateLabel }: ApplicationsPanelProps) {
           applications={applications}
           className="h-[32rem] min-h-0 sm:h-[36rem] lg:h-[40rem]"
           isFetchingNextPage={isFetchingNextPage}
-          onNearEndAction={handleNearEnd}
+          onNearEndAction={() => {
+            void handleNearEnd();
+          }}
           onRangeChangeAction={(startIndex: number) =>
             setIsListScrolled(startIndex > 0)
           }
@@ -247,9 +248,37 @@ export function ApplicationsPanel({ dateLabel }: ApplicationsPanelProps) {
           ref={tabsRef}
           tab={tab}
         />
+
+        {paginationError ? (
+          <div
+            aria-live="polite"
+            className="border-t border-border/70 bg-muted/20 px-5 py-4 sm:px-6"
+            role="status"
+          >
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-start gap-2 text-sm text-red-700">
+                <AlertCircleIcon
+                  aria-hidden="true"
+                  className="mt-0.5 size-4 shrink-0"
+                />
+                <p>추가 목록을 불러오지 못했습니다. {paginationError}</p>
+              </div>
+              <Button
+                className="w-full sm:w-auto"
+                onClick={() => {
+                  void handleNearEnd();
+                }}
+                size="sm"
+                variant="outline"
+              >
+                다시 시도
+              </Button>
+            </div>
+          </div>
+        ) : null}
       </section>
 
-      {shouldRenderPreview && (
+      {shouldRenderPreview ? (
         <ApplicationPreviewSheet
           application={selectedApplication}
           isOpen={true}
@@ -257,7 +286,8 @@ export function ApplicationsPanel({ dateLabel }: ApplicationsPanelProps) {
           onDetailNavigateAction={handleDetailNavigate}
           onStatusChangeAction={handleStatusChange}
         />
-      )}
+      ) : null}
+
       <GoToTopFAB
         className="md:bottom-24"
         isVisible={isListScrolled}

--- a/app/(protected)/applications/_components/constants.ts
+++ b/app/(protected)/applications/_components/constants.ts
@@ -1,5 +1,3 @@
-import type { GetApplicationsPage } from "@/lib/types/application";
-
 import { APPLICATION_STATUS_META } from "@/lib/constants/application-status";
 import { PLATFORM_LABEL } from "@/lib/constants/job-platform";
 import { JobStatus } from "@/lib/types/job";
@@ -120,33 +118,4 @@ export function parseTabParam(value: null | string): TabValue {
   return (TAB_VALUES as readonly string[]).includes(value ?? "")
     ? (value as TabValue)
     : "all";
-}
-
-/**
- * useInfiniteQuery / prefetchInfiniteQuery 공통 query key 베이스
- */
-export const APPLICATIONS_QUERY_KEY = ["applications"] as const;
-
-/**
- * 필터가 포함된 query key를 생성합니다.
- * Panel과 View에서 동일한 key를 사용해 HydrationBoundary가 올바르게 작동합니다.
- */
-export function buildApplicationsQueryKey(params: {
-  period: PeriodPreset;
-  search: string;
-  sort: SortValue;
-}) {
-  return [...APPLICATIONS_QUERY_KEY, params] as const;
-}
-
-/**
- * useInfiniteQuery / prefetchInfiniteQuery 공통 getNextPageParam.
- * lastPageParam + 현재 페이지 아이템 수로 다음 오프셋을 O(1)에 계산합니다.
- */
-export function getApplicationsNextPageParam(
-  lastPage: GetApplicationsPage,
-  _allPages: GetApplicationsPage[],
-  lastPageParam: number,
-): number | undefined {
-  return lastPage.hasMore ? lastPageParam + lastPage.items.length : undefined;
 }

--- a/lib/actions/__tests__/_verifyApplicationOwnership.test.ts
+++ b/lib/actions/__tests__/_verifyApplicationOwnership.test.ts
@@ -14,9 +14,9 @@ const mockEqUserId = vi.fn(() => ({ maybeSingle: mockMaybeSingle }));
 const mockEqId = vi.fn(() => ({ eq: mockEqUserId }));
 const mockSelect = vi.fn(() => ({ eq: mockEqId }));
 const mockFrom = vi.fn(() => ({ select: mockSelect }));
-const mockGetUser = vi.fn();
+const mockGetClaims = vi.fn();
 const mockSupabase = {
-  auth: { getUser: mockGetUser },
+  auth: { getClaims: mockGetClaims },
   from: mockFrom,
 };
 
@@ -26,8 +26,8 @@ const USER_ID = "user-1";
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(createClient).mockResolvedValue(mockSupabase as never);
-  mockGetUser.mockResolvedValue({
-    data: { user: { id: USER_ID } },
+  mockGetClaims.mockResolvedValue({
+    data: { claims: { sub: USER_ID } },
     error: null,
   });
   mockMaybeSingle.mockResolvedValue({
@@ -38,9 +38,9 @@ beforeEach(() => {
 
 describe("verifyApplicationOwnership", () => {
   describe("인증 실패", () => {
-    it("auth.getUser가 에러를 반환하면 AUTH_REQUIRED를 반환한다", async () => {
-      mockGetUser.mockResolvedValue({
-        data: { user: null },
+    it("auth.getClaims가 에러를 반환하면 AUTH_REQUIRED를 반환한다", async () => {
+      mockGetClaims.mockResolvedValue({
+        data: { claims: null },
         error: { message: "JWT expired" },
       });
 
@@ -49,8 +49,11 @@ describe("verifyApplicationOwnership", () => {
       expect(result).toMatchObject({ code: "AUTH_REQUIRED", ok: false });
     });
 
-    it("user가 null이면 AUTH_REQUIRED를 반환한다", async () => {
-      mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    it("claims.sub가 없으면 AUTH_REQUIRED를 반환한다", async () => {
+      mockGetClaims.mockResolvedValue({
+        data: { claims: {} },
+        error: null,
+      });
 
       const result = await verifyApplicationOwnership(APPLICATION_ID);
 
@@ -58,7 +61,10 @@ describe("verifyApplicationOwnership", () => {
     });
 
     it("인증 실패 시 from을 호출하지 않는다", async () => {
-      mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+      mockGetClaims.mockResolvedValue({
+        data: { claims: {} },
+        error: null,
+      });
 
       await verifyApplicationOwnership(APPLICATION_ID);
 

--- a/lib/actions/_auth.ts
+++ b/lib/actions/_auth.ts
@@ -1,0 +1,30 @@
+"server-only";
+
+import type { createClient } from "@/lib/supabase/server";
+
+const AUTH_REQUIRED_REASON = "로그인이 필요합니다.";
+
+type AuthenticatedUserIdResult =
+  | {
+      ok: false;
+      reason: string;
+    }
+  | {
+      ok: true;
+      userId: string;
+    };
+
+type ServerSupabaseClient = Awaited<ReturnType<typeof createClient>>;
+
+export async function getAuthenticatedUserId(
+  supabase: ServerSupabaseClient,
+): Promise<AuthenticatedUserIdResult> {
+  const { data, error } = await supabase.auth.getClaims();
+  const userId = data?.claims?.sub;
+
+  if (error || typeof userId !== "string" || userId.length === 0) {
+    return { ok: false, reason: AUTH_REQUIRED_REASON };
+  }
+
+  return { ok: true, userId };
+}

--- a/lib/actions/_verifyApplicationOwnership.ts
+++ b/lib/actions/_verifyApplicationOwnership.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 
+import { getAuthenticatedUserId } from "./_auth";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 
 type VerifyResult =
@@ -22,13 +23,13 @@ export async function verifyApplicationOwnership(
   applicationId: string,
 ): Promise<VerifyResult> {
   const supabase = await createClient();
-  const { data: authData, error: authError } = await supabase.auth.getUser();
+  const authResult = await getAuthenticatedUserId(supabase);
 
-  if (authError || !authData.user) {
+  if (!authResult.ok) {
     return {
       code: "AUTH_REQUIRED",
       ok: false,
-      reason: "로그인이 필요합니다.",
+      reason: authResult.reason,
     };
   }
 
@@ -36,7 +37,7 @@ export async function verifyApplicationOwnership(
     .from("applications")
     .select("id")
     .eq("id", applicationId)
-    .eq("user_id", authData.user.id)
+    .eq("user_id", authResult.userId)
     .maybeSingle();
 
   if (applicationError) {
@@ -58,5 +59,5 @@ export async function verifyApplicationOwnership(
     };
   }
 
-  return { ok: true, supabase, userId: authData.user.id };
+  return { ok: true, supabase, userId: authResult.userId };
 }

--- a/lib/actions/getApplicationDetail.ts
+++ b/lib/actions/getApplicationDetail.ts
@@ -7,11 +7,11 @@ import {
   type GetApplicationDetailResult,
 } from "@/lib/types/application";
 
+import { getAuthenticatedUserId } from "./_auth";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 
 const ERROR_MESSAGES = {
-  AUTH_REQUIRED: "로그인이 필요합니다.",
   INVALID_RESPONSE: "지원 상세 응답을 해석하지 못했습니다.",
   NOT_FOUND: "지원 상세 정보를 찾을 수 없습니다.",
   VALIDATION_ERROR: "유효하지 않은 applicationId입니다.",
@@ -33,13 +33,13 @@ export async function getApplicationDetail(
   }
 
   const supabase = await createClient();
-  const { data: authData, error: authError } = await supabase.auth.getUser();
+  const authResult = await getAuthenticatedUserId(supabase);
 
-  if (authError || !authData.user) {
+  if (!authResult.ok) {
     return {
       code: "AUTH_REQUIRED",
       ok: false,
-      reason: ERROR_MESSAGES.AUTH_REQUIRED,
+      reason: authResult.reason,
     };
   }
 
@@ -49,7 +49,7 @@ export async function getApplicationDetail(
       "id, applied_at, company_name, description, notes, origin_url, platform, position_title, status",
     )
     .eq("id", parsedApplicationId.data)
-    .eq("user_id", authData.user.id)
+    .eq("user_id", authResult.userId)
     .maybeSingle();
 
   if (error) {

--- a/lib/actions/getApplications.ts
+++ b/lib/actions/getApplications.ts
@@ -6,12 +6,9 @@ import type {
 } from "@/lib/types/application";
 
 import { createClient } from "../supabase/server";
+import { getAuthenticatedUserId } from "./_auth";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
-
-const ERROR_MESSAGES = {
-  AUTH_REQUIRED: "로그인이 필요합니다.",
-} as const;
 
 export async function getApplications({
   limit,
@@ -29,20 +26,20 @@ export async function getApplications({
   sort?: "applied_at_asc" | "applied_at_desc";
 }): Promise<GetApplicationsResult> {
   const supabase = await createClient();
-  const { data: authData, error: authError } = await supabase.auth.getUser();
+  const authResult = await getAuthenticatedUserId(supabase);
 
-  if (authError || !authData.user) {
+  if (!authResult.ok) {
     return {
       code: "AUTH_REQUIRED",
       ok: false,
-      reason: ERROR_MESSAGES.AUTH_REQUIRED,
+      reason: authResult.reason,
     };
   }
 
   let query = supabase
     .from("applications")
     .select("id, applied_at, company_name, platform, position_title, status")
-    .eq("user_id", authData.user.id)
+    .eq("user_id", authResult.userId)
     .order("applied_at", { ascending: sort === "applied_at_asc" })
     .range(offset, offset + limit);
 

--- a/lib/actions/getApplicationsStats.ts
+++ b/lib/actions/getApplicationsStats.ts
@@ -8,12 +8,9 @@ import {
 } from "@/lib/constants/application-status";
 
 import { createClient } from "../supabase/server";
+import { getAuthenticatedUserId } from "./_auth";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
-
-const ERROR_MESSAGES = {
-  AUTH_REQUIRED: "로그인이 필요합니다.",
-} as const;
 
 /**
  * 사용자의 지원 현황 통계를 반환합니다.
@@ -21,17 +18,17 @@ const ERROR_MESSAGES = {
  */
 export async function getApplicationsStats(): Promise<GetApplicationsStatsResult> {
   const supabase = await createClient();
-  const { data: authData, error: authError } = await supabase.auth.getUser();
+  const authResult = await getAuthenticatedUserId(supabase);
 
-  if (authError || !authData.user) {
+  if (!authResult.ok) {
     return {
       code: "AUTH_REQUIRED",
       ok: false,
-      reason: ERROR_MESSAGES.AUTH_REQUIRED,
+      reason: authResult.reason,
     };
   }
 
-  const userId = authData.user.id;
+  const userId = authResult.userId;
 
   const { data, error } = await supabase
     .from("applications")

--- a/lib/actions/getChartData.ts
+++ b/lib/actions/getChartData.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/constants/application-status";
 
 import { createClient, createClientWithToken } from "../supabase/server";
+import { getAuthenticatedUserId } from "./_auth";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 
@@ -111,13 +112,13 @@ const getCachedChartData = unstable_cache(
 
 export async function getChartData(): Promise<GetChartDataResult> {
   const supabase = await createClient();
-  const { data: authData, error: authError } = await supabase.auth.getUser();
+  const authResult = await getAuthenticatedUserId(supabase);
 
-  if (authError || !authData.user) {
+  if (!authResult.ok) {
     return {
       code: "AUTH_REQUIRED",
       ok: false,
-      reason: ERROR_MESSAGES.AUTH_REQUIRED,
+      reason: authResult.reason,
     };
   }
 
@@ -133,7 +134,7 @@ export async function getChartData(): Promise<GetChartDataResult> {
   }
 
   try {
-    const data = await getCachedChartData(authData.user.id, accessToken);
+    const data = await getCachedChartData(authResult.userId, accessToken);
     return { data, ok: true };
   } catch (e) {
     const reason = e instanceof Error ? e.message : "알 수 없는 오류";

--- a/lib/actions/getDashboardData.ts
+++ b/lib/actions/getDashboardData.ts
@@ -16,6 +16,7 @@ import {
 } from "@/lib/constants/application-status";
 
 import { createClient, createClientWithToken } from "../supabase/server";
+import { getAuthenticatedUserId } from "./_auth";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 
@@ -58,13 +59,13 @@ const getCachedDashboardData = unstable_cache(
 
 export async function getDashboardData(): Promise<GetDashboardDataResult> {
   const supabase = await createClient();
-  const { data: authData, error: authError } = await supabase.auth.getUser();
+  const authResult = await getAuthenticatedUserId(supabase);
 
-  if (authError || !authData.user) {
+  if (!authResult.ok) {
     return {
       code: "AUTH_REQUIRED",
       ok: false,
-      reason: ERROR_MESSAGES.AUTH_REQUIRED,
+      reason: authResult.reason,
     };
   }
 
@@ -80,7 +81,7 @@ export async function getDashboardData(): Promise<GetDashboardDataResult> {
   }
 
   try {
-    const data = await getCachedDashboardData(authData.user.id, accessToken);
+    const data = await getCachedDashboardData(authResult.userId, accessToken);
 
     return { data, ok: true };
   } catch (e) {

--- a/lib/actions/getStatCounts.ts
+++ b/lib/actions/getStatCounts.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/constants/application-status";
 
 import { createClient, createClientWithToken } from "../supabase/server";
+import { getAuthenticatedUserId } from "./_auth";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 
@@ -86,13 +87,13 @@ const getCachedStatCounts = unstable_cache(
 
 export async function getStatCounts(): Promise<GetStatCountsResult> {
   const supabase = await createClient();
-  const { data: authData, error: authError } = await supabase.auth.getUser();
+  const authResult = await getAuthenticatedUserId(supabase);
 
-  if (authError || !authData.user) {
+  if (!authResult.ok) {
     return {
       code: "AUTH_REQUIRED",
       ok: false,
-      reason: ERROR_MESSAGES.AUTH_REQUIRED,
+      reason: authResult.reason,
     };
   }
 
@@ -108,7 +109,7 @@ export async function getStatCounts(): Promise<GetStatCountsResult> {
   }
 
   try {
-    const data = await getCachedStatCounts(authData.user.id, accessToken);
+    const data = await getCachedStatCounts(authResult.userId, accessToken);
     return { data, ok: true };
   } catch (e) {
     const reason = e instanceof Error ? e.message : "알 수 없는 오류";


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #347

## 📌 작업 내용

- `/applications` 첫 페이지를 서버에서 직접 조회하고 클라이언트에서는 후속 페이지 로드만 담당하도록 목록 데이터 흐름을 단순화
- 목록 페이지에서 React Query hydration 경로를 제거해 초기 클라이언트 번들 크기와 불필요한 실행 비용을 줄임
- 추가 페이지 로드 실패 시 재시도 UI를 제공해 무한 스크롤 동작을 유지하면서 오류 상태를 명시적으로 노출
- 서버 읽기 액션의 인증 확인을 `auth.getClaims()` 기반 공통 헬퍼로 통일해 중복 인증 조회를 줄이고 초기 TTFB 병목을 완화


