### PR TITLE
refactor: 대시보드 데이터 로딩 경계 분리(#368)

### DIFF
--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1,18 +1,16 @@
-import { getDashboardData } from "@/lib/actions";
+import { Suspense } from "react";
+
+import { getChartData, getStatCounts } from "@/lib/actions";
 import { formatKoreanDate } from "@/lib/utils";
 
 import { DashboardCharts } from "./_components/dashboard-view/DashboardCharts";
 import { DashboardOverview } from "./_components/dashboard-view/DashboardOverview";
+import {
+  ChartsSkeleton,
+  StatCardsSkeleton,
+} from "./_components/dashboard-view/DashboardSkeleton";
 
-export default async function DashboardPage() {
-  const dashboardResult = await getDashboardData();
-
-  if (!dashboardResult.ok) {
-    throw new Error(dashboardResult.reason);
-  }
-
-  const { funnel, monthly, stats } = dashboardResult.data;
-
+export default function DashboardPage() {
   return (
     <main className="min-h-screen bg-background pb-20">
       <section className="bg-muted/30">
@@ -39,9 +37,38 @@ export default async function DashboardPage() {
       </section>
 
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 py-10 sm:px-6 lg:gap-20 lg:px-8 lg:py-12">
-        <DashboardOverview stats={stats} />
-        <DashboardCharts funnel={funnel} monthly={monthly} />
+        <Suspense fallback={<StatCardsSkeleton />}>
+          <DashboardOverviewSection />
+        </Suspense>
+        <Suspense fallback={<ChartsSkeleton />}>
+          <DashboardChartsSection />
+        </Suspense>
       </div>
     </main>
   );
+}
+
+async function DashboardChartsSection() {
+  const result = await getChartData();
+
+  if (!result.ok) {
+    throw new Error(result.reason);
+  }
+
+  return (
+    <DashboardCharts
+      funnel={result.data.funnel}
+      monthly={result.data.monthly}
+    />
+  );
+}
+
+async function DashboardOverviewSection() {
+  const result = await getStatCounts();
+
+  if (!result.ok) {
+    throw new Error(result.reason);
+  }
+
+  return <DashboardOverview stats={result.data} />;
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #368

## 📌 작업 내용

- 대시보드 통계와 차트 데이터를 각각 독립적인 서버 섹션에서 조회하도록 분리
- `Suspense` 경계를 추가해 통계 카드와 차트 영역이 개별 스켈레톤 상태를 표시하도록 개선
- 기존 통합 조회 대신 `getStatCounts`, `getChartData`를 사용해 데이터 소유 범위를 명확히 정리

