### PR TITLE
refactor: 서버 액션 인증 컨텍스트 통일(#372)

### DIFF
--- a/lib/actions/__tests__/_verifyApplicationOwnership.test.ts
+++ b/lib/actions/__tests__/_verifyApplicationOwnership.test.ts
@@ -1,12 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AUTH_ERROR_CODE } from "@/lib/actions/_queryError";
-import { createClient } from "@/lib/supabase/server";
+import { createClientWithToken } from "@/lib/supabase/server";
 
+import { getAuthContext } from "../_authContext";
 import { verifyApplicationOwnership } from "../_verifyApplicationOwnership";
 
 vi.mock("@/lib/supabase/server", () => ({
-  createClient: vi.fn(),
+  createClientWithToken: vi.fn(),
+}));
+
+vi.mock("../_authContext", () => ({
+  getAuthContext: vi.fn(),
 }));
 
 const mockMaybeSingle = vi.fn();
@@ -14,21 +19,21 @@ const mockEqUserId = vi.fn(() => ({ maybeSingle: mockMaybeSingle }));
 const mockEqId = vi.fn(() => ({ eq: mockEqUserId }));
 const mockSelect = vi.fn(() => ({ eq: mockEqId }));
 const mockFrom = vi.fn(() => ({ select: mockSelect }));
-const mockGetClaims = vi.fn();
 const mockSupabase = {
-  auth: { getClaims: mockGetClaims },
   from: mockFrom,
 };
 
+const ACCESS_TOKEN = "access-token";
 const APPLICATION_ID = "550e8400-e29b-41d4-a716-446655440000";
 const USER_ID = "user-1";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(createClient).mockResolvedValue(mockSupabase as never);
