### PR TITLE
fix: 지원 목록 미리보기 바텀시트 오류 복구(#355)

### DIFF
--- a/app/(protected)/applications/_components/ApplicationsView.tsx
+++ b/app/(protected)/applications/_components/ApplicationsView.tsx
@@ -1,6 +1,7 @@
 import { getApplications } from "@/lib/actions";
 
 import { parseApplicationsRouteState } from "../_utils/route-state";
+import { ApplicationsProviders } from "../ApplicationsProviders";
 import { AddJobTrigger } from "./add-job";
 import { ApplicationFilters } from "./components/ApplicationFilters";
 import { ApplicationsPanel } from "./components/ApplicationsPanel";
@@ -32,25 +33,27 @@ export async function ApplicationsView({
 
   return (
     <main className="min-h-screen bg-background pb-20">
-      <div className="mx-auto flex w-full max-w-6xl flex-col px-4 pt-6 pb-10 sm:px-6 sm:pt-8 lg:px-8 lg:pt-10 lg:pb-12">
-        <section className="flex flex-col overflow-hidden rounded-3xl border border-border/70 bg-background">
-          <ApplicationFilters
-            period={period}
-            search={search}
-            sort={sort}
-            tab={tab}
-          />
-          <ApplicationsPanel
-            initialPage={initialPageResult.data}
-            key={panelKey}
-            period={period}
-            previewApplicationId={previewApplicationId}
-            search={search}
-            sort={sort}
-            tab={tab}
-          />
-        </section>
-      </div>
+      <ApplicationsProviders>
+        <div className="mx-auto flex w-full max-w-6xl flex-col px-4 pt-6 pb-10 sm:px-6 sm:pt-8 lg:px-8 lg:pt-10 lg:pb-12">
+          <section className="flex flex-col overflow-hidden rounded-3xl border border-border/70 bg-background">
+            <ApplicationFilters
+              period={period}
+              search={search}
+              sort={sort}
+              tab={tab}
+            />
+            <ApplicationsPanel
+              initialPage={initialPageResult.data}
+              key={panelKey}
+              period={period}
+              previewApplicationId={previewApplicationId}
+              search={search}
+              sort={sort}
+              tab={tab}
+            />
+          </section>
+        </div>
+      </ApplicationsProviders>
       <AddJobTrigger />
     </main>
   );

--- a/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
@@ -5,7 +5,7 @@ import type { Route } from "next";
 import { AlertCircleIcon } from "lucide-react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 
 import type {
@@ -65,6 +65,9 @@ export function ApplicationsPanel({
   const [isFetchingNextPage, setIsFetchingNextPage] = useState(false);
   const [isListScrolled, setIsListScrolled] = useState(false);
   const [isNavigatingFromPreview, setIsNavigatingFromPreview] = useState(false);
+  const [localPreviewApplicationId, setLocalPreviewApplicationId] = useState<
+    null | string
+  >(previewApplicationId);
   const [pages, setPages] = useState<GetApplicationsPage[]>([initialPage]);
   const [paginationError, setPaginationError] = useState<null | string>(null);
 
@@ -73,26 +76,48 @@ export function ApplicationsPanel({
   const hasNextPage = pages[pages.length - 1]?.hasMore ?? false;
   const selectedApplication =
     applications.find(
-      (application) => application.id === previewApplicationId,
+      (application) => application.id === localPreviewApplicationId,
     ) ?? null;
   const shouldRenderPreview =
-    previewApplicationId !== null &&
+    localPreviewApplicationId !== null &&
     !isNavigatingFromPreview &&
     selectedApplication !== null;
 
+  useEffect(() => {
+    setLocalPreviewApplicationId(previewApplicationId);
+  }, [previewApplicationId]);
+
   function updateRoute(nextState: RouteStateUpdate) {
+    const nextPreviewApplicationId =
+      nextState.previewApplicationId !== undefined
+        ? nextState.previewApplicationId
+        : localPreviewApplicationId;
+
+    if (nextState.previewApplicationId !== undefined) {
+      setLocalPreviewApplicationId(nextPreviewApplicationId);
+    }
+
     const href = buildApplicationsHref({
       period: nextState.period ?? period,
-      previewApplicationId:
-        nextState.previewApplicationId !== undefined
-          ? nextState.previewApplicationId
-          : previewApplicationId,
+      previewApplicationId: nextPreviewApplicationId,
       search: nextState.search ?? search,
       sort: nextState.sort ?? sort,
       tab: nextState.tab ?? tab,
     });
 
     router.replace(href as Route, { scroll: false });
+  }
+
+  function updatePreviewHistory(nextPreviewApplicationId: null | string) {
+    const href = buildApplicationsHref({
+      period,
+      previewApplicationId: nextPreviewApplicationId,
+      search,
+      sort,
+      tab,
+    });
+
+    window.history.replaceState(window.history.state, "", href);
   }
 
   function handleTabChange(nextTab: TabValue) {
@@ -104,12 +129,15 @@ export function ApplicationsPanel({
 
   function handleSelectApplication(application: ApplicationListItem) {
     setIsNavigatingFromPreview(false);
-    updateRoute({ previewApplicationId: application.id });
+    setLocalPreviewApplicationId(application.id);
+    // preview는 서버 데이터가 아니라 목록 위의 UI 상태이므로 App Router 재요청 없이 URL만 동기화합니다.
+    updatePreviewHistory(application.id);
   }
 
   function handleClosePreview() {
     setIsNavigatingFromPreview(false);
-    updateRoute({ previewApplicationId: null });
+    setLocalPreviewApplicationId(null);
+    updatePreviewHistory(null);
   }
 
   function handleDetailNavigate() {


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #355

## 📌 작업 내용

- 지원 항목 클릭 시 preview 쿼리 변경으로 App Router 전체를 다시 태우지 않고, 로컬 상태와 history 동기화로 바텀시트를 열도록 수정
- 미리보기는 서버 데이터가 아닌 목록 UI 상태로 분리해 바텀시트 오픈 시 오류 페이지로 전환되던 흐름을 차단
- `/applications` 목록 화면에 `ApplicationsProviders`를 다시 연결해 미리보기 내부 `ApplicationStatusSelector`의 React Query mutation이 `QueryClientProvider` 안에서 동작하도록 복구
- 필터·탭 변경 시에는 기존처럼 라우트 갱신을 유지해 데이터 조건 변경과 UI 상태 변경의 책임을 분리


