### PR TITLE
refactor: 로그인 OAuth 시작을 서버 라우트로 이동(#363)

### DIFF
--- a/app/auth/login/google/route.ts
+++ b/app/auth/login/google/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+
+import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
+import { trackServerEvent } from "@/lib/analytics/server";
+import { createClient } from "@/lib/supabase/server";
+
+const CALLBACK_PATH = "/auth/callback";
+const DASHBOARD_PATH = "/dashboard";
+const ERROR_PATH = "/auth/auth-code-error";
+
+export async function GET(request: Request): Promise<NextResponse> {
+  const { origin } = new URL(request.url);
+  const supabase = await createClient();
+  const redirectTo = new URL(CALLBACK_PATH, origin);
+  redirectTo.searchParams.set("next", DASHBOARD_PATH);
+
+  trackServerEvent("anonymous", ANALYTICS_EVENTS.LOGIN_ATTEMPTED);
+
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    options: {
+      redirectTo: redirectTo.toString(),
+    },
+    provider: "google",
+  });
+
+  if (error || !data.url) {
+    return NextResponse.redirect(new URL(ERROR_PATH, origin), 302);
+  }
+
+  return NextResponse.redirect(data.url, 302);
+}

--- a/app/login/_components/GoogleLoginButton.tsx
+++ b/app/login/_components/GoogleLoginButton.tsx
@@ -1,66 +1,17 @@
-"use client";
-
-import { useState } from "react";
-
 import GoogleIcon from "@/assets/google.svg";
 import { Button } from "@/components/ui/button/Button";
-import { trackEvent } from "@/lib/analytics/client";
-import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 export function GoogleLoginButton() {
-  const [isLoading, setIsLoading] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<null | string>(null);
-
-  const handleGoogleLogin = async () => {
-    trackEvent(ANALYTICS_EVENTS.LOGIN_ATTEMPTED);
-    setIsLoading(true);
-    setErrorMessage(null);
-
-    try {
-      const { createClient } = await import("@/lib/supabase/client");
-      const supabase = createClient();
-
-      const url = new URL("/auth/callback", window.location.origin);
-      url.searchParams.set("next", "/dashboard");
-
-      const { error } = await supabase.auth.signInWithOAuth({
-        options: {
-          redirectTo: url.toString(),
-        },
-        provider: "google",
-      });
-
-      if (error) {
-        setErrorMessage(error.message);
-      }
-    } catch {
-      setErrorMessage("로그인을 시작할 수 없습니다. 다시 시도해 주세요.");
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
   return (
-    <>
-      <Button
-        aria-busy={isLoading}
-        className="h-auto w-full gap-3 rounded-2xl border-border/60 bg-background px-4 py-4 text-[15px] font-bold text-foreground hover:border-primary/20 hover:bg-muted/30 active:scale-[0.98] disabled:opacity-60"
-        disabled={isLoading}
-        onClick={handleGoogleLogin}
-        variant="outline"
-      >
+    <Button
+      asChild
+      className="h-auto w-full gap-3 rounded-2xl border-border/60 bg-background px-4 py-4 text-[15px] font-bold text-foreground hover:border-primary/20 hover:bg-muted/30 active:scale-[0.98] disabled:opacity-60"
+      variant="outline"
+    >
+      <a href="/auth/login/google">
         <GoogleIcon aria-hidden="true" className="h-5 w-5" />
-        <span>{isLoading ? "로그인 중..." : "Google로 계속하기"}</span>
-      </Button>
-
-      {errorMessage && (
-        <p
-          className="px-1 text-center text-sm font-medium text-destructive"
-          role="alert"
-        >
-          {errorMessage}
-        </p>
-      )}
-    </>
+        <span>Google로 계속하기</span>
+      </a>
+    </Button>
   );
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #363

## 📌 작업 내용

- 로그인 버튼의 클라이언트 상태와 Supabase 동적 import를 제거해 `/login` 페이지의 필수 클라이언트 JS를 줄임
- `/auth/login/google` 라우트에서 Google OAuth URL을 생성하고 Supabase 인증 흐름으로 리다이렉트하도록 변경
- 로그인 시도 이벤트는 서버 라우트에서 기록해 기존 계측 흐름을 유지