-  mockGetClaims.mockResolvedValue({
-    data: { claims: { sub: USER_ID } },
-    error: null,
+  vi.mocked(createClientWithToken).mockReturnValue(mockSupabase as never);
+  vi.mocked(getAuthContext).mockResolvedValue({
+    accessToken: ACCESS_TOKEN,
+    ok: true,
+    userId: USER_ID,
   });
   mockMaybeSingle.mockResolvedValue({
     data: { id: APPLICATION_ID },
@@ -38,21 +43,10 @@ beforeEach(() => {
 
 describe("verifyApplicationOwnership", () => {
   describe("인증 실패", () => {
-    it("auth.getClaims가 에러를 반환하면 AUTH_REQUIRED를 반환한다", async () => {
-      mockGetClaims.mockResolvedValue({
-        data: { claims: null },
-        error: { message: "JWT expired" },
-      });
-
-      const result = await verifyApplicationOwnership(APPLICATION_ID);
-
-      expect(result).toMatchObject({ code: "AUTH_REQUIRED", ok: false });
-    });
-
-    it("claims.sub가 없으면 AUTH_REQUIRED를 반환한다", async () => {
-      mockGetClaims.mockResolvedValue({
-        data: { claims: {} },
-        error: null,
+    it("인증 컨텍스트가 실패하면 AUTH_REQUIRED를 반환한다", async () => {
+      vi.mocked(getAuthContext).mockResolvedValue({
+        ok: false,
+        reason: "로그인이 필요합니다.",
       });
 
       const result = await verifyApplicationOwnership(APPLICATION_ID);
@@ -61,13 +55,14 @@ describe("verifyApplicationOwnership", () => {
     });
 
     it("인증 실패 시 from을 호출하지 않는다", async () => {
-      mockGetClaims.mockResolvedValue({
-        data: { claims: {} },
-        error: null,
+      vi.mocked(getAuthContext).mockResolvedValue({
+        ok: false,
+        reason: "로그인이 필요합니다.",
       });
 
       await verifyApplicationOwnership(APPLICATION_ID);
 
+      expect(createClientWithToken).not.toHaveBeenCalled();
       expect(mockFrom).not.toHaveBeenCalled();
     });
   });
@@ -140,6 +135,12 @@ describe("verifyApplicationOwnership", () => {
         supabase: mockSupabase,
         userId: USER_ID,
       });
+    });
+
+    it("access token으로 Supabase 클라이언트를 생성한다", async () => {
+      await verifyApplicationOwnership(APPLICATION_ID);
+
+      expect(createClientWithToken).toHaveBeenCalledWith(ACCESS_TOKEN);
     });
 
     it("select 쿼리 시 applicationId와 userId를 올바르게 전달한다", async () => {

--- a/lib/actions/_authContext.ts
+++ b/lib/actions/_authContext.ts
@@ -1,0 +1,30 @@
+import "server-only";
+import { cache } from "react";
+
+import { createClient } from "@/lib/supabase/server";
+
+import { getAuthenticatedUserId } from "./_auth";
+
+const AUTH_REQUIRED_REASON = "로그인이 필요합니다.";
+
+export type AuthContextResult =
+  | { accessToken: string; ok: true; userId: string }
+  | { ok: false; reason: string };
+
+export const getAuthContext = cache(async (): Promise<AuthContextResult> => {
+  const supabase = await createClient();
+  const authResult = await getAuthenticatedUserId(supabase);
+
+  if (!authResult.ok) {
+    return { ok: false, reason: authResult.reason };
+  }
+
+  const { data: sessionData } = await supabase.auth.getSession();
+  const accessToken = sessionData.session?.access_token;
+
+  if (!accessToken) {
+    return { ok: false, reason: AUTH_REQUIRED_REASON };
+  }
+
+  return { accessToken, ok: true, userId: authResult.userId };
+});

--- a/lib/actions/_verifyApplicationOwnership.ts
+++ b/lib/actions/_verifyApplicationOwnership.ts
@@ -1,7 +1,9 @@
-import { createClient } from "@/lib/supabase/server";
+import { createClientWithToken } from "@/lib/supabase/server";
 
-import { getAuthenticatedUserId } from "./_auth";
+import { getAuthContext } from "./_authContext";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
+
+type ServerSupabaseClient = ReturnType<typeof createClientWithToken>;
 
 type VerifyResult =
   | {
@@ -11,7 +13,7 @@ type VerifyResult =
     }
   | {
       ok: true;
-      supabase: Awaited<ReturnType<typeof createClient>>;
+      supabase: ServerSupabaseClient;
       userId: string;
     };
 
@@ -22,8 +24,7 @@ type VerifyResult =
 export async function verifyApplicationOwnership(
   applicationId: string,
 ): Promise<VerifyResult> {
-  const supabase = await createClient();
-  const authResult = await getAuthenticatedUserId(supabase);
+  const authResult = await getAuthContext();
 
   if (!authResult.ok) {
     return {
@@ -32,6 +33,8 @@ export async function verifyApplicationOwnership(
       reason: authResult.reason,
     };
   }
+
+  const supabase = createClientWithToken(authResult.accessToken);
 
   const { data: applicationData, error: applicationError } = await supabase
     .from("applications")

--- a/lib/actions/getApplicationDetail.ts
+++ b/lib/actions/getApplicationDetail.ts
@@ -1,13 +1,13 @@
 "use server";
 
-import { createClient } from "@/lib/supabase/server";
+import { createClientWithToken } from "@/lib/supabase/server";
 import {
   applicationDetailSchema,
   applicationIdSchema,
   type GetApplicationDetailResult,
 } from "@/lib/types/application";
 
-import { getAuthenticatedUserId } from "./_auth";
+import { getAuthContext } from "./_authContext";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 
@@ -32,8 +32,7 @@ export async function getApplicationDetail(
     };
   }
 
-  const supabase = await createClient();
-  const authResult = await getAuthenticatedUserId(supabase);
+  const authResult = await getAuthContext();
 
   if (!authResult.ok) {
     return {
@@ -42,6 +41,8 @@ export async function getApplicationDetail(
       reason: authResult.reason,
     };
   }
+
+  const supabase = createClientWithToken(authResult.accessToken);
 
   const { data, error } = await supabase
     .from("applications")

--- a/lib/actions/getApplications.ts
+++ b/lib/actions/getApplications.ts
@@ -5,8 +5,8 @@ import type {
   GetApplicationsResult,
 } from "@/lib/types/application";
 
-import { createClient } from "../supabase/server";
-import { getAuthenticatedUserId } from "./_auth";
+import { createClientWithToken } from "../supabase/server";
+import { getAuthContext } from "./_authContext";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 
@@ -25,8 +25,7 @@ export async function getApplications({
   search?: string;
   sort?: "applied_at_asc" | "applied_at_desc";
 }): Promise<GetApplicationsResult> {
-  const supabase = await createClient();
-  const authResult = await getAuthenticatedUserId(supabase);
+  const authResult = await getAuthContext();
 
   if (!authResult.ok) {
     return {
@@ -35,6 +34,8 @@ export async function getApplications({
       reason: authResult.reason,
     };
   }
+
+  const supabase = createClientWithToken(authResult.accessToken);
 
   let query = supabase
     .from("applications")

--- a/lib/actions/getApplicationsStats.ts
+++ b/lib/actions/getApplicationsStats.ts
@@ -7,8 +7,8 @@ import {
   DOCS_STATUSES,
 } from "@/lib/constants/application-status";
 
-import { createClient } from "../supabase/server";
-import { getAuthenticatedUserId } from "./_auth";
+import { createClientWithToken } from "../supabase/server";
+import { getAuthContext } from "./_authContext";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 
@@ -17,8 +17,7 @@ import { reportQueryError } from "./_reportQueryError";
  * 페이지네이션과 무관하게 전체 데이터 기준으로 집계합니다.
  */
 export async function getApplicationsStats(): Promise<GetApplicationsStatsResult> {
-  const supabase = await createClient();
-  const authResult = await getAuthenticatedUserId(supabase);
+  const authResult = await getAuthContext();
 
   if (!authResult.ok) {
     return {
@@ -28,6 +27,7 @@ export async function getApplicationsStats(): Promise<GetApplicationsStatsResult
     };
   }
 
+  const supabase = createClientWithToken(authResult.accessToken);
   const userId = authResult.userId;
 
   const { data, error } = await supabase

--- a/lib/actions/getChartData.ts
+++ b/lib/actions/getChartData.ts
@@ -13,14 +13,10 @@ import {
   INTERVIEW_STATUSES,
 } from "@/lib/constants/application-status";
 
-import { createClient, createClientWithToken } from "../supabase/server";
-import { getAuthenticatedUserId } from "./_auth";
+import { createClientWithToken } from "../supabase/server";
+import { getAuthContext } from "./_authContext";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
-
-const ERROR_MESSAGES = {
-  AUTH_REQUIRED: "로그인이 필요합니다.",
-} as const;
 
 function getMonthCutoff(): string {
   const d = new Date();
@@ -111,8 +107,7 @@ const getCachedChartData = unstable_cache(
 );
 
 export async function getChartData(): Promise<GetChartDataResult> {
-  const supabase = await createClient();
-  const authResult = await getAuthenticatedUserId(supabase);
+  const authResult = await getAuthContext();
 
   if (!authResult.ok) {
     return {
@@ -122,19 +117,11 @@ export async function getChartData(): Promise<GetChartDataResult> {
     };
   }
 
-  const { data: sessionData } = await supabase.auth.getSession();
-  const accessToken = sessionData.session?.access_token;
-
-  if (!accessToken) {
-    return {
-      code: "AUTH_REQUIRED",
-      ok: false,
-      reason: ERROR_MESSAGES.AUTH_REQUIRED,
-    };
-  }
-
   try {
-    const data = await getCachedChartData(authResult.userId, accessToken);
+    const data = await getCachedChartData(
+      authResult.userId,
+      authResult.accessToken,
+    );
     return { data, ok: true };
   } catch (e) {
     const reason = e instanceof Error ? e.message : "알 수 없는 오류";

--- a/lib/actions/getDashboardData.ts
+++ b/lib/actions/getDashboardData.ts
@@ -15,14 +15,10 @@ import {
   DOCS_STATUSES,
 } from "@/lib/constants/application-status";
 
-import { createClient, createClientWithToken } from "../supabase/server";
-import { getAuthenticatedUserId } from "./_auth";
+import { createClientWithToken } from "../supabase/server";
+import { getAuthContext } from "./_authContext";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
-
-const ERROR_MESSAGES = {
-  AUTH_REQUIRED: "로그인이 필요합니다.",
-} as const;
 
 type DashboardApplicationRow = {
   applied_at: null | string;
@@ -58,8 +54,7 @@ const getCachedDashboardData = unstable_cache(
 );
 
 export async function getDashboardData(): Promise<GetDashboardDataResult> {
-  const supabase = await createClient();
-  const authResult = await getAuthenticatedUserId(supabase);
+  const authResult = await getAuthContext();
 
   if (!authResult.ok) {
     return {
@@ -69,19 +64,11 @@ export async function getDashboardData(): Promise<GetDashboardDataResult> {
     };
   }
 
-  const { data: sessionData } = await supabase.auth.getSession();
-  const accessToken = sessionData.session?.access_token;
-
-  if (!accessToken) {
-    return {
-      code: "AUTH_REQUIRED",
-      ok: false,
-      reason: ERROR_MESSAGES.AUTH_REQUIRED,
-    };
-  }
-
   try {
-    const data = await getCachedDashboardData(authResult.userId, accessToken);
+    const data = await getCachedDashboardData(
+      authResult.userId,
+      authResult.accessToken,
+    );
 
     return { data, ok: true };
   } catch (e) {

--- a/lib/actions/getStatCounts.ts
+++ b/lib/actions/getStatCounts.ts
@@ -9,14 +9,10 @@ import {
   DOCS_STATUSES,
 } from "@/lib/constants/application-status";
 
-import { createClient, createClientWithToken } from "../supabase/server";
-import { getAuthenticatedUserId } from "./_auth";
+import { createClientWithToken } from "../supabase/server";
+import { getAuthContext } from "./_authContext";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
-
-const ERROR_MESSAGES = {
-  AUTH_REQUIRED: "로그인이 필요합니다.",
-} as const;
 
 // cookies()를 사용하지 않으므로 unstable_cache 안에서 안전하게 실행됩니다.
 const getCachedStatCounts = unstable_cache(
@@ -86,8 +82,7 @@ const getCachedStatCounts = unstable_cache(
 );
 
 export async function getStatCounts(): Promise<GetStatCountsResult> {
-  const supabase = await createClient();
-  const authResult = await getAuthenticatedUserId(supabase);
+  const authResult = await getAuthContext();
 
   if (!authResult.ok) {
     return {
@@ -97,19 +92,11 @@ export async function getStatCounts(): Promise<GetStatCountsResult> {
     };
   }
 
-  const { data: sessionData } = await supabase.auth.getSession();
-  const accessToken = sessionData.session?.access_token;
-
-  if (!accessToken) {
-    return {
-      code: "AUTH_REQUIRED",
-      ok: false,
-      reason: ERROR_MESSAGES.AUTH_REQUIRED,
-    };
-  }
-
   try {
-    const data = await getCachedStatCounts(authResult.userId, accessToken);
+    const data = await getCachedStatCounts(
+      authResult.userId,
+      authResult.accessToken,
+    );
     return { data, ok: true };
   } catch (e) {
     const reason = e instanceof Error ? e.message : "알 수 없는 오류";


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #372

## 📌 작업 내용

- 공통 getAuthContext를 추가해 인증된 사용자 ID와 access token 조회를 한 곳에서 처리
- 지원 내역 조회, 상세 조회, 통계, 차트, 대시보드 데이터 액션이 access token 기반 Supabase 클라이언트를 사용하도록 정리
- 지원서 소유권 검증 테스트를 인증 컨텍스트 기반 흐름에 맞게 갱신해 인증 실패와 토큰 클라이언트 생성 동작을 검증


