### PR TITLE
feat: 지원 목록 로딩 화면 추가(#374)

### DIFF
--- a/app/(protected)/applications/loading.tsx
+++ b/app/(protected)/applications/loading.tsx
@@ -1,0 +1,37 @@
+import { Skeleton } from "@/components/ui/skeleton/Skeleton";
+
+import { ApplicationsPanelFallback } from "./_components/components/ApplicationsPanelFallback";
+
+const PERIOD_CHIP_KEYS = [0, 1, 2, 3] as const;
+
+export default function ApplicationsLoading() {
+  return (
+    <main className="min-h-screen bg-background pb-20">
+      <div className="mx-auto flex w-full max-w-6xl flex-col px-4 pt-6 pb-10 sm:px-6 sm:pt-8 lg:px-8 lg:pt-10 lg:pb-12">
+        <section className="flex flex-col overflow-hidden rounded-3xl border border-border/70 bg-background">
+          <ApplicationFiltersFallback />
+          <ApplicationsPanelFallback />
+        </section>
+      </div>
+    </main>
+  );
+}
+
+function ApplicationFiltersFallback() {
+  return (
+    <section
+      aria-hidden="true"
+      className="bg-background/95 px-5 py-5 backdrop-blur-sm sm:px-6"
+    >
+      <div className="grid gap-4">
+        <Skeleton className="h-12 w-full rounded-2xl" />
+        <div className="flex flex-wrap items-center gap-2">
+          {PERIOD_CHIP_KEYS.map((key) => (
+            <Skeleton className="h-8 w-16 rounded-full" key={key} />
+          ))}
+          <Skeleton className="ml-auto h-8 w-28 rounded-full" />
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #374

## 📌 작업 내용

- `/applications` 라우트에 Next.js `loading.tsx`를 추가해 초기 로딩 중에도 레이아웃을 유지
- 필터, 기간 칩, 탭, 목록 영역을 스켈레톤 UI로 표현해 데이터 로드 전 화면 전환을 자연스럽게 개선
- 기존 `ApplicationsPanelFallback`을 재사용해 실제 목록 구조와 로딩 상태의 시각적 흐름을 맞춤


