### PR TITLE
feat: 서버 기반 활성 사용자 이벤트 추가(#366)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,22 +265,23 @@ flowchart LR
 
 ### 이벤트 목록
 
-| 이벤트명                     | 발생 시점                      | 프로퍼티                           |
-| ---------------------------- | ------------------------------ | ---------------------------------- |
-| `login_attempted`            | Google 로그인 버튼 클릭        | -                                  |
-| `application_add_opened`     | 공고 추가 FAB 클릭             | -                                  |
-| `application_add_submitted`  | 수동 폼 제출 → 리뷰 단계 진입  | `has_url: boolean`                 |
-| `application_add_saved`      | 공고 저장 완료                 | -                                  |
-| `application_add_reset`      | 리뷰 단계에서 "다시 입력" 클릭 | -                                  |
-| `application_preview_opened` | 대시보드에서 지원 행 클릭      | -                                  |
-| `application_status_changed` | 지원 상태 변경 성공            | `from_status`, `to_status`         |
-| `application_deleted`        | 지원 삭제 완료                 | -                                  |
-| `interview_added`            | 면접 일정 추가 완료            | `interview_type`, `round`          |
-| `interview_edited`           | 면접 일정 수정 완료            | `interview_type`, `round`          |
-| `interview_deleted`          | 면접 일정 삭제 완료            | -                                  |
-| `job_description_saved`      | 공고 설명 저장 완료            | -                                  |
-| `memo_saved`                 | 개인 메모 저장 완료            | -                                  |
-| `applications_tab_changed`   | 지원 목록 탭 전환              | `tab: 'all' \| 'active' \| 'done'` |
+| 이벤트명                     | 발생 시점                             | 프로퍼티                           |
+| ---------------------------- | ------------------------------------- | ---------------------------------- |
+| `user_active`                | 인증된 사용자의 보호 영역 데이터 조회 | -                                  |
+| `login_attempted`            | Google 로그인 버튼 클릭               | -                                  |
+| `application_add_opened`     | 공고 추가 FAB 클릭                    | -                                  |
+| `application_add_submitted`  | 수동 폼 제출 → 리뷰 단계 진입         | `has_url: boolean`                 |
+| `application_add_saved`      | 공고 저장 완료                        | -                                  |
+| `application_add_reset`      | 리뷰 단계에서 "다시 입력" 클릭        | -                                  |
+| `application_preview_opened` | 대시보드에서 지원 행 클릭             | -                                  |
+| `application_status_changed` | 지원 상태 변경 성공                   | `from_status`, `to_status`         |
+| `application_deleted`        | 지원 삭제 완료                        | -                                  |
+| `interview_added`            | 면접 일정 추가 완료                   | `interview_type`, `round`          |
+| `interview_edited`           | 면접 일정 수정 완료                   | `interview_type`, `round`          |
+| `interview_deleted`          | 면접 일정 삭제 완료                   | -                                  |
+| `job_description_saved`      | 공고 설명 저장 완료                   | -                                  |
+| `memo_saved`                 | 개인 메모 저장 완료                   | -                                  |
+| `applications_tab_changed`   | 지원 목록 탭 전환                     | `tab: 'all' \| 'active' \| 'done'` |
 
 ### 퍼널 설정(PostHog 대시보드)
 

--- a/lib/actions/_auth.ts
+++ b/lib/actions/_auth.ts
@@ -2,6 +2,8 @@
 
 import type { createClient } from "@/lib/supabase/server";
 
+import { trackAuthenticatedUserActivity } from "@/lib/analytics/server";
+
 const AUTH_REQUIRED_REASON = "로그인이 필요합니다.";
 
 type AuthenticatedUserIdResult =
@@ -25,6 +27,8 @@ export async function getAuthenticatedUserId(
   if (error || typeof userId !== "string" || userId.length === 0) {
     return { ok: false, reason: AUTH_REQUIRED_REASON };
   }
+
+  trackAuthenticatedUserActivity(userId);
 
   return { ok: true, userId };
 }

--- a/lib/analytics/events.ts
+++ b/lib/analytics/events.ts
@@ -22,6 +22,8 @@ export const ANALYTICS_EVENTS = {
   LOGIN_ATTEMPTED: "login_attempted",
   LOGOUT_CLICKED: "logout_clicked",
   MEMO_SAVED: "memo_saved",
+  // 사용자 활성
+  USER_ACTIVE: "user_active",
 } as const;
 
 export type AnalyticsEvent =

--- a/lib/analytics/server.ts
+++ b/lib/analytics/server.ts
@@ -3,12 +3,16 @@
 import { after } from "next/server";
 import { PostHog } from "posthog-node";
 
-import type { AnalyticsEvent } from "./events";
+import { ANALYTICS_EVENTS, type AnalyticsEvent } from "./events";
 
 const POSTHOG_TOKEN = process.env.POSTHOG_PROJECT_TOKEN;
 const POSTHOG_HOST = process.env.POSTHOG_HOST;
 
 let _client: null | PostHog = null;
+
+export function trackAuthenticatedUserActivity(userId: string): void {
+  trackServerEvent(userId, ANALYTICS_EVENTS.USER_ACTIVE);
+}
 
 export function trackServerEvent(
   distinctId: string,


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #366

## 📌 작업 내용

- 인증된 보호 영역 데이터 조회 시 `user_active` 이벤트를 PostHog로 전송하도록 공통 인증 유틸에 계측을 추가
- 클라이언트 번들 변경 없이 Supabase user id를 `distinct_id`로 사용해 MAU 집계 기준을 마련
- 이벤트 목록 문서를 갱신해 `user_active` 발생 시점을 명시
- 기존 PostHog 전송 흐름의 `after()` flush 구조를 유지해 렌더링 응답 경로의 지연을 최소화


