### PR TITLE
refactor: 대시보드 헤더와 로딩 상태 분리(#370)

### DIFF
--- a/app/(protected)/dashboard/_components/dashboard-view/DashboardHeader.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DashboardHeader.tsx
@@ -1,0 +1,28 @@
+import { formatKoreanDate } from "@/lib/utils";
+
+export function DashboardHeader() {
+  return (
+    <section className="bg-muted/30">
+      <div className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6 lg:px-8 lg:py-12">
+        <header className="space-y-3">
+          <div className="space-y-3">
+            <p className="text-sm font-medium text-muted-foreground">
+              {formatKoreanDate(new Date())}
+            </p>
+            <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
+              지원 대시보드
+            </h1>
+            <p className="max-w-2xl text-sm leading-6 font-medium text-muted-foreground">
+              <span className="block break-keep">
+                전체 파이프라인 규모, 최근 12개월 지원 추이,
+              </span>
+              <span className="block break-keep">
+                단계별 전환 흐름을 한 화면에서 확인합니다.
+              </span>
+            </p>
+          </div>
+        </header>
+      </div>
+    </section>
+  );
+}

--- a/app/(protected)/dashboard/loading.tsx
+++ b/app/(protected)/dashboard/loading.tsx
@@ -1,0 +1,18 @@
+import { DashboardHeader } from "./_components/dashboard-view/DashboardHeader";
+import {
+  ChartsSkeleton,
+  StatCardsSkeleton,
+} from "./_components/dashboard-view/DashboardSkeleton";
+
+export default function DashboardLoading() {
+  return (
+    <main className="min-h-screen bg-background pb-20">
+      <DashboardHeader />
+
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 py-10 sm:px-6 lg:gap-20 lg:px-8 lg:py-12">
+        <StatCardsSkeleton />
+        <ChartsSkeleton />
+      </div>
+    </main>
+  );
+}

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1,9 +1,9 @@
 import { Suspense } from "react";
 
 import { getChartData, getStatCounts } from "@/lib/actions";
-import { formatKoreanDate } from "@/lib/utils";
 
 import { DashboardCharts } from "./_components/dashboard-view/DashboardCharts";
+import { DashboardHeader } from "./_components/dashboard-view/DashboardHeader";
 import { DashboardOverview } from "./_components/dashboard-view/DashboardOverview";
 import {
   ChartsSkeleton,
@@ -13,28 +13,7 @@ import {
 export default function DashboardPage() {
   return (
     <main className="min-h-screen bg-background pb-20">
-      <section className="bg-muted/30">
-        <div className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6 lg:px-8 lg:py-12">
-          <header className="space-y-3">
-            <div className="space-y-3">
-              <p className="text-sm font-medium text-muted-foreground">
-                {formatKoreanDate(new Date())}
-              </p>
-              <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
-                지원 대시보드
-              </h1>
-              <p className="max-w-2xl text-sm leading-6 font-medium text-muted-foreground">
-                <span className="block break-keep">
-                  전체 파이프라인 규모, 최근 12개월 지원 추이,
-                </span>
-                <span className="block break-keep">
-                  단계별 전환 흐름을 한 화면에서 확인합니다.
-                </span>
-              </p>
-            </div>
-          </header>
-        </div>
-      </section>
+      <DashboardHeader />
 
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 py-10 sm:px-6 lg:gap-20 lg:px-8 lg:py-12">
         <Suspense fallback={<StatCardsSkeleton />}>


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #370

## 📌 작업 내용

- 대시보드 상단 헤더를 `DashboardHeader` 컴포넌트로 분리해 페이지의 orchestration 책임을 줄임
- `loading.tsx`를 추가해 대시보드 진입 시 헤더와 스켈레톤 UI가 먼저 렌더링되도록 구성
- 통계 카드와 차트 영역의 Suspense fallback 구조를 유지해 데이터 로딩 상태를 명확하게 표현


