### PR TITLE
perf: 지원 목록 초기 렌더링 비용 축소(#351)

### DIFF
--- a/app/(protected)/applications/_components/ApplicationsView.tsx
+++ b/app/(protected)/applications/_components/ApplicationsView.tsx
@@ -1,17 +1,12 @@
 import { getApplications } from "@/lib/actions";
 import { formatKoreanDate } from "@/lib/utils";
 
+import { parseApplicationsRouteState } from "../_utils/route-state";
 import { AddJobTrigger } from "./add-job";
+import { ApplicationsPageHeader } from "./ApplicationsPageHeader";
+import { ApplicationFilters } from "./components/ApplicationFilters";
 import { ApplicationsPanel } from "./components/ApplicationsPanel";
-import {
-  getPeriodDateRange,
-  PAGE_SIZE,
-  parsePeriodParam,
-  parseSortParam,
-  PERIOD_PARAM,
-  SEARCH_PARAM,
-  SORT_PARAM,
-} from "./constants";
+import { getPeriodDateRange, PAGE_SIZE } from "./constants";
 
 type SearchParams = Record<string, string | string[] | undefined>;
 
@@ -20,11 +15,8 @@ export async function ApplicationsView({
 }: {
   searchParams: SearchParams;
 }) {
-  const search = getString(searchParams[SEARCH_PARAM]);
-  const period = parsePeriodParam(
-    getString(searchParams[PERIOD_PARAM]) || null,
-  );
-  const sort = parseSortParam(getString(searchParams[SORT_PARAM]) || null);
+  const { period, previewApplicationId, search, sort, tab } =
+    parseApplicationsRouteState(searchParams);
   const dateRange = getPeriodDateRange(period);
   const dateLabel = formatKoreanDate(new Date());
   const panelKey = JSON.stringify({ period, search, sort });
@@ -44,17 +36,35 @@ export async function ApplicationsView({
   return (
     <main className="min-h-screen bg-background pb-20">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 pt-0 pb-10 sm:px-6 lg:gap-20 lg:px-8 lg:pb-12">
-        <ApplicationsPanel
+        <ApplicationsPageHeader
+          applications={initialPageResult.data.items}
           dateLabel={dateLabel}
-          initialPage={initialPageResult.data}
-          key={panelKey}
+          hasNextPage={initialPageResult.data.hasMore}
+          period={period}
+          search={search}
+          sort={sort}
+          tab={tab}
         />
+
+        <section className="flex flex-col overflow-hidden rounded-3xl border border-border/70 bg-background">
+          <ApplicationFilters
+            period={period}
+            search={search}
+            sort={sort}
+            tab={tab}
+          />
+          <ApplicationsPanel
+            initialPage={initialPageResult.data}
+            key={panelKey}
+            period={period}
+            previewApplicationId={previewApplicationId}
+            search={search}
+            sort={sort}
+            tab={tab}
+          />
+        </section>
       </div>
       <AddJobTrigger />
     </main>
   );
-}
-
-function getString(value: string | string[] | undefined): string {
-  return typeof value === "string" ? value : "";
 }

--- a/app/(protected)/applications/_components/components/ApplicationFilters.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationFilters.tsx
@@ -1,13 +1,13 @@
-"use client";
+import type { Route } from "next";
 
-import { ChevronDownIcon, SearchIcon, XIcon } from "lucide-react";
-import { useEffect, useState } from "react";
+import { SearchIcon, XIcon } from "lucide-react";
+import Link from "next/link";
 
-import { Button } from "@/components/ui/button/Button";
 import { cn } from "@/lib/utils";
 
-import type { PeriodPreset, SortValue } from "../constants";
+import type { PeriodPreset, SortValue, TabValue } from "../constants";
 
+import { buildApplicationsHref } from "../../_utils/route-state";
 import {
   PERIOD_PRESET_LABELS,
   PERIOD_PRESETS,
@@ -16,59 +16,33 @@ import {
 } from "../constants";
 
 type ApplicationFiltersProps = {
-  onPeriodChangeAction: (period: PeriodPreset) => void;
-  onResetFiltersAction: () => void;
-  onSearchSubmitAction: (search: string) => void;
-  onSortChangeAction: (sort: SortValue) => void;
   period: PeriodPreset;
-  resultCount: number;
   search: string;
   sort: SortValue;
+  tab: TabValue;
 };
 
 export function ApplicationFilters({
-  onPeriodChangeAction,
-  onResetFiltersAction,
-  onSearchSubmitAction,
-  onSortChangeAction,
   period,
-  resultCount,
   search,
   sort,
+  tab,
 }: ApplicationFiltersProps) {
-  const [inputValue, setInputValue] = useState(search);
-
-  // URL 상태(뒤로가기 등)로 search prop이 외부에서 바뀔 때 입력창을 동기화
-  useEffect(() => {
-    setInputValue(search);
-  }, [search]);
-
   const isFiltered =
     search !== "" || period !== "all" || sort !== "applied_at_desc";
-
-  function handleSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault();
-    onSearchSubmitAction(inputValue.trim());
-  }
-
-  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const value = e.target.value;
-    setInputValue(value);
-    if (value === "") {
-      onSearchSubmitAction("");
-    }
-  }
-
-  function handleClear() {
-    setInputValue("");
-    onSearchSubmitAction("");
-  }
+  const resetHref = buildApplicationsHref({
+    period: "all",
+    previewApplicationId: null,
+    search: "",
+    sort: "applied_at_desc",
+    tab: "all",
+  }) as Route;
 
   return (
     <section className="bg-background/95 px-5 py-5 backdrop-blur-sm sm:px-6">
       <div className="flex flex-col gap-4">
         <div className="grid gap-4">
-          <form onSubmit={handleSubmit} role="search">
+          <form action="/applications" method="get" role="search">
             <div className="relative">
               <SearchIcon
                 aria-hidden="true"
@@ -77,21 +51,38 @@ export function ApplicationFilters({
               <input
                 aria-label="회사명 검색"
                 className="w-full rounded-2xl border border-border bg-muted/40 py-3 pr-11 pl-11 text-base text-foreground placeholder:text-muted-foreground focus:border-primary/50 focus:ring-2 focus:ring-primary/10 focus:outline-none sm:text-sm"
+                defaultValue={search}
                 id="applications-company-search"
-                onChange={handleChange}
+                name="q"
                 placeholder="회사명으로 현재 목록 좁히기"
                 type="text"
-                value={inputValue}
               />
-              {inputValue !== "" && (
-                <button
+              {period !== "all" && (
+                <input name="period" type="hidden" value={period} />
+              )}
+              {sort !== "applied_at_desc" && (
+                <input name="sort" type="hidden" value={sort} />
+              )}
+              {tab !== "all" && <input name="tab" type="hidden" value={tab} />}
+              <button className="sr-only" type="submit">
+                회사명 검색
+              </button>
+              {search !== "" && (
+                <Link
                   aria-label="검색어 지우기"
                   className="absolute top-1/2 right-4 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
-                  onClick={handleClear}
-                  type="button"
+                  href={
+                    buildApplicationsHref({
+                      period,
+                      previewApplicationId: null,
+                      search: "",
+                      sort,
+                      tab,
+                    }) as Route
+                  }
                 >
                   <XIcon aria-hidden="true" className="size-4" />
-                </button>
+                </Link>
               )}
             </div>
           </form>
@@ -103,67 +94,81 @@ export function ApplicationFilters({
               role="group"
             >
               {PERIOD_PRESETS.map((preset) => (
-                <button
-                  aria-pressed={period === preset}
+                <Link
                   className={cn(
                     "rounded-full border px-3.5 py-2 text-sm font-semibold transition-colors",
                     period === preset
                       ? "border-primary bg-primary text-primary-foreground"
                       : "border-border bg-background text-muted-foreground hover:border-primary/30 hover:text-foreground",
                   )}
+                  data-state={period === preset ? "active" : "inactive"}
+                  href={
+                    buildApplicationsHref({
+                      period: preset,
+                      previewApplicationId: null,
+                      search,
+                      sort,
+                      tab,
+                    }) as Route
+                  }
                   key={preset}
-                  onClick={() => onPeriodChangeAction(preset)}
-                  type="button"
                 >
                   {PERIOD_PRESET_LABELS[preset]}
-                </button>
+                  {period === preset ? (
+                    <span className="sr-only"> 선택됨</span>
+                  ) : null}
+                </Link>
               ))}
             </div>
 
             <div className="flex flex-wrap items-center gap-2">
-              <div className="relative inline-flex shrink-0">
-                <select
-                  aria-label="정렬"
-                  className="appearance-none rounded-full bg-background py-2 pr-8 pl-3.5 text-sm font-semibold text-foreground focus:ring-2 focus:ring-primary/10 focus:outline-none sm:min-w-28 sm:pr-10 sm:pl-4"
-                  id="applications-sort"
-                  onChange={(e) =>
-                    onSortChangeAction(e.target.value as SortValue)
-                  }
-                  value={sort}
-                >
-                  {SORT_VALUES.map((value) => (
-                    <option key={value} value={value}>
-                      {SORT_LABELS[value]}
-                    </option>
-                  ))}
-                </select>
-                <ChevronDownIcon
-                  aria-hidden="true"
-                  className="pointer-events-none absolute top-1/2 right-3 size-3.5 -translate-y-1/2 text-muted-foreground sm:right-4"
-                />
+              <div
+                aria-label="정렬"
+                className="flex flex-wrap items-center gap-2"
+                role="group"
+              >
+                {SORT_VALUES.map((value) => (
+                  <Link
+                    className={cn(
+                      "rounded-full border px-3.5 py-2 text-sm font-semibold transition-colors",
+                      sort === value
+                        ? "border-primary bg-primary/10 text-primary"
+                        : "border-border bg-background text-muted-foreground hover:border-primary/30 hover:text-foreground",
+                    )}
+                    href={
+                      buildApplicationsHref({
+                        period,
+                        previewApplicationId: null,
+                        search,
+                        sort: value,
+                        tab,
+                      }) as Route
+                    }
+                    key={value}
+                  >
+                    {SORT_LABELS[value]}
+                    {sort === value ? (
+                      <span className="sr-only"> 선택됨</span>
+                    ) : null}
+                  </Link>
+                ))}
               </div>
 
-              <Button
-                aria-hidden={!isFiltered}
+              <Link
                 className={cn(
-                  "min-w-24 rounded-full px-4",
-                  !isFiltered && "pointer-events-none invisible",
+                  "min-w-24 rounded-full border px-4 py-2 text-sm font-semibold transition-colors",
+                  isFiltered
+                    ? "border-border bg-background text-foreground hover:border-primary/30 hover:text-primary"
+                    : "pointer-events-none invisible",
                 )}
-                disabled={!isFiltered}
-                onClick={onResetFiltersAction}
-                size="sm"
+                href={resetHref}
                 tabIndex={isFiltered ? 0 : -1}
-                variant="outline"
               >
                 필터 초기화
-              </Button>
+              </Link>
             </div>
           </div>
         </div>
-
-        <p aria-atomic="true" aria-live="polite" className="sr-only">
-          {resultCount}개의 지원 내역이 있습니다
-        </p>
       </div>
     </section>
   );

--- a/app/(protected)/applications/_components/components/ApplicationTabs.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationTabs.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useImperativeHandle, useRef } from "react";
+import { useId, useImperativeHandle, useRef } from "react";
 
 import type { VirtualListHandle } from "@/components/ui/virtual-list";
 
-import { Tabs } from "@/components/ui/tabs/Tabs";
 import { trackEvent } from "@/lib/analytics/client";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { cn } from "@/lib/utils";
@@ -16,10 +15,10 @@ import { DONE_STATUSES, IN_PROGRESS_STATUSES } from "../constants";
 import { ApplicationList } from "./ApplicationList";
 
 const TAB_TRIGGER_CLASS =
-  "group relative flex items-center gap-1.5 rounded-none px-1 pb-3 text-sm font-semibold transition-colors text-muted-foreground hover:text-foreground data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:rounded-full after:bg-transparent data-[state=active]:after:bg-primary";
+  "group relative flex items-center gap-1.5 rounded-none px-1 pb-3 text-sm font-semibold transition-colors text-muted-foreground hover:text-foreground aria-selected:text-foreground after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:rounded-full after:bg-transparent aria-selected:after:bg-primary";
 
 const BADGE_CLASS =
-  "rounded-full px-1.5 py-0.5 text-[10px] font-bold tabular-nums text-muted-foreground transition-colors group-data-[state=active]:bg-primary/10 group-data-[state=active]:text-primary";
+  "rounded-full px-1.5 py-0.5 text-[10px] font-bold tabular-nums text-muted-foreground transition-colors group-aria-selected:bg-primary/10 group-aria-selected:text-primary";
 
 export type ApplicationTabsHandle = {
   scrollToTop: () => void;
@@ -48,11 +47,9 @@ export function ApplicationTabs({
   ref,
   tab,
 }: ApplicationTabsProps) {
-  /**
-   * TabsContent의 forceMount 기본값이 false이므로 활성 탭 하나만 렌더링됩니다.
-   * 따라서 listRef 하나로 현재 활성 탭의 VirtualList를 참조할 수 있습니다.
-   */
+  const baseId = useId();
   const listRef = useRef<VirtualListHandle>(null);
+  const triggerRefs = useRef<Array<HTMLButtonElement | null>>([]);
 
   const inProgressApplications = applications.filter((a) =>
     IN_PROGRESS_STATUSES.includes(a.status),
@@ -60,73 +57,153 @@ export function ApplicationTabs({
   const doneApplications = applications.filter((a) =>
     DONE_STATUSES.includes(a.status),
   );
+  const tabItems: Array<{
+    count: number;
+    label: string;
+    value: TabValue;
+  }> = [
+    { count: applications.length, label: "전체", value: "all" },
+    { count: inProgressApplications.length, label: "진행중", value: "active" },
+    { count: doneApplications.length, label: "완료", value: "done" },
+  ];
+  const selectedApplications = getApplicationsByTab({
+    active: inProgressApplications,
+    all: applications,
+    done: doneApplications,
+    tab,
+  });
+  const selectedTriggerId = `${baseId}-${tab}-trigger`;
+  const selectedPanelId = `${baseId}-${tab}-panel`;
 
   useImperativeHandle(ref, () => ({
     scrollToTop: () => listRef.current?.scrollToIndex(0),
   }));
 
+  function handleTabSelect(nextTab: TabValue) {
+    if (nextTab === tab) {
+      return;
+    }
+
+    trackEvent(ANALYTICS_EVENTS.APPLICATIONS_TAB_CHANGED, { tab: nextTab });
+    // 탭 전환 시 GoToTopFAB 상태를 즉시 초기화합니다.
+    // 새 목록이 렌더링되면 onRangeChangeAction(0, N)이 다시 호출됩니다.
+    onRangeChangeAction?.(0, 0);
+    onTabChangeAction(nextTab);
+  }
+
+  function handleTabListKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    const currentIndex = tabItems.findIndex((item) => item.value === tab);
+
+    if (currentIndex < 0) {
+      return;
+    }
+
+    const keyMap: Record<string, number> = {
+      ArrowLeft: (currentIndex - 1 + tabItems.length) % tabItems.length,
+      ArrowRight: (currentIndex + 1) % tabItems.length,
+      End: tabItems.length - 1,
+      Home: 0,
+    };
+
+    const nextIndex = keyMap[event.key];
+
+    if (nextIndex === undefined) {
+      return;
+    }
+
+    event.preventDefault();
+    const nextItem = tabItems[nextIndex];
+
+    triggerRefs.current[nextIndex]?.focus();
+    handleTabSelect(nextItem.value);
+  }
+
   return (
-    <Tabs
-      className={cn("flex flex-col", className ?? "h-full")}
-      onValueChange={(value) => {
-        trackEvent(ANALYTICS_EVENTS.APPLICATIONS_TAB_CHANGED, { tab: value });
-        // 탭 전환 시 GoToTopFAB 상태를 즉시 초기화합니다.
-        // 새 탭의 VirtualList가 마운트되면 onRangeChangeAction(0, N)이 다시 호출됩니다.
-        onRangeChangeAction?.(0, 0);
-        onTabChangeAction(value as TabValue);
-      }}
-      value={tab}
-    >
+    <div className={cn("flex flex-col", className ?? "h-full")}>
       <div className="border-b border-border/70 bg-background px-5 sm:px-6">
-        <Tabs.List className="flex h-auto items-end gap-5 rounded-none bg-transparent p-0">
-          <Tabs.Trigger className={TAB_TRIGGER_CLASS} value="all">
-            전체
-            <span className={BADGE_CLASS}>{applications.length}</span>
-          </Tabs.Trigger>
-          <Tabs.Trigger className={TAB_TRIGGER_CLASS} value="active">
-            진행중
-            <span className={BADGE_CLASS}>{inProgressApplications.length}</span>
-          </Tabs.Trigger>
-          <Tabs.Trigger className={TAB_TRIGGER_CLASS} value="done">
-            완료
-            <span className={BADGE_CLASS}>{doneApplications.length}</span>
-          </Tabs.Trigger>
-        </Tabs.List>
+        <div
+          aria-orientation="horizontal"
+          className="flex h-auto items-end gap-5 rounded-none bg-transparent p-0"
+          onKeyDown={handleTabListKeyDown}
+          role="tablist"
+        >
+          {tabItems.map((item, index) => {
+            const isSelected = item.value === tab;
+
+            return (
+              <button
+                aria-controls={`${baseId}-${item.value}-panel`}
+                aria-selected={isSelected}
+                className={TAB_TRIGGER_CLASS}
+                id={`${baseId}-${item.value}-trigger`}
+                key={item.value}
+                onClick={() => handleTabSelect(item.value)}
+                ref={(node) => {
+                  triggerRefs.current[index] = node;
+                }}
+                role="tab"
+                tabIndex={isSelected ? 0 : -1}
+                type="button"
+              >
+                {item.label}
+                <span className={BADGE_CLASS}>{item.count}</span>
+              </button>
+            );
+          })}
+        </div>
       </div>
 
-      <Tabs.Content className="mt-0 min-h-0 flex-1 px-4 sm:px-5" value="all">
+      <div
+        aria-labelledby={selectedTriggerId}
+        className="mt-0 min-h-0 flex-1 px-4 sm:px-5"
+        id={selectedPanelId}
+        role="tabpanel"
+        tabIndex={0}
+      >
         <ApplicationList
-          applications={applications}
-          emptyMessage="아직 지원한 곳이 없습니다"
+          applications={selectedApplications}
+          emptyMessage={getEmptyMessage(tab)}
           isFetchingNextPage={isFetchingNextPage}
           onNearEnd={onNearEndAction}
           onRangeChange={onRangeChangeAction}
           onSelectApplication={onSelectApplicationAction}
           ref={listRef}
         />
-      </Tabs.Content>
-      <Tabs.Content className="mt-0 min-h-0 flex-1 px-4 sm:px-5" value="active">
-        <ApplicationList
-          applications={inProgressApplications}
-          emptyMessage="진행 중인 지원이 없습니다"
-          isFetchingNextPage={isFetchingNextPage}
-          onNearEnd={onNearEndAction}
-          onRangeChange={onRangeChangeAction}
-          onSelectApplication={onSelectApplicationAction}
-          ref={listRef}
-        />
-      </Tabs.Content>
-      <Tabs.Content className="mt-0 min-h-0 flex-1 px-4 sm:px-5" value="done">
-        <ApplicationList
-          applications={doneApplications}
-          emptyMessage="완료된 지원이 없습니다"
-          isFetchingNextPage={isFetchingNextPage}
-          onNearEnd={onNearEndAction}
-          onRangeChange={onRangeChangeAction}
-          onSelectApplication={onSelectApplicationAction}
-          ref={listRef}
-        />
-      </Tabs.Content>
-    </Tabs>
+      </div>
+    </div>
   );
+}
+
+function getApplicationsByTab({
+  active,
+  all,
+  done,
+  tab,
+}: {
+  active: ApplicationListItem[];
+  all: ApplicationListItem[];
+  done: ApplicationListItem[];
+  tab: TabValue;
+}) {
+  if (tab === "active") {
+    return active;
+  }
+
+  if (tab === "done") {
+    return done;
+  }
+
+  return all;
+}
+
+function getEmptyMessage(tab: TabValue) {
+  if (tab === "active") {
+    return "진행 중인 지원이 없습니다";
+  }
+
+  if (tab === "done") {
+    return "완료된 지원이 없습니다";
+  }
+
+  return "아직 지원한 곳이 없습니다";
 }

--- a/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
@@ -4,7 +4,7 @@ import type { Route } from "next";
 
 import { AlertCircleIcon } from "lucide-react";
 import dynamic from "next/dynamic";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useRef, useState } from "react";
 import { flushSync } from "react-dom";
 
@@ -20,21 +20,9 @@ import { getApplications } from "@/lib/actions";
 import type { PeriodPreset, SortValue, TabValue } from "../constants";
 import type { ApplicationTabsHandle } from "./ApplicationTabs";
 
-import { ApplicationsPageHeader } from "../ApplicationsPageHeader";
-import {
-  getPeriodDateRange,
-  PAGE_SIZE,
-  parsePeriodParam,
-  parseSortParam,
-  parseTabParam,
-  PERIOD_PARAM,
-  PREVIEW_PARAM,
-  SEARCH_PARAM,
-  SORT_PARAM,
-  TAB_PARAM,
-} from "../constants";
+import { buildApplicationsHref } from "../../_utils/route-state";
+import { getPeriodDateRange, PAGE_SIZE } from "../constants";
 import { GoToTopFAB } from "../go-to-top";
-import { ApplicationFilters } from "./ApplicationFilters";
 import { ApplicationTabs } from "./ApplicationTabs";
 
 const ApplicationPreviewSheet = dynamic(
@@ -46,17 +34,31 @@ const ApplicationPreviewSheet = dynamic(
 );
 
 type ApplicationsPanelProps = {
-  dateLabel: string;
   initialPage: GetApplicationsPage;
+  period: PeriodPreset;
+  previewApplicationId: null | string;
+  search: string;
+  sort: SortValue;
+  tab: TabValue;
+};
+
+type RouteStateUpdate = {
+  period?: PeriodPreset;
+  previewApplicationId?: null | string;
+  search?: string;
+  sort?: SortValue;
+  tab?: TabValue;
 };
 
 export function ApplicationsPanel({
-  dateLabel,
   initialPage,
+  period,
+  previewApplicationId,
+  search,
+  sort,
+  tab,
 }: ApplicationsPanelProps) {
   const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
 
   const tabsRef = useRef<ApplicationTabsHandle>(null);
   const paginationSequenceRef = useRef(0);
@@ -65,12 +67,6 @@ export function ApplicationsPanel({
   const [isNavigatingFromPreview, setIsNavigatingFromPreview] = useState(false);
   const [pages, setPages] = useState<GetApplicationsPage[]>([initialPage]);
   const [paginationError, setPaginationError] = useState<null | string>(null);
-
-  const search = searchParams.get(SEARCH_PARAM) ?? "";
-  const period = parsePeriodParam(searchParams.get(PERIOD_PARAM));
-  const sort = parseSortParam(searchParams.get(SORT_PARAM));
-  const tab = parseTabParam(searchParams.get(TAB_PARAM));
-  const previewApplicationId = searchParams.get(PREVIEW_PARAM);
 
   const dateRange = getPeriodDateRange(period);
   const applications = pages.flatMap((page) => page.items);
@@ -84,67 +80,36 @@ export function ApplicationsPanel({
     !isNavigatingFromPreview &&
     selectedApplication !== null;
 
-  function updateParams(updates: Record<string, string>) {
-    const params = new URLSearchParams(searchParams.toString());
-
-    for (const [key, value] of Object.entries(updates)) {
-      if (value) {
-        params.set(key, value);
-      } else {
-        params.delete(key);
-      }
-    }
-
-    const query = params.toString();
-    router.replace(
-      `${pathname}${query ? `?${query}` : ""}` as unknown as Route,
-      { scroll: false },
-    );
-  }
-
-  function handleSearchSubmit(nextSearch: string) {
-    updateParams({ [PREVIEW_PARAM]: "", [SEARCH_PARAM]: nextSearch });
-  }
-
-  function handlePeriodChange(nextPeriod: PeriodPreset) {
-    updateParams({
-      [PERIOD_PARAM]: nextPeriod === "all" ? "" : nextPeriod,
-      [PREVIEW_PARAM]: "",
+  function updateRoute(nextState: RouteStateUpdate) {
+    const href = buildApplicationsHref({
+      period: nextState.period ?? period,
+      previewApplicationId:
+        nextState.previewApplicationId !== undefined
+          ? nextState.previewApplicationId
+          : previewApplicationId,
+      search: nextState.search ?? search,
+      sort: nextState.sort ?? sort,
+      tab: nextState.tab ?? tab,
     });
-  }
 
-  function handleSortChange(nextSort: SortValue) {
-    updateParams({
-      [PREVIEW_PARAM]: "",
-      [SORT_PARAM]: nextSort === "applied_at_desc" ? "" : nextSort,
-    });
-  }
-
-  function handleResetFilters() {
-    updateParams({
-      [PERIOD_PARAM]: "",
-      [PREVIEW_PARAM]: "",
-      [SEARCH_PARAM]: "",
-      [SORT_PARAM]: "",
-      [TAB_PARAM]: "",
-    });
+    router.replace(href as Route, { scroll: false });
   }
 
   function handleTabChange(nextTab: TabValue) {
-    updateParams({
-      [PREVIEW_PARAM]: "",
-      [TAB_PARAM]: nextTab === "all" ? "" : nextTab,
+    updateRoute({
+      previewApplicationId: null,
+      tab: nextTab,
     });
   }
 
   function handleSelectApplication(application: ApplicationListItem) {
     setIsNavigatingFromPreview(false);
-    updateParams({ [PREVIEW_PARAM]: application.id });
+    updateRoute({ previewApplicationId: application.id });
   }
 
   function handleClosePreview() {
     setIsNavigatingFromPreview(false);
-    updateParams({ [PREVIEW_PARAM]: "" });
+    updateRoute({ previewApplicationId: null });
   }
 
   function handleDetailNavigate() {
@@ -153,11 +118,13 @@ export function ApplicationsPanel({
       setIsNavigatingFromPreview(true);
     });
 
-    const params = new URLSearchParams(searchParams.toString());
-    params.delete(PREVIEW_PARAM);
-
-    const query = params.toString();
-    const nextUrl = `${pathname}${query ? `?${query}` : ""}`;
+    const nextUrl = buildApplicationsHref({
+      period,
+      previewApplicationId: null,
+      search,
+      sort,
+      tab,
+    });
 
     window.history.replaceState(window.history.state, "", nextUrl);
   }
@@ -211,72 +178,50 @@ export function ApplicationsPanel({
   }
 
   return (
-    <div className="flex flex-col gap-6">
-      <ApplicationsPageHeader
+    <div className="flex flex-col">
+      <ApplicationTabs
         applications={applications}
-        dateLabel={dateLabel}
-        hasNextPage={hasNextPage}
-        period={period}
-        search={search}
-        sort={sort}
+        className="h-[32rem] min-h-0 sm:h-[36rem] lg:h-[40rem]"
+        isFetchingNextPage={isFetchingNextPage}
+        onNearEndAction={() => {
+          void handleNearEnd();
+        }}
+        onRangeChangeAction={(startIndex: number) =>
+          setIsListScrolled(startIndex > 0)
+        }
+        onSelectApplicationAction={handleSelectApplication}
+        onTabChangeAction={handleTabChange}
+        ref={tabsRef}
         tab={tab}
       />
 
-      <section className="flex flex-col overflow-hidden rounded-3xl border border-border/70 bg-background">
-        <ApplicationFilters
-          onPeriodChangeAction={handlePeriodChange}
-          onResetFiltersAction={handleResetFilters}
-          onSearchSubmitAction={handleSearchSubmit}
-          onSortChangeAction={handleSortChange}
-          period={period}
-          resultCount={applications.length}
-          search={search}
-          sort={sort}
-        />
-        <ApplicationTabs
-          applications={applications}
-          className="h-[32rem] min-h-0 sm:h-[36rem] lg:h-[40rem]"
-          isFetchingNextPage={isFetchingNextPage}
-          onNearEndAction={() => {
-            void handleNearEnd();
-          }}
-          onRangeChangeAction={(startIndex: number) =>
-            setIsListScrolled(startIndex > 0)
-          }
-          onSelectApplicationAction={handleSelectApplication}
-          onTabChangeAction={handleTabChange}
-          ref={tabsRef}
-          tab={tab}
-        />
-
-        {paginationError ? (
-          <div
-            aria-live="polite"
-            className="border-t border-border/70 bg-muted/20 px-5 py-4 sm:px-6"
-            role="status"
-          >
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <div className="flex items-start gap-2 text-sm text-red-700">
-                <AlertCircleIcon
-                  aria-hidden="true"
-                  className="mt-0.5 size-4 shrink-0"
-                />
-                <p>추가 목록을 불러오지 못했습니다. {paginationError}</p>
-              </div>
-              <Button
-                className="w-full sm:w-auto"
-                onClick={() => {
-                  void handleNearEnd();
-                }}
-                size="sm"
-                variant="outline"
-              >
-                다시 시도
-              </Button>
+      {paginationError ? (
+        <div
+          aria-live="polite"
+          className="border-t border-border/70 bg-muted/20 px-5 py-4 sm:px-6"
+          role="status"
+        >
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-start gap-2 text-sm text-red-700">
+              <AlertCircleIcon
+                aria-hidden="true"
+                className="mt-0.5 size-4 shrink-0"
+              />
+              <p>추가 목록을 불러오지 못했습니다. {paginationError}</p>
             </div>
+            <Button
+              className="w-full sm:w-auto"
+              onClick={() => {
+                void handleNearEnd();
+              }}
+              size="sm"
+              variant="outline"
+            >
+              다시 시도
+            </Button>
           </div>
-        ) : null}
-      </section>
+        </div>
+      ) : null}
 
       {shouldRenderPreview ? (
         <ApplicationPreviewSheet

--- a/app/(protected)/applications/_utils/route-state.ts
+++ b/app/(protected)/applications/_utils/route-state.ts
@@ -1,0 +1,80 @@
+import type {
+  PeriodPreset,
+  SortValue,
+  TabValue,
+} from "../_components/constants";
+
+import {
+  parsePeriodParam,
+  parseSortParam,
+  parseTabParam,
+  PERIOD_PARAM,
+  PREVIEW_PARAM,
+  SEARCH_PARAM,
+  SORT_PARAM,
+  TAB_PARAM,
+} from "../_components/constants";
+
+export type ApplicationsRouteState = {
+  period: PeriodPreset;
+  previewApplicationId: null | string;
+  search: string;
+  sort: SortValue;
+  tab: TabValue;
+};
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+const APPLICATIONS_PATHNAME = "/applications";
+
+export function buildApplicationsHref({
+  period,
+  previewApplicationId,
+  search,
+  sort,
+  tab,
+}: ApplicationsRouteState): string {
+  const params = new URLSearchParams();
+
+  if (search !== "") {
+    params.set(SEARCH_PARAM, search);
+  }
+
+  if (period !== "all") {
+    params.set(PERIOD_PARAM, period);
+  }
+
+  if (sort !== "applied_at_desc") {
+    params.set(SORT_PARAM, sort);
+  }
+
+  if (tab !== "all") {
+    params.set(TAB_PARAM, tab);
+  }
+
+  if (previewApplicationId) {
+    params.set(PREVIEW_PARAM, previewApplicationId);
+  }
+
+  const query = params.toString();
+
+  return query ? `${APPLICATIONS_PATHNAME}?${query}` : APPLICATIONS_PATHNAME;
+}
+
+export function parseApplicationsRouteState(
+  searchParams: SearchParams,
+): ApplicationsRouteState {
+  return {
+    period: parsePeriodParam(
+      getFirstString(searchParams[PERIOD_PARAM]) || null,
+    ),
+    previewApplicationId: getFirstString(searchParams[PREVIEW_PARAM]) || null,
+    search: getFirstString(searchParams[SEARCH_PARAM]),
+    sort: parseSortParam(getFirstString(searchParams[SORT_PARAM]) || null),
+    tab: parseTabParam(getFirstString(searchParams[TAB_PARAM]) || null),
+  };
+}
+
+function getFirstString(value: string | string[] | undefined): string {
+  return typeof value === "string" ? value : "";
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #351

## 📌 작업 내용

- 지원 목록 라우트의 query 파라미터 해석과 URL 생성 로직을 별도 유틸로 분리해 서버/클라이언트 상태 흐름을 명확히 정리
- 검색/기간/정렬 필터를 서버 렌더링 기반으로 재구성해 초기 hydration 범위와 클라이언트 번들 부담을 줄임
- 탭 패널 구조를 단순화해 활성 목록만 렌더링하도록 변경하고, 숨겨진 패널 DOM 및 관련 클라이언트 작업을 제거
- 목록 패널은 무한 스크롤·미리보기 상호작용에만 집중하도록 역할을 좁혀 `/applications` 초기 렌더 성능 개선 기반을 마련

