### PR TITLE
perf: 지원 목록 초기 응답과 클라이언트 번들 비용 최적화(#359)

### DIFF
--- a/app/(protected)/applications/_components/ApplicationsView.tsx
+++ b/app/(protected)/applications/_components/ApplicationsView.tsx
@@ -1,20 +1,70 @@
-import { getApplications } from "@/lib/actions";
+import { Suspense } from "react";
+
+import { getApplications } from "@/lib/actions/getApplications";
 
 import { parseApplicationsRouteState } from "../_utils/route-state";
 import { AddJobTrigger } from "./add-job";
 import { ApplicationFilters } from "./components/ApplicationFilters";
 import { ApplicationsPanel } from "./components/ApplicationsPanel";
-import { getPeriodDateRange, PAGE_SIZE } from "./constants";
+import { ApplicationsPanelFallback } from "./components/ApplicationsPanelFallback";
+import {
+  getPeriodDateRange,
+  PAGE_SIZE,
+  type PeriodPreset,
+  type SortValue,
+  type TabValue,
+} from "./constants";
 
 type SearchParams = Record<string, string | string[] | undefined>;
 
-export async function ApplicationsView({
+export function ApplicationsView({
   searchParams,
 }: {
   searchParams: SearchParams;
 }) {
   const { period, previewApplicationId, search, sort, tab } =
     parseApplicationsRouteState(searchParams);
+  const panelKey = JSON.stringify({ period, search, sort });
+
+  return (
+    <main className="min-h-screen bg-background pb-20">
+      <div className="mx-auto flex w-full max-w-6xl flex-col px-4 pt-6 pb-10 sm:px-6 sm:pt-8 lg:px-8 lg:pt-10 lg:pb-12">
+        <section className="flex flex-col overflow-hidden rounded-3xl border border-border/70 bg-background">
+          <ApplicationFilters
+            period={period}
+            search={search}
+            sort={sort}
+            tab={tab}
+          />
+          <Suspense fallback={<ApplicationsPanelFallback />} key={panelKey}>
+            <ApplicationsPanelSection
+              period={period}
+              previewApplicationId={previewApplicationId}
+              search={search}
+              sort={sort}
+              tab={tab}
+            />
+          </Suspense>
+        </section>
+      </div>
+      <AddJobTrigger />
+    </main>
+  );
+}
+
+async function ApplicationsPanelSection({
+  period,
+  previewApplicationId,
+  search,
+  sort,
+  tab,
+}: {
+  period: PeriodPreset;
+  previewApplicationId: null | string;
+  search: string;
+  sort: SortValue;
+  tab: TabValue;
+}) {
   const dateRange = getPeriodDateRange(period);
   const panelKey = JSON.stringify({ period, search, sort });
   const initialPageResult = await getApplications({
@@ -31,27 +81,14 @@ export async function ApplicationsView({
   }
 
   return (
-    <main className="min-h-screen bg-background pb-20">
-      <div className="mx-auto flex w-full max-w-6xl flex-col px-4 pt-6 pb-10 sm:px-6 sm:pt-8 lg:px-8 lg:pt-10 lg:pb-12">
-        <section className="flex flex-col overflow-hidden rounded-3xl border border-border/70 bg-background">
-          <ApplicationFilters
-            period={period}
-            search={search}
-            sort={sort}
-            tab={tab}
-          />
-          <ApplicationsPanel
-            initialPage={initialPageResult.data}
-            key={panelKey}
-            period={period}
-            previewApplicationId={previewApplicationId}
-            search={search}
-            sort={sort}
-            tab={tab}
-          />
-        </section>
-      </div>
-      <AddJobTrigger />
-    </main>
+    <ApplicationsPanel
+      initialPage={initialPageResult.data}
+      key={panelKey}
+      period={period}
+      previewApplicationId={previewApplicationId}
+      search={search}
+      sort={sort}
+      tab={tab}
+    />
   );
 }

--- a/app/(protected)/applications/_components/components/ApplicationFilters.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationFilters.tsx
@@ -1,23 +1,15 @@
-"use client";
-
 import type { Route } from "next";
-import type { ChangeEvent, FormEvent } from "react";
 
 import { ChevronDownIcon, SearchIcon, XIcon } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 
 import { cn } from "@/lib/utils";
 
 import type { PeriodPreset, SortValue, TabValue } from "../constants";
 
 import { buildApplicationsHref } from "../../_utils/route-state";
-import {
-  PERIOD_PRESET_LABELS,
-  PERIOD_PRESETS,
-  SORT_LABELS,
-  SORT_VALUES,
-} from "../constants";
+import { PERIOD_PRESET_LABELS, PERIOD_PRESETS } from "../constants";
+import { ApplicationSortSelect } from "./ApplicationSortSelect";
 
 type ApplicationFiltersProps = {
   period: PeriodPreset;
@@ -32,7 +24,6 @@ export function ApplicationFilters({
   sort,
   tab,
 }: ApplicationFiltersProps) {
-  const router = useRouter();
   const isFiltered =
     search !== "" || period !== "all" || sort !== "applied_at_desc";
   const resetHref = buildApplicationsHref({
@@ -43,39 +34,11 @@ export function ApplicationFilters({
     tab: "all",
   }) as Route;
 
-  function handleSearchSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-
-    const formData = new FormData(event.currentTarget);
-    const nextSearch = String(formData.get("q") ?? "").trim();
-    const nextHref = buildApplicationsHref({
-      period,
-      previewApplicationId: null,
-      search: nextSearch,
-      sort,
-      tab,
-    }) as Route;
-
-    router.push(nextHref, { scroll: false });
-  }
-
-  function handleSortChange(event: ChangeEvent<HTMLSelectElement>) {
-    const nextSort = event.target.value as SortValue;
-    const nextHref = buildApplicationsHref({
-      period,
-      previewApplicationId: null,
-      search,
-      sort: nextSort,
-      tab,
-    }) as Route;
-
-    router.push(nextHref, { scroll: false });
-  }
-
   return (
     <section className="bg-background/95 px-5 py-5 backdrop-blur-sm sm:px-6">
       <div className="grid gap-4">
-        <form onSubmit={handleSearchSubmit} role="search">
+        <form action="/applications" method="get" role="search">
+          <HiddenRouteStateFields period={period} sort={sort} tab={tab} />
           <div className="relative">
             <SearchIcon
               aria-hidden="true"
@@ -86,7 +49,6 @@ export function ApplicationFilters({
               className="w-full rounded-2xl border border-border bg-muted/40 py-3 pr-11 pl-11 text-base text-foreground placeholder:text-muted-foreground focus:border-primary/50 focus:ring-2 focus:ring-primary/10 focus:outline-none sm:text-sm"
               defaultValue={search}
               id="applications-company-search"
-              key={search}
               name="q"
               placeholder="회사명으로 현재 목록 좁히기"
               type="text"
@@ -94,7 +56,7 @@ export function ApplicationFilters({
             <button className="sr-only" type="submit">
               회사명 검색
             </button>
-            {search !== "" && (
+            {search !== "" ? (
               <Link
                 aria-label="검색어 지우기"
                 className="absolute top-1/2 right-4 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
@@ -111,7 +73,7 @@ export function ApplicationFilters({
               >
                 <XIcon aria-hidden="true" className="size-4" />
               </Link>
-            )}
+            ) : null}
           </div>
         </form>
 
@@ -159,18 +121,13 @@ export function ApplicationFilters({
                 정렬
               </span>
               <div className="relative">
-                <select
-                  className="min-w-28 appearance-none rounded-full bg-transparent py-2 pr-9 pl-1 text-sm font-semibold text-foreground outline-none"
+                <ApplicationSortSelect
                   id="applications-sort"
-                  onChange={handleSortChange}
-                  value={sort}
-                >
-                  {SORT_VALUES.map((value) => (
-                    <option key={value} value={value}>
-                      {SORT_LABELS[value]}
-                    </option>
-                  ))}
-                </select>
+                  period={period}
+                  search={search}
+                  sort={sort}
+                  tab={tab}
+                />
                 <ChevronDownIcon
                   aria-hidden="true"
                   className="pointer-events-none absolute top-1/2 right-3 size-4 -translate-y-1/2 text-muted-foreground"
@@ -191,5 +148,27 @@ export function ApplicationFilters({
         </div>
       </div>
     </section>
+  );
+}
+
+function HiddenRouteStateFields({
+  period,
+  sort,
+  tab,
+}: {
+  period: PeriodPreset;
+  sort: SortValue;
+  tab: TabValue;
+}) {
+  return (
+    <>
+      {period !== "all" ? (
+        <input name="period" type="hidden" value={period} />
+      ) : null}
+      {sort !== "applied_at_desc" ? (
+        <input name="sort" type="hidden" value={sort} />
+      ) : null}
+      {tab !== "all" ? <input name="tab" type="hidden" value={tab} /> : null}
+    </>
   );
 }

--- a/app/(protected)/applications/_components/components/ApplicationList.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationList.tsx
@@ -15,6 +15,7 @@ const ESTIMATED_ROW_HEIGHT = 105;
 
 // 끝에서 몇 개 전에 다음 페이지를 미리 로드할지.
 const NEAR_END_THRESHOLD = 5;
+const PAGINATION_SKELETON_KEYS = [0, 1, 2] as const;
 
 type ApplicationListProps = {
   applications: ApplicationListItem[];
@@ -76,8 +77,8 @@ export function ApplicationList({
           className="pb-10"
           role="status"
         >
-          {Array.from({ length: 3 }).map((_, i) => (
-            <ApplicationRowSkeleton key={i} />
+          {PAGINATION_SKELETON_KEYS.map((key) => (
+            <ApplicationRowSkeleton key={key} />
           ))}
         </div>
       )}

--- a/app/(protected)/applications/_components/components/ApplicationPreviewSheet.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationPreviewSheet.tsx
@@ -23,7 +23,7 @@ import { ApplicationsProviders } from "@/app/(protected)/applications/Applicatio
 import { BottomSheet } from "@/components/ui/bottom-sheet/BottomSheet";
 import { Button } from "@/components/ui/button/Button";
 import { Skeleton } from "@/components/ui/skeleton/Skeleton";
-import { getApplicationDetail } from "@/lib/actions";
+import { getApplicationDetail } from "@/lib/actions/getApplicationDetail";
 import { updateApplicationStatus } from "@/lib/actions/updateApplicationStatus";
 
 import {
@@ -63,8 +63,8 @@ const DEFAULT_PREVIEW_BODY_MIN_HEIGHT_CLASS = "min-h-58";
 const DEFAULT_PREVIEW_SHEET_HEIGHT_CLASS = "min-h-[40vh]";
 const MANUAL_PREVIEW_BODY_MIN_HEIGHT_CLASS = "min-h-36";
 const MANUAL_PREVIEW_SHEET_HEIGHT_CLASS = "min-h-[30vh]";
-const DEFAULT_PREVIEW_SKELETON_COUNT = 2;
-const MANUAL_PREVIEW_SKELETON_COUNT = 1;
+const DEFAULT_PREVIEW_SKELETON_KEYS = [0, 1] as const;
+const MANUAL_PREVIEW_SKELETON_KEYS = [0] as const;
 
 export function ApplicationPreviewSheet({
   application,
@@ -133,9 +133,9 @@ export function ApplicationPreviewSheet({
   const notesMeta = getNotesMeta(detail);
   const isManualPlatform = platform === "MANUAL";
   const shouldShowDescription = !isManualPlatform;
-  const previewSkeletonCount = isManualPlatform
-    ? MANUAL_PREVIEW_SKELETON_COUNT
-    : DEFAULT_PREVIEW_SKELETON_COUNT;
+  const previewSkeletonKeys = isManualPlatform
+    ? MANUAL_PREVIEW_SKELETON_KEYS
+    : DEFAULT_PREVIEW_SKELETON_KEYS;
 
   const footerButtonContent = (
     <>
@@ -219,11 +219,9 @@ export function ApplicationPreviewSheet({
                   className="space-y-4"
                   role="status"
                 >
-                  {Array.from({ length: previewSkeletonCount }).map(
-                    (_, index) => (
-                      <ApplicationPreviewSectionSkeleton key={index} />
-                    ),
-                  )}
+                  {previewSkeletonKeys.map((key) => (
+                    <ApplicationPreviewSectionSkeleton key={key} />
+                  ))}
                 </div>
               )}
 

--- a/app/(protected)/applications/_components/components/ApplicationSortSelect.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationSortSelect.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import type { Route } from "next";
+import type { ChangeEvent } from "react";
+
+import { useRouter } from "next/navigation";
+
+import type { PeriodPreset, SortValue, TabValue } from "../constants";
+
+import { buildApplicationsHref } from "../../_utils/route-state";
+import { SORT_LABELS, SORT_VALUES } from "../constants";
+
+type ApplicationSortSelectProps = {
+  id: string;
+  period: PeriodPreset;
+  search: string;
+  sort: SortValue;
+  tab: TabValue;
+};
+
+export function ApplicationSortSelect({
+  id,
+  period,
+  search,
+  sort,
+  tab,
+}: ApplicationSortSelectProps) {
+  const router = useRouter();
+
+  function handleChange(event: ChangeEvent<HTMLSelectElement>) {
+    const nextSort = event.target.value as SortValue;
+    const nextHref = buildApplicationsHref({
+      period,
+      previewApplicationId: null,
+      search,
+      sort: nextSort,
+      tab,
+    }) as Route;
+
+    router.push(nextHref, { scroll: false });
+  }
+
+  return (
+    <select
+      className="min-w-28 appearance-none rounded-full bg-transparent py-2 pr-9 pl-1 text-sm font-semibold text-foreground outline-none"
+      id={id}
+      onChange={handleChange}
+      value={sort}
+    >
+      {SORT_VALUES.map((value) => (
+        <option key={value} value={value}>
+          {SORT_LABELS[value]}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
@@ -15,7 +15,7 @@ import type {
 import type { JobStatus } from "@/lib/types/job";
 
 import { Button } from "@/components/ui/button/Button";
-import { getApplications } from "@/lib/actions";
+import { getApplications } from "@/lib/actions/getApplications";
 
 import type { PeriodPreset, SortValue, TabValue } from "../constants";
 import type { ApplicationTabsHandle } from "./ApplicationTabs";

--- a/app/(protected)/applications/_components/components/ApplicationsPanelFallback.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanelFallback.tsx
@@ -1,0 +1,49 @@
+import { Skeleton } from "@/components/ui/skeleton/Skeleton";
+
+const TAB_SKELETON_KEYS = [0, 1, 2] as const;
+const ROW_SKELETON_KEYS = [0, 1, 2, 3, 4] as const;
+
+export function ApplicationsPanelFallback() {
+  return (
+    <div className="flex flex-col">
+      <div className="border-b border-border/70 bg-background px-5 sm:px-6">
+        <div className="flex items-end gap-5 py-3">
+          {TAB_SKELETON_KEYS.map((key) => (
+            <Skeleton
+              className={
+                key === 1 ? "h-6 w-20 rounded-full" : "h-6 w-16 rounded-full"
+              }
+              key={key}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="px-4 sm:px-5">
+        <div className="h-[32rem] min-h-0 space-y-3 overflow-hidden pt-4 sm:h-[36rem] lg:h-[40rem]">
+          {ROW_SKELETON_KEYS.map((index) => (
+            <div
+              className="rounded-2xl border border-border/60 px-4 py-4"
+              key={index}
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex min-w-0 flex-1 flex-col gap-3">
+                  <div className="space-y-2">
+                    <Skeleton className="h-4.5 w-24" />
+                    <Skeleton className="h-4 w-40" />
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Skeleton className="h-6 w-16 rounded-full" />
+                    <Skeleton className="h-4 w-14" />
+                    <Skeleton className="h-4 w-20" />
+                  </div>
+                </div>
+                <Skeleton className="mt-1 h-4 w-16" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #359

## 📌 작업 내용

- `/applications` 목록 패널을 Suspense 경계로 분리하고 fallback skeleton을 추가해 필터 셸이 데이터 조회보다 먼저 스트리밍되도록 조정
- 필터 UI를 서버 중심 구조로 재구성하고 정렬 select만 작은 클라이언트 컴포넌트로 분리해 초기 하이드레이션 범위를 축소
- 클라이언트 컴포넌트의 서버 액션 import를 개별 파일 경로로 좁혀 불필요한 참조 그래프 유입을 줄임
- 목록/프리뷰 skeleton 렌더링의 `Array.from` 사용을 정적 key 배열로 바꿔 legacy polyfill 및 번들 낭비를 줄이도록 정리


