### PR TITLE
perf: 로그인 페이지 초기 요청 지연 개선(#361)

### DIFF
--- a/app/login/_components/GoogleLoginButton.tsx
+++ b/app/login/_components/GoogleLoginButton.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+
+import GoogleIcon from "@/assets/google.svg";
+import { Button } from "@/components/ui/button/Button";
+import { trackEvent } from "@/lib/analytics/client";
+import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
+
+export function GoogleLoginButton() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<null | string>(null);
+
+  const handleGoogleLogin = async () => {
+    trackEvent(ANALYTICS_EVENTS.LOGIN_ATTEMPTED);
+    setIsLoading(true);
+    setErrorMessage(null);
+
+    try {
+      const { createClient } = await import("@/lib/supabase/client");
+      const supabase = createClient();
+
+      const url = new URL("/auth/callback", window.location.origin);
+      url.searchParams.set("next", "/dashboard");
+
+      const { error } = await supabase.auth.signInWithOAuth({
+        options: {
+          redirectTo: url.toString(),
+        },
+        provider: "google",
+      });
+
+      if (error) {
+        setErrorMessage(error.message);
+      }
+    } catch {
+      setErrorMessage("로그인을 시작할 수 없습니다. 다시 시도해 주세요.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        aria-busy={isLoading}
+        className="h-auto w-full gap-3 rounded-2xl border-border/60 bg-background px-4 py-4 text-[15px] font-bold text-foreground hover:border-primary/20 hover:bg-muted/30 active:scale-[0.98] disabled:opacity-60"
+        disabled={isLoading}
+        onClick={handleGoogleLogin}
+        variant="outline"
+      >
+        <GoogleIcon aria-hidden="true" className="h-5 w-5" />
+        <span>{isLoading ? "로그인 중..." : "Google로 계속하기"}</span>
+      </Button>
+
+      {errorMessage && (
+        <p
+          className="px-1 text-center text-sm font-medium text-destructive"
+          role="alert"
+        >
+          {errorMessage}
+        </p>
+      )}
+    </>
+  );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,106 +1,44 @@
-"use client";
-
-import type { Route } from "next";
-
-import Link from "next/link";
-import { useState } from "react";
-
-import GoogleIcon from "@/assets/google.svg";
-import { trackEvent } from "@/lib/analytics/client";
-import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
-
 import { PublicHeader } from "../_components/PublicHeader";
+import { GoogleLoginButton } from "./_components/GoogleLoginButton";
 
-const PRIVACY_PAGE_HREF = "/privacy" as Route;
+const PRIVACY_PAGE_HREF = "/privacy";
 
 export default function LoginPage() {
-  return <LoginPageContent />;
-}
-
-function LoginPageContent() {
-  const [isLoading, setIsLoading] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<null | string>(null);
-
-  const handleGoogleLogin = async () => {
-    trackEvent(ANALYTICS_EVENTS.LOGIN_ATTEMPTED);
-    setIsLoading(true);
-    setErrorMessage(null);
-
-    try {
-      const { createClient } = await import("@/lib/supabase/client");
-      const supabase = createClient();
-
-      const url = new URL("/auth/callback", window.location.origin);
-      url.searchParams.set("next", "/dashboard");
-
-      const { error } = await supabase.auth.signInWithOAuth({
-        options: {
-          redirectTo: url.toString(),
-        },
-        provider: "google",
-      });
-
-      if (error) {
-        setErrorMessage(error.message);
-      }
-    } catch {
-      setErrorMessage("로그인을 시작할 수 없습니다. 다시 시도해 주세요.");
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
   return (
-    <>
-      <div className="flex h-dvh flex-col bg-muted/30">
-        <PublicHeader />
-        <div className="flex flex-1 flex-col items-center justify-center px-5 pb-20">
-          <div className="w-full max-w-sm rounded-[32px] border border-border/50 bg-background p-10 shadow-xl shadow-black/[0.03]">
-            <header className="mb-10 text-center">
-              <span className="text-[11px] font-bold tracking-[0.2em] text-primary uppercase">
-                Welcome
-              </span>
-              <h1 className="mt-3 text-[32px] font-bold tracking-tight text-foreground">
-                로그인
-              </h1>
-              <p className="mt-2 text-sm font-medium text-muted-foreground">
-                201 escape에 오신 것을 환영합니다.
+    <div className="flex h-dvh flex-col bg-muted/30">
+      <PublicHeader />
+      <div className="flex flex-1 flex-col items-center justify-center px-5 pb-20">
+        <div className="w-full max-w-sm rounded-[32px] border border-border/50 bg-background p-10 shadow-xl shadow-black/[0.03]">
+          <header className="mb-10 text-center">
+            <span className="text-[11px] font-bold tracking-[0.2em] text-primary uppercase">
+              Welcome
+            </span>
+            <h1 className="mt-3 text-[32px] font-bold tracking-tight text-foreground">
+              로그인
+            </h1>
+            <p className="mt-2 text-sm font-medium text-muted-foreground">
+              201 escape에 오신 것을 환영합니다.
+            </p>
+          </header>
+
+          <div className="space-y-4">
+            <GoogleLoginButton />
+
+            <div className="flex justify-center px-1">
+              <p className="inline-flex flex-wrap items-center justify-center gap-x-1 text-center text-sm leading-5 font-medium text-muted-foreground">
+                <span>계속 진행하면</span>
+                <a
+                  className="font-semibold text-primary underline underline-offset-4"
+                  href={PRIVACY_PAGE_HREF}
+                >
+                  개인정보처리방침
+                </a>
+                <span>에 동의한 것으로 간주됩니다.</span>
               </p>
-            </header>
-
-            <div className="space-y-4">
-              <button
-                className="flex w-full cursor-pointer items-center justify-center gap-3 rounded-2xl border border-border/60 bg-background px-4 py-4 text-[15px] font-bold text-foreground transition-all hover:border-primary/20 hover:bg-muted/30 active:scale-[0.98]"
-                disabled={isLoading}
-                onClick={handleGoogleLogin}
-                type="button"
-              >
-                <GoogleIcon className="h-5 w-5" />
-                <span>{isLoading ? "로그인 중..." : "Google로 계속하기"}</span>
-              </button>
-
-              {errorMessage && (
-                <p className="px-1 text-center text-sm font-medium text-destructive">
-                  {errorMessage}
-                </p>
-              )}
-
-              <div className="flex justify-center px-1">
-                <p className="inline-flex flex-wrap items-center justify-center gap-x-1 text-center text-sm leading-5 font-medium text-muted-foreground">
-                  <span>계속 진행하면</span>
-                  <Link
-                    className="font-semibold text-primary underline underline-offset-4"
-                    href={PRIVACY_PAGE_HREF}
-                  >
-                    개인정보처리방침
-                  </Link>
-                  <span>에 동의한 것으로 간주됩니다.</span>
-                </p>
-              </div>
             </div>
           </div>
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/lib/supabase/proxy.ts
+++ b/lib/supabase/proxy.ts
@@ -1,7 +1,26 @@
 import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
 
+const ROOT_PATH = "/";
+const LOGIN_PATH = "/login";
+const DASHBOARD_PATH = "/dashboard";
+const AUTH_BYPASS_PATH_PREFIXES = [
+  "/api/events",
+  "/auth",
+  "/login",
+  "/monitoring",
+  "/privacy",
+] as const;
+
 export async function updateSession(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (isAuthBypassPath(pathname)) {
+    return NextResponse.next({
+      request,
+    });
+  }
+
   let supabaseResponse = NextResponse.next({
     request,
   });
@@ -40,25 +59,16 @@ export async function updateSession(request: NextRequest) {
   const { data } = await supabase.auth.getClaims();
 
   const user = data?.claims;
-  const { pathname } = request.nextUrl;
 
-  const isPublicPath =
-    pathname === "/" ||
-    pathname.startsWith("/api/events") ||
-    pathname.startsWith("/monitoring") ||
-    pathname.startsWith("/privacy") ||
-    pathname.startsWith("/login") ||
-    pathname.startsWith("/auth");
-
-  if (!user && !isPublicPath) {
+  if (!user && pathname !== ROOT_PATH) {
     const url = request.nextUrl.clone();
-    url.pathname = "/login";
+    url.pathname = LOGIN_PATH;
     return NextResponse.redirect(url);
   }
 
-  if (user && pathname === "/") {
+  if (user && pathname === ROOT_PATH) {
     const url = request.nextUrl.clone();
-    url.pathname = "/dashboard";
+    url.pathname = DASHBOARD_PATH;
     return NextResponse.redirect(url);
   }
 
@@ -76,4 +86,10 @@ export async function updateSession(request: NextRequest) {
   // of sync and terminate the user's session prematurely!
 
   return supabaseResponse;
+}
+
+function isAuthBypassPath(pathname: string) {
+  return AUTH_BYPASS_PATH_PREFIXES.some((prefix) => {
+    return pathname === prefix || pathname.startsWith(`${prefix}/`);
+  });
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -12,8 +12,9 @@ export const config = {
      * - _next/static (static files)
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
+     * - public routes that do not need session refresh
      * Feel free to modify this pattern to include more paths.
      */
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+    "/((?!_next/static|_next/image|favicon.ico|api/events(?:/|$)|auth(?:/|$)|login(?:/|$)|monitoring(?:/|$)|privacy(?:/|$)|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
   ],
 };


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #361

## 📌 작업 내용

- 공개 경로를 proxy matcher와 Supabase 세션 갱신 로직에서 제외해 `/login` 첫 요청이 인증 확인을 기다리지 않도록 수정
- 로그인 페이지를 서버 컴포넌트로 전환하고 Google 로그인 버튼만 클라이언트 컴포넌트로 분리해 초기 JS 경계를 축소
- 로그인 에러 메시지에 `role="alert"`를 추가하고 버튼의 disabled/focus 상태를 명시해 접근성 상태 표현을 보강


