### PR TITLE
perf: applications 초기 번들에서 불필요한 UI 청크 분리(#349)

### DIFF
--- a/app/(protected)/applications/[applicationId]/page.tsx
+++ b/app/(protected)/applications/[applicationId]/page.tsx
@@ -2,7 +2,7 @@ import { FileTextIcon, LockKeyholeIcon } from "lucide-react";
 import { type CSSProperties, Suspense } from "react";
 
 import { ApplicationsProviders } from "@/app/(protected)/applications/ApplicationsProviders";
-import { Skeleton } from "@/components/ui";
+import { Skeleton } from "@/components/ui/skeleton/Skeleton";
 import { deleteApplication, getApplicationDetail } from "@/lib/actions";
 import { updateApplicationNotes } from "@/lib/actions/updateApplicationNotes";
 import { updateApplicationStatus } from "@/lib/actions/updateApplicationStatus";

--- a/app/(protected)/applications/_components/add-job/AddJobSheet.tsx
+++ b/app/(protected)/applications/_components/add-job/AddJobSheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BottomSheet } from "@/components/ui";
+import { BottomSheet } from "@/components/ui/bottom-sheet/BottomSheet";
 
 import { ManualFormView } from "./components/ManualFormView";
 import { ReviewView } from "./components/ReviewView";

--- a/app/(protected)/applications/_components/add-job/AddJobTrigger.tsx
+++ b/app/(protected)/applications/_components/add-job/AddJobTrigger.tsx
@@ -4,7 +4,7 @@ import { Plus as PlusIcon } from "lucide-react";
 import dynamic from "next/dynamic";
 import { useState } from "react";
 
-import { Button } from "@/components/ui";
+import { Button } from "@/components/ui/button/Button";
 import { trackEvent } from "@/lib/analytics/client";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 

--- a/app/(protected)/applications/_components/add-job/components/ManualFormView.tsx
+++ b/app/(protected)/applications/_components/add-job/components/ManualFormView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useId, useState } from "react";
 
-import { Button } from "@/components/ui";
+import { Button } from "@/components/ui/button/Button";
 import { cn } from "@/lib/utils";
 
 type ManualFormFields = {

--- a/app/(protected)/applications/_components/add-job/components/ReviewView.tsx
+++ b/app/(protected)/applications/_components/add-job/components/ReviewView.tsx
@@ -1,6 +1,6 @@
 import type { JobPlatform, JobPost } from "@/lib/types/job";
 
-import { Button } from "@/components/ui";
+import { Button } from "@/components/ui/button/Button";
 import { PLATFORM_LABEL } from "@/lib/constants/job-platform";
 
 type ReviewFieldProps = {

--- a/app/(protected)/applications/_components/add-job/components/UrlInputView.tsx
+++ b/app/(protected)/applications/_components/add-job/components/UrlInputView.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/components/ui";
+import { Button } from "@/components/ui/button/Button";
 import { cn } from "@/lib/utils";
 
 type UrlInputViewProps = {

--- a/app/(protected)/applications/_components/components/ApplicationFilters.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationFilters.tsx
@@ -3,7 +3,7 @@
 import { ChevronDownIcon, SearchIcon, XIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 
-import { Button } from "@/components/ui";
+import { Button } from "@/components/ui/button/Button";
 import { cn } from "@/lib/utils";
 
 import type { PeriodPreset, SortValue } from "../constants";

--- a/app/(protected)/applications/_components/components/ApplicationList.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationList.tsx
@@ -2,7 +2,7 @@ import { InboxIcon } from "lucide-react";
 
 import type { VirtualListHandle } from "@/components/ui/virtual-list";
 
-import { Skeleton } from "@/components/ui";
+import { Skeleton } from "@/components/ui/skeleton/Skeleton";
 import { VirtualList } from "@/components/ui/virtual-list";
 
 import type { ApplicationListItem } from "../types";

--- a/app/(protected)/applications/_components/components/ApplicationPreviewSheet.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationPreviewSheet.tsx
@@ -19,7 +19,9 @@ import type {
 import type { JobStatus } from "@/lib/types/job";
 
 import { ApplicationStatusSelector } from "@/app/(protected)/_components/ApplicationStatusSelector";
-import { BottomSheet, Button, Skeleton } from "@/components/ui";
+import { BottomSheet } from "@/components/ui/bottom-sheet/BottomSheet";
+import { Button } from "@/components/ui/button/Button";
+import { Skeleton } from "@/components/ui/skeleton/Skeleton";
 import { getApplicationDetail } from "@/lib/actions";
 import { updateApplicationStatus } from "@/lib/actions/updateApplicationStatus";
 

--- a/app/(protected)/applications/_components/components/ApplicationTabs.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationTabs.tsx
@@ -4,7 +4,7 @@ import { useImperativeHandle, useRef } from "react";
 
 import type { VirtualListHandle } from "@/components/ui/virtual-list";
 
-import { Tabs } from "@/components/ui";
+import { Tabs } from "@/components/ui/tabs/Tabs";
 import { trackEvent } from "@/lib/analytics/client";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { cn } from "@/lib/utils";

--- a/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
@@ -14,7 +14,7 @@ import type {
 } from "@/lib/types/application";
 import type { JobStatus } from "@/lib/types/job";
 
-import { Button } from "@/components/ui";
+import { Button } from "@/components/ui/button/Button";
 import { getApplications } from "@/lib/actions";
 
 import type { PeriodPreset, SortValue, TabValue } from "../constants";

--- a/app/(protected)/applications/_components/go-to-top/GoToTopFAB.tsx
+++ b/app/(protected)/applications/_components/go-to-top/GoToTopFAB.tsx
@@ -1,6 +1,6 @@
 import { ArrowUp as ArrowUpIcon } from "lucide-react";
 
-import { Button } from "@/components/ui";
+import { Button } from "@/components/ui/button/Button";
 import { cn } from "@/lib/utils";
 
 type GoToTopFABProps = {


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #349

## 📌 작업 내용

- applications 라우트와 상세 화면의 UI import를 배럴 경로 대신 직접 경로로 교체
- 초기 클라이언트 엔트리에서 BottomSheet, Tooltip, TabSelector 등 비필수 UI 코드가 함께 번들링되지 않도록 정리
- /applications 초기 JS 엔트리 청크 수와 총량을 줄여 LCP 및 메인 스레드 초기 작업 부담을 낮출 수 있도록 구조를 개선

