### PR TITLE
perf: 지원 목록 초기 렌더 경계와 Sentry 클라이언트 초기화 시점 최적화(#357)

### DIFF
--- a/app/(protected)/applications/_components/ApplicationsView.tsx
+++ b/app/(protected)/applications/_components/ApplicationsView.tsx
@@ -1,7 +1,6 @@
 import { getApplications } from "@/lib/actions";
 
 import { parseApplicationsRouteState } from "../_utils/route-state";
-import { ApplicationsProviders } from "../ApplicationsProviders";
 import { AddJobTrigger } from "./add-job";
 import { ApplicationFilters } from "./components/ApplicationFilters";
 import { ApplicationsPanel } from "./components/ApplicationsPanel";
@@ -33,27 +32,25 @@ export async function ApplicationsView({
 
   return (
     <main className="min-h-screen bg-background pb-20">
-      <ApplicationsProviders>
-        <div className="mx-auto flex w-full max-w-6xl flex-col px-4 pt-6 pb-10 sm:px-6 sm:pt-8 lg:px-8 lg:pt-10 lg:pb-12">
-          <section className="flex flex-col overflow-hidden rounded-3xl border border-border/70 bg-background">
-            <ApplicationFilters
-              period={period}
-              search={search}
-              sort={sort}
-              tab={tab}
-            />
-            <ApplicationsPanel
-              initialPage={initialPageResult.data}
-              key={panelKey}
-              period={period}
-              previewApplicationId={previewApplicationId}
-              search={search}
-              sort={sort}
-              tab={tab}
-            />
-          </section>
-        </div>
-      </ApplicationsProviders>
+      <div className="mx-auto flex w-full max-w-6xl flex-col px-4 pt-6 pb-10 sm:px-6 sm:pt-8 lg:px-8 lg:pt-10 lg:pb-12">
+        <section className="flex flex-col overflow-hidden rounded-3xl border border-border/70 bg-background">
+          <ApplicationFilters
+            period={period}
+            search={search}
+            sort={sort}
+            tab={tab}
+          />
+          <ApplicationsPanel
+            initialPage={initialPageResult.data}
+            key={panelKey}
+            period={period}
+            previewApplicationId={previewApplicationId}
+            search={search}
+            sort={sort}
+            tab={tab}
+          />
+        </section>
+      </div>
       <AddJobTrigger />
     </main>
   );

--- a/app/(protected)/applications/_components/components/ApplicationFilters.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationFilters.tsx
@@ -74,125 +74,119 @@ export function ApplicationFilters({
 
   return (
     <section className="bg-background/95 px-5 py-5 backdrop-blur-sm sm:px-6">
-      <div className="flex flex-col gap-4">
-        <div className="grid gap-4">
-          <form onSubmit={handleSearchSubmit} role="search">
-            <div className="relative">
-              <SearchIcon
-                aria-hidden="true"
-                className="absolute top-1/2 left-4 size-4 -translate-y-1/2 text-muted-foreground"
-              />
-              <input
-                aria-label="회사명 검색"
-                className="w-full rounded-2xl border border-border bg-muted/40 py-3 pr-11 pl-11 text-base text-foreground placeholder:text-muted-foreground focus:border-primary/50 focus:ring-2 focus:ring-primary/10 focus:outline-none sm:text-sm"
-                defaultValue={search}
-                id="applications-company-search"
-                key={search}
-                name="q"
-                placeholder="회사명으로 현재 목록 좁히기"
-                type="text"
-              />
-              <button className="sr-only" type="submit">
-                회사명 검색
-              </button>
-              {search !== "" && (
-                <Link
-                  aria-label="검색어 지우기"
-                  className="absolute top-1/2 right-4 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
-                  href={
-                    buildApplicationsHref({
-                      period,
-                      previewApplicationId: null,
-                      search: "",
-                      sort,
-                      tab,
-                    }) as Route
-                  }
-                  scroll={false}
-                >
-                  <XIcon aria-hidden="true" className="size-4" />
-                </Link>
-              )}
-            </div>
-          </form>
-
-          <div className="flex flex-wrap items-center gap-2">
-            <div
-              aria-label="기간 필터"
-              className="flex flex-wrap gap-2"
-              role="group"
-            >
-              {PERIOD_PRESETS.map((preset) => (
-                <Link
-                  className={cn(
-                    "rounded-full border px-3.5 py-2 text-sm font-semibold transition-colors",
-                    period === preset
-                      ? "border-primary bg-primary text-primary-foreground"
-                      : "border-border bg-background text-muted-foreground hover:border-primary/30 hover:text-foreground",
-                  )}
-                  data-state={period === preset ? "active" : "inactive"}
-                  href={
-                    buildApplicationsHref({
-                      period: preset,
-                      previewApplicationId: null,
-                      search,
-                      sort,
-                      tab,
-                    }) as Route
-                  }
-                  key={preset}
-                  scroll={false}
-                >
-                  {PERIOD_PRESET_LABELS[preset]}
-                  {period === preset ? (
-                    <span className="sr-only"> 선택됨</span>
-                  ) : null}
-                </Link>
-              ))}
-            </div>
-
-            <div className="flex flex-wrap items-center gap-2">
-              <label
-                className="flex items-center gap-2 rounded-full border border-border bg-background pl-4"
-                htmlFor="applications-sort"
+      <div className="grid gap-4">
+        <form onSubmit={handleSearchSubmit} role="search">
+          <div className="relative">
+            <SearchIcon
+              aria-hidden="true"
+              className="absolute top-1/2 left-4 size-4 -translate-y-1/2 text-muted-foreground"
+            />
+            <input
+              aria-label="회사명 검색"
+              className="w-full rounded-2xl border border-border bg-muted/40 py-3 pr-11 pl-11 text-base text-foreground placeholder:text-muted-foreground focus:border-primary/50 focus:ring-2 focus:ring-primary/10 focus:outline-none sm:text-sm"
+              defaultValue={search}
+              id="applications-company-search"
+              key={search}
+              name="q"
+              placeholder="회사명으로 현재 목록 좁히기"
+              type="text"
+            />
+            <button className="sr-only" type="submit">
+              회사명 검색
+            </button>
+            {search !== "" && (
+              <Link
+                aria-label="검색어 지우기"
+                className="absolute top-1/2 right-4 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
+                href={
+                  buildApplicationsHref({
+                    period,
+                    previewApplicationId: null,
+                    search: "",
+                    sort,
+                    tab,
+                  }) as Route
+                }
+                scroll={false}
               >
-                <span className="text-sm font-semibold text-muted-foreground">
-                  정렬
-                </span>
-                <div className="relative">
-                  <select
-                    className="min-w-28 appearance-none rounded-full bg-transparent py-2 pr-9 pl-1 text-sm font-semibold text-foreground outline-none"
-                    id="applications-sort"
-                    onChange={handleSortChange}
-                    value={sort}
-                  >
-                    {SORT_VALUES.map((value) => (
-                      <option key={value} value={value}>
-                        {SORT_LABELS[value]}
-                      </option>
-                    ))}
-                  </select>
-                  <ChevronDownIcon
-                    aria-hidden="true"
-                    className="pointer-events-none absolute top-1/2 right-3 size-4 -translate-y-1/2 text-muted-foreground"
-                  />
-                </div>
-              </label>
+                <XIcon aria-hidden="true" className="size-4" />
+              </Link>
+            )}
+          </div>
+        </form>
 
+        <div className="flex flex-wrap items-center gap-2">
+          <div
+            aria-label="기간 필터"
+            className="flex flex-wrap gap-2"
+            role="group"
+          >
+            {PERIOD_PRESETS.map((preset) => (
               <Link
                 className={cn(
-                  "min-w-24 rounded-full border px-4 py-2 text-sm font-semibold transition-colors",
-                  isFiltered
-                    ? "border-border bg-background text-foreground hover:border-primary/30 hover:text-primary"
-                    : "pointer-events-none invisible",
+                  "rounded-full border px-3.5 py-2 text-sm font-semibold transition-colors",
+                  period === preset
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-border bg-background text-muted-foreground hover:border-primary/30 hover:text-foreground",
                 )}
+                data-state={period === preset ? "active" : "inactive"}
+                href={
+                  buildApplicationsHref({
+                    period: preset,
+                    previewApplicationId: null,
+                    search,
+                    sort,
+                    tab,
+                  }) as Route
+                }
+                key={preset}
+                scroll={false}
+              >
+                {PERIOD_PRESET_LABELS[preset]}
+                {period === preset ? (
+                  <span className="sr-only"> 선택됨</span>
+                ) : null}
+              </Link>
+            ))}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <label
+              className="flex items-center gap-2 rounded-full border border-border bg-background pl-4"
+              htmlFor="applications-sort"
+            >
+              <span className="text-sm font-semibold text-muted-foreground">
+                정렬
+              </span>
+              <div className="relative">
+                <select
+                  className="min-w-28 appearance-none rounded-full bg-transparent py-2 pr-9 pl-1 text-sm font-semibold text-foreground outline-none"
+                  id="applications-sort"
+                  onChange={handleSortChange}
+                  value={sort}
+                >
+                  {SORT_VALUES.map((value) => (
+                    <option key={value} value={value}>
+                      {SORT_LABELS[value]}
+                    </option>
+                  ))}
+                </select>
+                <ChevronDownIcon
+                  aria-hidden="true"
+                  className="pointer-events-none absolute top-1/2 right-3 size-4 -translate-y-1/2 text-muted-foreground"
+                />
+              </div>
+            </label>
+
+            {isFiltered ? (
+              <Link
+                className="min-w-24 rounded-full border border-border bg-background px-4 py-2 text-sm font-semibold text-foreground transition-colors hover:border-primary/30 hover:text-primary"
                 href={resetHref}
                 scroll={false}
-                tabIndex={isFiltered ? 0 : -1}
               >
                 필터 초기화
               </Link>
-            </div>
+            ) : null}
           </div>
         </div>
       </div>

--- a/app/(protected)/applications/_components/components/ApplicationPreviewSheet.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationPreviewSheet.tsx
@@ -19,6 +19,7 @@ import type {
 import type { JobStatus } from "@/lib/types/job";
 
 import { ApplicationStatusSelector } from "@/app/(protected)/_components/ApplicationStatusSelector";
+import { ApplicationsProviders } from "@/app/(protected)/applications/ApplicationsProviders";
 import { BottomSheet } from "@/components/ui/bottom-sheet/BottomSheet";
 import { Button } from "@/components/ui/button/Button";
 import { Skeleton } from "@/components/ui/skeleton/Skeleton";
@@ -144,171 +145,175 @@ export function ApplicationPreviewSheet({
   );
 
   return (
-    <BottomSheet isOpen={isOpen} onClose={onCloseAction}>
-      <BottomSheet.Overlay />
-      <BottomSheet.Content
-        className={
-          isManualPlatform
-            ? MANUAL_PREVIEW_SHEET_HEIGHT_CLASS
-            : DEFAULT_PREVIEW_SHEET_HEIGHT_CLASS
-        }
-      >
-        <BottomSheet.Header />
-        <div className="px-6 pb-4">
-          {(platform || appliedAt) && (
-            <div className="mb-2 flex flex-wrap items-center gap-0">
-              {platform && platform !== "MANUAL" && (
-                <span className="text-sm font-medium text-muted-foreground">
-                  {PLATFORM_LABEL[platform]}
-                </span>
-              )}
-              {platform && platform !== "MANUAL" && appliedAt && (
-                <span className="mx-2 text-sm text-muted-foreground/40">|</span>
-              )}
-              {appliedAt && (
-                <span className="flex gap-1 text-sm font-medium text-muted-foreground">
-                  <span>{status === "SAVED" ? "저장일" : "지원일"}</span>
-                  <span>{formatAppliedAt(appliedAt)}</span>
-                </span>
-              )}
-            </div>
-          )}
-          <BottomSheet.Title className="text-xl tracking-[-0.02em] text-foreground">
-            {title}
-          </BottomSheet.Title>
-          {companyName && (
-            <p className="mt-2 text-sm font-medium text-muted-foreground">
-              {companyName}
-            </p>
-          )}
-        </div>
-
-        <BottomSheet.Body className="space-y-4 px-6 pb-4">
-          {application && (
-            <ApplicationStatusSelector
-              applicationId={application.id}
-              ariaLabel="지원 상태 변경"
-              className="mt-2"
-              icon={<ListChecksIcon aria-hidden="true" className="size-4" />}
-              key={application.id}
-              label="지원 상태"
-              onStatusChangeAction={(nextStatus) => {
-                onStatusChangeAction(application.id, nextStatus);
-              }}
-              status={application.status}
-              updateStatusAction={updateApplicationStatus}
-            />
-          )}
-
-          {/* min-h는 로딩→콘텐츠 전환 시 시트 높이 변동(레이아웃 시프트)을 방지합니다. */}
-          <div
-            className={
-              isManualPlatform
-                ? MANUAL_PREVIEW_BODY_MIN_HEIGHT_CLASS
-                : DEFAULT_PREVIEW_BODY_MIN_HEIGHT_CLASS
-            }
-          >
-            {visiblePreviewState.status === "loading" && (
-              <div
-                aria-busy="true"
-                aria-label="지원 정보를 불러오는 중입니다"
-                className="space-y-4"
-                role="status"
-              >
-                {Array.from({ length: previewSkeletonCount }).map(
-                  (_, index) => (
-                    <ApplicationPreviewSectionSkeleton key={index} />
-                  ),
+    <ApplicationsProviders>
+      <BottomSheet isOpen={isOpen} onClose={onCloseAction}>
+        <BottomSheet.Overlay />
+        <BottomSheet.Content
+          className={
+            isManualPlatform
+              ? MANUAL_PREVIEW_SHEET_HEIGHT_CLASS
+              : DEFAULT_PREVIEW_SHEET_HEIGHT_CLASS
+          }
+        >
+          <BottomSheet.Header />
+          <div className="px-6 pb-4">
+            {(platform || appliedAt) && (
+              <div className="mb-2 flex flex-wrap items-center gap-0">
+                {platform && platform !== "MANUAL" && (
+                  <span className="text-sm font-medium text-muted-foreground">
+                    {PLATFORM_LABEL[platform]}
+                  </span>
+                )}
+                {platform && platform !== "MANUAL" && appliedAt && (
+                  <span className="mx-2 text-sm text-muted-foreground/40">
+                    |
+                  </span>
+                )}
+                {appliedAt && (
+                  <span className="flex gap-1 text-sm font-medium text-muted-foreground">
+                    <span>{status === "SAVED" ? "저장일" : "지원일"}</span>
+                    <span>{formatAppliedAt(appliedAt)}</span>
+                  </span>
                 )}
               </div>
             )}
-
-            {visiblePreviewState.status === "error" && (
-              <section
-                aria-live="polite"
-                className="rounded-2xl border border-red-200 bg-red-50 px-4 py-4 text-red-700"
-              >
-                <div className="flex items-start gap-3">
-                  <AlertCircleIcon
-                    aria-hidden="true"
-                    className="mt-0.5 size-5 shrink-0"
-                  />
-                  <div className="space-y-1">
-                    <p className="text-sm font-semibold">
-                      미리보기를 불러오지 못했습니다
-                    </p>
-                    <p className="text-sm leading-6">
-                      {visiblePreviewState.summary}
-                    </p>
-                  </div>
-                </div>
-              </section>
-            )}
-
-            {detail && (
-              <>
-                {shouldShowDescription ? (
-                  <ApplicationPreviewSection
-                    body={descriptionMeta.text}
-                    icon={
-                      <FileTextIcon aria-hidden="true" className="size-4" />
-                    }
-                    isEmpty={descriptionMeta.isEmpty}
-                    title="공고 설명"
-                  />
-                ) : null}
-                <ApplicationPreviewSection
-                  body={notesMeta.text}
-                  icon={
-                    <StickyNoteIcon aria-hidden="true" className="size-4" />
-                  }
-                  isEmpty={notesMeta.isEmpty}
-                  title="개인 메모"
-                />
-              </>
+            <BottomSheet.Title className="text-xl tracking-[-0.02em] text-foreground">
+              {title}
+            </BottomSheet.Title>
+            {companyName && (
+              <p className="mt-2 text-sm font-medium text-muted-foreground">
+                {companyName}
+              </p>
             )}
           </div>
-        </BottomSheet.Body>
 
-        <div className="border-t border-border bg-background px-6 py-4">
-          {application ? (
-            <Button
-              asChild
-              className="h-11 w-full justify-between rounded-xl px-4"
-            >
-              <Link
-                href={`/applications/${application.id}` as Route}
-                onClick={(event) => {
-                  if (
-                    event.defaultPrevented ||
-                    event.button !== 0 ||
-                    event.metaKey ||
-                    event.ctrlKey ||
-                    event.shiftKey ||
-                    event.altKey
-                  ) {
-                    return;
-                  }
-
-                  // iOS Safari bfcache 복원 시 이전 목록 URL의 preview 파라미터로
-                  // 바텀시트가 다시 열리지 않도록 현재 히스토리 엔트리를 정리합니다.
-                  onDetailNavigateAction();
+          <BottomSheet.Body className="space-y-4 px-6 pb-4">
+            {application && (
+              <ApplicationStatusSelector
+                applicationId={application.id}
+                ariaLabel="지원 상태 변경"
+                className="mt-2"
+                icon={<ListChecksIcon aria-hidden="true" className="size-4" />}
+                key={application.id}
+                label="지원 상태"
+                onStatusChangeAction={(nextStatus) => {
+                  onStatusChangeAction(application.id, nextStatus);
                 }}
+                status={application.status}
+                updateStatusAction={updateApplicationStatus}
+              />
+            )}
+
+            {/* min-h는 로딩→콘텐츠 전환 시 시트 높이 변동(레이아웃 시프트)을 방지합니다. */}
+            <div
+              className={
+                isManualPlatform
+                  ? MANUAL_PREVIEW_BODY_MIN_HEIGHT_CLASS
+                  : DEFAULT_PREVIEW_BODY_MIN_HEIGHT_CLASS
+              }
+            >
+              {visiblePreviewState.status === "loading" && (
+                <div
+                  aria-busy="true"
+                  aria-label="지원 정보를 불러오는 중입니다"
+                  className="space-y-4"
+                  role="status"
+                >
+                  {Array.from({ length: previewSkeletonCount }).map(
+                    (_, index) => (
+                      <ApplicationPreviewSectionSkeleton key={index} />
+                    ),
+                  )}
+                </div>
+              )}
+
+              {visiblePreviewState.status === "error" && (
+                <section
+                  aria-live="polite"
+                  className="rounded-2xl border border-red-200 bg-red-50 px-4 py-4 text-red-700"
+                >
+                  <div className="flex items-start gap-3">
+                    <AlertCircleIcon
+                      aria-hidden="true"
+                      className="mt-0.5 size-5 shrink-0"
+                    />
+                    <div className="space-y-1">
+                      <p className="text-sm font-semibold">
+                        미리보기를 불러오지 못했습니다
+                      </p>
+                      <p className="text-sm leading-6">
+                        {visiblePreviewState.summary}
+                      </p>
+                    </div>
+                  </div>
+                </section>
+              )}
+
+              {detail && (
+                <>
+                  {shouldShowDescription ? (
+                    <ApplicationPreviewSection
+                      body={descriptionMeta.text}
+                      icon={
+                        <FileTextIcon aria-hidden="true" className="size-4" />
+                      }
+                      isEmpty={descriptionMeta.isEmpty}
+                      title="공고 설명"
+                    />
+                  ) : null}
+                  <ApplicationPreviewSection
+                    body={notesMeta.text}
+                    icon={
+                      <StickyNoteIcon aria-hidden="true" className="size-4" />
+                    }
+                    isEmpty={notesMeta.isEmpty}
+                    title="개인 메모"
+                  />
+                </>
+              )}
+            </div>
+          </BottomSheet.Body>
+
+          <div className="border-t border-border bg-background px-6 py-4">
+            {application ? (
+              <Button
+                asChild
+                className="h-11 w-full justify-between rounded-xl px-4"
+              >
+                <Link
+                  href={`/applications/${application.id}` as Route}
+                  onClick={(event) => {
+                    if (
+                      event.defaultPrevented ||
+                      event.button !== 0 ||
+                      event.metaKey ||
+                      event.ctrlKey ||
+                      event.shiftKey ||
+                      event.altKey
+                    ) {
+                      return;
+                    }
+
+                    // iOS Safari bfcache 복원 시 이전 목록 URL의 preview 파라미터로
+                    // 바텀시트가 다시 열리지 않도록 현재 히스토리 엔트리를 정리합니다.
+                    onDetailNavigateAction();
+                  }}
+                >
+                  {footerButtonContent}
+                </Link>
+              </Button>
+            ) : (
+              <Button
+                className="h-11 w-full justify-between rounded-xl px-4"
+                disabled
               >
                 {footerButtonContent}
-              </Link>
-            </Button>
-          ) : (
-            <Button
-              className="h-11 w-full justify-between rounded-xl px-4"
-              disabled
-            >
-              {footerButtonContent}
-            </Button>
-          )}
-        </div>
-      </BottomSheet.Content>
-    </BottomSheet>
+              </Button>
+            )}
+          </div>
+        </BottomSheet.Content>
+      </BottomSheet>
+    </ApplicationsProviders>
   );
 }
 

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,11 +1,76 @@
-import * as Sentry from "@sentry/nextjs";
-
 const hasSentryDsn = Boolean(process.env.NEXT_PUBLIC_SENTRY_DSN);
+const shouldLoadSentry = process.env.NODE_ENV === "production" && hasSentryDsn;
 
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  enabled: hasSentryDsn,
-  sendDefaultPii: false,
-});
+type RouterTransitionType = "push" | "replace" | "traverse";
+type SentryClientModule = typeof import("@sentry/nextjs");
 
-export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;
+let sentryClientModulePromise: null | Promise<null | SentryClientModule> = null;
+
+function loadSentryClient() {
+  if (!shouldLoadSentry) {
+    return null;
+  }
+
+  if (sentryClientModulePromise) {
+    return sentryClientModulePromise;
+  }
+
+  sentryClientModulePromise = import("@sentry/nextjs")
+    .then((Sentry) => {
+      Sentry.init({
+        dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+        enabled: true,
+        sendDefaultPii: false,
+      });
+
+      return Sentry;
+    })
+    .catch(() => null);
+
+  return sentryClientModulePromise;
+}
+
+function scheduleSentryInit() {
+  if (!shouldLoadSentry || typeof window === "undefined") {
+    return;
+  }
+
+  const startWhenIdle = () => {
+    const requestIdleCallback =
+      "requestIdleCallback" in globalThis
+        ? globalThis.requestIdleCallback
+        : null;
+
+    if (requestIdleCallback) {
+      requestIdleCallback(
+        () => {
+          void loadSentryClient();
+        },
+        { timeout: 2000 },
+      );
+      return;
+    }
+
+    globalThis.setTimeout(() => {
+      void loadSentryClient();
+    }, 0);
+  };
+
+  if (document.readyState === "complete") {
+    startWhenIdle();
+    return;
+  }
+
+  window.addEventListener("load", startWhenIdle, { once: true });
+}
+
+scheduleSentryInit();
+
+export function onRouterTransitionStart(
+  url: string,
+  navigationType: RouterTransitionType,
+) {
+  void loadSentryClient()?.then((Sentry) => {
+    Sentry?.captureRouterTransitionStart(url, navigationType);
+  });
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #357

## 📌 작업 내용

- `/applications` 목록 페이지에서 전역 `ApplicationsProviders`를 제거해 초기 진입 시 불필요한 react-query provider가 번들 경계에 포함되지 않도록 조정
- 프리뷰 시트에서만 provider를 감싸도록 이동해 상태 변경 mutation이 필요한 시점에만 클라이언트 의존성이 활성화되게 분리
- 필터 영역의 불필요한 래퍼를 정리하고 `필터 초기화` 버튼을 조건부 렌더링으로 변경해 숨겨진 DOM 노드와 접근성 복잡도를 줄임
- `instrumentation-client.ts`에서 `@sentry/nextjs` 정적 import를 제거하고 프로덕션 + DSN 존재 시점에만 로드 후보가 되도록 분리
- 초기 진입 시에는 `window.load` 이후 idle 시점에만 Sentry를 비동기 초기화하고, 라우트 전환 시에는 필요할 때만 동일 모듈을 재사용해 로드하도록 조정
- 지원 목록 초기 로드의 unused JavaScript와 메인 스레드 경쟁을 줄이면서 LCP 경로에서 클라이언트 모니터링 초기화가 앞서 실행되지 않도록 정리


