### PR TITLE
feat: 지원 데이터 캐시 태그 무효화 도입(#376)

### DIFF
--- a/lib/actions/__tests__/saveJobApplication.test.ts
+++ b/lib/actions/__tests__/saveJobApplication.test.ts
@@ -1,3 +1,4 @@
+import { updateTag } from "next/cache";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { SaveJobApplicationInput } from "@/lib/types/jobApplication";
@@ -14,6 +15,10 @@ vi.mock("@/lib/analytics/server", () => ({
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  updateTag: vi.fn(),
 }));
 
 const mockRpc = vi.fn();
@@ -214,6 +219,7 @@ describe("saveJobApplication", () => {
         "user-1",
         "application_add_saved",
       );
+      expect(updateTag).toHaveBeenCalledWith("user-1");
     });
 
     it("선택 필드를 포함한 전체 입력도 성공적으로 처리한다", async () => {

--- a/lib/actions/__tests__/updateApplicationStatus.test.ts
+++ b/lib/actions/__tests__/updateApplicationStatus.test.ts
@@ -1,3 +1,4 @@
+import { updateTag } from "next/cache";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { UpdateApplicationStatusInput } from "@/lib/types/application";
@@ -14,6 +15,10 @@ vi.mock("@/lib/analytics/server", () => ({
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  updateTag: vi.fn(),
 }));
 
 const mockMaybeSingle = vi.fn();
@@ -175,6 +180,7 @@ describe("updateApplicationStatus", () => {
         "application_status_changed",
         { from_status: "SAVED", to_status: "APPLIED" },
       );
+      expect(updateTag).toHaveBeenCalledWith("user-1");
     });
 
     it.each<UpdateApplicationStatusInput["status"]>([

--- a/lib/actions/_cacheTags.ts
+++ b/lib/actions/_cacheTags.ts
@@ -1,0 +1,9 @@
+export const APPLICATIONS_CACHE_TAG = "applications";
+
+export function getApplicationsCacheTags(userId: string): [string, string] {
+  return [APPLICATIONS_CACHE_TAG, userId];
+}
+
+export function getApplicationsUserCacheTag(userId: string): string {
+  return userId;
+}

--- a/lib/actions/deleteApplication.ts
+++ b/lib/actions/deleteApplication.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { updateTag } from "next/cache";
 import { z } from "zod";
 
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
@@ -10,6 +11,7 @@ import {
   type DeleteApplicationResult,
 } from "@/lib/types/application";
 
+import { getApplicationsUserCacheTag } from "./_cacheTags";
 import { normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 import { verifyApplicationOwnership } from "./_verifyApplicationOwnership";
@@ -54,6 +56,7 @@ export async function deleteApplication(
   }
 
   trackServerEvent(userId, ANALYTICS_EVENTS.APPLICATION_DELETED);
+  updateTag(getApplicationsUserCacheTag(userId));
 
   return { ok: true };
 }

--- a/lib/actions/getApplications.ts
+++ b/lib/actions/getApplications.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { unstable_cache } from "next/cache";
+
 import type {
   ApplicationListItem,
   GetApplicationsResult,
@@ -7,24 +9,27 @@ import type {
 
 import { createClientWithToken } from "../supabase/server";
 import { getAuthContext } from "./_authContext";
+import { getApplicationsCacheTags } from "./_cacheTags";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 
-export async function getApplications({
-  limit,
-  offset,
-  periodEnd,
-  periodStart,
-  search,
-  sort = "applied_at_desc",
-}: {
+type ApplicationsPage = {
+  hasMore: boolean;
+  items: ApplicationListItem[];
+};
+
+type ApplicationsQueryParams = {
   limit: number;
   offset: number;
   periodEnd?: string;
   periodStart?: string;
   search?: string;
   sort?: "applied_at_asc" | "applied_at_desc";
-}): Promise<GetApplicationsResult> {
+};
+
+export async function getApplications(
+  params: ApplicationsQueryParams,
+): Promise<GetApplicationsResult> {
   const authResult = await getAuthContext();
 
   if (!authResult.ok) {
@@ -35,53 +40,76 @@ export async function getApplications({
     };
   }
 
-  const supabase = createClientWithToken(authResult.accessToken);
+  const { accessToken, userId } = authResult;
 
-  let query = supabase
-    .from("applications")
-    .select("id, applied_at, company_name, platform, position_title, status")
-    .eq("user_id", authResult.userId)
-    .order("applied_at", { ascending: sort === "applied_at_asc" })
-    .range(offset, offset + limit);
+  // cookies()를 사용하지 않으므로 unstable_cache 안에서 안전하게 실행됩니다.
+  const getCachedApplications = unstable_cache(
+    async (
+      cachedParams: ApplicationsQueryParams,
+    ): Promise<ApplicationsPage> => {
+      const supabase = createClientWithToken(accessToken);
+      const {
+        limit,
+        offset,
+        periodEnd,
+        periodStart,
+        search,
+        sort = "applied_at_desc",
+      } = cachedParams;
 
-  if (search) {
-    query = query.ilike("company_name", `%${search}%`);
-  }
-  if (periodStart) {
-    query = query.gte("applied_at", periodStart);
-  }
-  if (periodEnd) {
-    query = query.lte("applied_at", periodEnd);
-  }
+      let query = supabase
+        .from("applications")
+        .select(
+          "id, applied_at, company_name, platform, position_title, status",
+        )
+        .eq("user_id", userId)
+        .order("applied_at", { ascending: sort === "applied_at_asc" })
+        .range(offset, offset + limit);
 
-  const { data, error } = await query;
+      if (search) {
+        query = query.ilike("company_name", `%${search}%`);
+      }
+      if (periodStart) {
+        query = query.gte("applied_at", periodStart);
+      }
+      if (periodEnd) {
+        query = query.lte("applied_at", periodEnd);
+      }
 
-  if (error) {
-    const code =
-      error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
-    const reason = normalizeQueryError(error);
-    if (code === "QUERY_ERROR") {
-      reportQueryError("getApplications", reason);
-    }
-    return { code, ok: false, reason };
-  }
+      const { data, error } = await query;
 
-  const items: ApplicationListItem[] = data
-    .map((row) => {
-      return {
+      if (error) {
+        const reason = normalizeQueryError(error);
+        if (error.code !== AUTH_ERROR_CODE) {
+          reportQueryError("getApplications", reason);
+        }
+        throw new Error(reason);
+      }
+
+      const items: ApplicationListItem[] = data.map((row) => ({
         appliedAt: row.applied_at,
         companyName: row.company_name,
         id: row.id,
         platform: row.platform,
         positionTitle: row.position_title,
         status: row.status,
-      };
-    })
-    .filter((item) => item !== null);
+      }));
 
-  // limit + 1개를 요청해 실제로 limit개만 반환하고, 초과분이 있으면 hasMore = true
-  const hasMore = items.length > limit;
-  const pageItems = hasMore ? items.slice(0, limit) : items;
+      // limit + 1개를 요청해 실제로 limit개만 반환하고, 초과분이 있으면 hasMore = true
+      const hasMore = items.length > limit;
+      const pageItems = hasMore ? items.slice(0, limit) : items;
 
-  return { data: { hasMore, items: pageItems }, ok: true };
+      return { hasMore, items: pageItems };
+    },
+    ["applications-page", userId],
+    { revalidate: 60, tags: getApplicationsCacheTags(userId) },
+  );
+
+  try {
+    const data = await getCachedApplications(params);
+    return { data, ok: true };
+  } catch (e) {
+    const reason = e instanceof Error ? e.message : "알 수 없는 오류";
+    return { code: "QUERY_ERROR", ok: false, reason };
+  }
 }

--- a/lib/actions/getChartData.ts
+++ b/lib/actions/getChartData.ts
@@ -15,96 +15,9 @@ import {
 
 import { createClientWithToken } from "../supabase/server";
 import { getAuthContext } from "./_authContext";
+import { getApplicationsCacheTags } from "./_cacheTags";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
-
-function getMonthCutoff(): string {
-  const d = new Date();
-  d.setFullYear(d.getFullYear() - 1);
-  return d.toISOString().slice(0, 10);
-}
-
-// cookies()를 사용하지 않으므로 unstable_cache 안에서 안전하게 실행됩니다.
-const getCachedChartData = unstable_cache(
-  async (userId: string, accessToken: string): Promise<ChartData> => {
-    const supabase = createClientWithToken(accessToken);
-
-    const [
-      appliedRes,
-      docsPassedRes,
-      interviewingOrOfferedRes,
-      offeredRes,
-      monthlyRes,
-    ] = await Promise.all([
-      supabase
-        .from("applications")
-        .select("*", { count: "exact", head: true })
-        .eq("user_id", userId)
-        .neq("status", "SAVED"),
-      supabase
-        .from("applications")
-        .select("*", { count: "exact", head: true })
-        .eq("user_id", userId)
-        .in("status", DOCS_PASSED_STATUSES),
-      supabase
-        .from("applications")
-        .select("*", { count: "exact", head: true })
-        .eq("user_id", userId)
-        .in("status", INTERVIEW_STATUSES),
-      supabase
-        .from("applications")
-        .select("*", { count: "exact", head: true })
-        .eq("user_id", userId)
-        .eq("status", "OFFERED"),
-      supabase
-        .from("applications")
-        .select("applied_at")
-        .eq("user_id", userId)
-        .not("applied_at", "is", null)
-        .gte("applied_at", getMonthCutoff()),
-    ]);
-
-    const firstError =
-      appliedRes.error ??
-      docsPassedRes.error ??
-      interviewingOrOfferedRes.error ??
-      offeredRes.error ??
-      monthlyRes.error;
-
-    if (firstError) {
-      const code =
-        firstError.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
-      const reason = normalizeQueryError(firstError);
-      if (code === "QUERY_ERROR") {
-        reportQueryError("getChartData", reason);
-      }
-      throw new Error(reason);
-    }
-
-    const monthlyMap = new Map<string, number>();
-    for (const row of monthlyRes.data ?? []) {
-      if (row.applied_at) {
-        const month = (row.applied_at as string).slice(0, 7);
-        monthlyMap.set(month, (monthlyMap.get(month) ?? 0) + 1);
-      }
-    }
-
-    const monthly: MonthlyCount[] = Array.from(monthlyMap.entries())
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([month, count]) => ({ count, month }));
-
-    const funnel = [
-      { count: appliedRes.count ?? 0, label: "지원" },
-      { count: docsPassedRes.count ?? 0, label: "서류 통과" },
-      { count: interviewingOrOfferedRes.count ?? 0, label: "면접" },
-      { count: offeredRes.count ?? 0, label: "합격" },
-    ];
-
-    return { funnel, monthly };
-  },
-  ["chart-data"],
-  { revalidate: 60 },
-);
 
 export async function getChartData(): Promise<GetChartDataResult> {
   const authResult = await getAuthContext();
@@ -117,14 +30,101 @@ export async function getChartData(): Promise<GetChartDataResult> {
     };
   }
 
+  const { accessToken, userId } = authResult;
+
+  // cookies()를 사용하지 않으므로 unstable_cache 안에서 안전하게 실행됩니다.
+  const getCachedChartData = unstable_cache(
+    async (): Promise<ChartData> => {
+      const supabase = createClientWithToken(accessToken);
+
+      const [
+        appliedRes,
+        docsPassedRes,
+        interviewingOrOfferedRes,
+        offeredRes,
+        monthlyRes,
+      ] = await Promise.all([
+        supabase
+          .from("applications")
+          .select("*", { count: "exact", head: true })
+          .eq("user_id", userId)
+          .neq("status", "SAVED"),
+        supabase
+          .from("applications")
+          .select("*", { count: "exact", head: true })
+          .eq("user_id", userId)
+          .in("status", DOCS_PASSED_STATUSES),
+        supabase
+          .from("applications")
+          .select("*", { count: "exact", head: true })
+          .eq("user_id", userId)
+          .in("status", INTERVIEW_STATUSES),
+        supabase
+          .from("applications")
+          .select("*", { count: "exact", head: true })
+          .eq("user_id", userId)
+          .eq("status", "OFFERED"),
+        supabase
+          .from("applications")
+          .select("applied_at")
+          .eq("user_id", userId)
+          .not("applied_at", "is", null)
+          .gte("applied_at", getMonthCutoff()),
+      ]);
+
+      const firstError =
+        appliedRes.error ??
+        docsPassedRes.error ??
+        interviewingOrOfferedRes.error ??
+        offeredRes.error ??
+        monthlyRes.error;
+
+      if (firstError) {
+        const code =
+          firstError.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
+        const reason = normalizeQueryError(firstError);
+        if (code === "QUERY_ERROR") {
+          reportQueryError("getChartData", reason);
+        }
+        throw new Error(reason);
+      }
+
+      const monthlyMap = new Map<string, number>();
+      for (const row of monthlyRes.data ?? []) {
+        if (row.applied_at) {
+          const month = (row.applied_at as string).slice(0, 7);
+          monthlyMap.set(month, (monthlyMap.get(month) ?? 0) + 1);
+        }
+      }
+
+      const monthly: MonthlyCount[] = Array.from(monthlyMap.entries())
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([month, count]) => ({ count, month }));
+
+      const funnel = [
+        { count: appliedRes.count ?? 0, label: "지원" },
+        { count: docsPassedRes.count ?? 0, label: "서류 통과" },
+        { count: interviewingOrOfferedRes.count ?? 0, label: "면접" },
+        { count: offeredRes.count ?? 0, label: "합격" },
+      ];
+
+      return { funnel, monthly };
+    },
+    ["chart-data", userId],
+    { revalidate: 60, tags: getApplicationsCacheTags(userId) },
+  );
+
   try {
-    const data = await getCachedChartData(
-      authResult.userId,
-      authResult.accessToken,
-    );
+    const data = await getCachedChartData();
     return { data, ok: true };
   } catch (e) {
     const reason = e instanceof Error ? e.message : "알 수 없는 오류";
     return { code: "QUERY_ERROR", ok: false, reason };
   }
+}
+
+function getMonthCutoff(): string {
+  const d = new Date();
+  d.setFullYear(d.getFullYear() - 1);
+  return d.toISOString().slice(0, 10);
 }

--- a/lib/actions/getStatCounts.ts
+++ b/lib/actions/getStatCounts.ts
@@ -11,75 +11,9 @@ import {
 
 import { createClientWithToken } from "../supabase/server";
 import { getAuthContext } from "./_authContext";
+import { getApplicationsCacheTags } from "./_cacheTags";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
-
-// cookies()를 사용하지 않으므로 unstable_cache 안에서 안전하게 실행됩니다.
-const getCachedStatCounts = unstable_cache(
-  async (userId: string, accessToken: string): Promise<StatCounts> => {
-    const supabase = createClientWithToken(accessToken);
-
-    const { data, error } = await supabase
-      .from("applications")
-      .select("status")
-      .eq("user_id", userId);
-
-    if (error) {
-      const code =
-        error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
-      const reason = normalizeQueryError(error);
-      if (code === "QUERY_ERROR") {
-        reportQueryError("getStatCounts", reason);
-      }
-      throw new Error(reason);
-    }
-
-    let applied = 0;
-    let docs = 0;
-    let docsPassed = 0;
-    let interviewing = 0;
-    let offered = 0;
-    let saved = 0;
-
-    for (const row of data ?? []) {
-      const { status } = row;
-
-      if (status === "SAVED") {
-        saved++;
-      } else {
-        applied++;
-      }
-
-      if ((DOCS_STATUSES as readonly string[]).includes(status)) {
-        docs++;
-      }
-
-      if ((DOCS_PASSED_STATUSES as readonly string[]).includes(status)) {
-        docsPassed++;
-      }
-
-      if (status === "INTERVIEWING") {
-        interviewing++;
-      }
-
-      if (status === "OFFERED") {
-        offered++;
-      }
-    }
-
-    return {
-      applied,
-      docs,
-      docsPassed,
-      interviewing,
-      offered,
-      saved,
-      total: (data ?? []).length,
-    };
-  },
-  ["stat-counts"],
-  { revalidate: 60 },
-);
 
 export async function getStatCounts(): Promise<GetStatCountsResult> {
   const authResult = await getAuthContext();
@@ -92,11 +26,77 @@ export async function getStatCounts(): Promise<GetStatCountsResult> {
     };
   }
 
+  const { accessToken, userId } = authResult;
+
+  // cookies()를 사용하지 않으므로 unstable_cache 안에서 안전하게 실행됩니다.
+  const getCachedStatCounts = unstable_cache(
+    async (): Promise<StatCounts> => {
+      const supabase = createClientWithToken(accessToken);
+
+      const { data, error } = await supabase
+        .from("applications")
+        .select("status")
+        .eq("user_id", userId);
+
+      if (error) {
+        const code =
+          error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
+        const reason = normalizeQueryError(error);
+        if (code === "QUERY_ERROR") {
+          reportQueryError("getStatCounts", reason);
+        }
+        throw new Error(reason);
+      }
+
+      let applied = 0;
+      let docs = 0;
+      let docsPassed = 0;
+      let interviewing = 0;
+      let offered = 0;
+      let saved = 0;
+
+      for (const row of data ?? []) {
+        const { status } = row;
+
+        if (status === "SAVED") {
+          saved++;
+        } else {
+          applied++;
+        }
+
+        if ((DOCS_STATUSES as readonly string[]).includes(status)) {
+          docs++;
+        }
+
+        if ((DOCS_PASSED_STATUSES as readonly string[]).includes(status)) {
+          docsPassed++;
+        }
+
+        if (status === "INTERVIEWING") {
+          interviewing++;
+        }
+
+        if (status === "OFFERED") {
+          offered++;
+        }
+      }
+
+      return {
+        applied,
+        docs,
+        docsPassed,
+        interviewing,
+        offered,
+        saved,
+        total: (data ?? []).length,
+      };
+    },
+    ["stat-counts", userId],
+    { revalidate: 60, tags: getApplicationsCacheTags(userId) },
+  );
+
   try {
-    const data = await getCachedStatCounts(
-      authResult.userId,
-      authResult.accessToken,
-    );
+    const data = await getCachedStatCounts();
     return { data, ok: true };
   } catch (e) {
     const reason = e instanceof Error ? e.message : "알 수 없는 오류";

--- a/lib/actions/saveJobApplication.ts
+++ b/lib/actions/saveJobApplication.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { updateTag } from "next/cache";
 import { z } from "zod";
 
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
@@ -13,6 +14,7 @@ import {
   type SaveJobApplicationResult,
 } from "@/lib/types/jobApplication";
 
+import { getApplicationsUserCacheTag } from "./_cacheTags";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 
@@ -86,6 +88,7 @@ export async function saveJobApplication(
   }
 
   trackServerEvent(authData.user.id, ANALYTICS_EVENTS.APPLICATION_ADD_SAVED);
+  updateTag(getApplicationsUserCacheTag(authData.user.id));
 
   return {
     data: parsedPayload.data,

--- a/lib/actions/updateApplicationNotes.ts
+++ b/lib/actions/updateApplicationNotes.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { updateTag } from "next/cache";
 import { z } from "zod";
 
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
@@ -11,6 +12,7 @@ import {
   type UpdateApplicationNotesResult,
 } from "@/lib/types/application";
 
+import { getApplicationsUserCacheTag } from "./_cacheTags";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 
@@ -78,6 +80,7 @@ export async function updateApplicationNotes(
   }
 
   trackServerEvent(authData.user.id, ANALYTICS_EVENTS.MEMO_SAVED);
+  updateTag(getApplicationsUserCacheTag(authData.user.id));
 
   return {
     data: {

--- a/lib/actions/updateApplicationStatus.ts
+++ b/lib/actions/updateApplicationStatus.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { updateTag } from "next/cache";
 import { z } from "zod";
 
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
@@ -11,6 +12,7 @@ import {
   type UpdateApplicationStatusResult,
 } from "@/lib/types/application";
 
+import { getApplicationsUserCacheTag } from "./_cacheTags";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 
@@ -87,6 +89,7 @@ export async function updateApplicationStatus(
         }
       : { to_status: parsedInput.data.status },
   );
+  updateTag(getApplicationsUserCacheTag(authData.user.id));
 
   return {
     ok: true,

--- a/lib/actions/updateJobDescription.ts
+++ b/lib/actions/updateJobDescription.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { updateTag } from "next/cache";
 import { z } from "zod";
 
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
@@ -11,6 +12,7 @@ import {
   type UpdateJobDescriptionResult,
 } from "@/lib/types/application";
 
+import { getApplicationsUserCacheTag } from "./_cacheTags";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 
@@ -76,6 +78,7 @@ export async function updateJobDescription(
   }
 
   trackServerEvent(authData.user.id, ANALYTICS_EVENTS.JOB_DESCRIPTION_SAVED);
+  updateTag(getApplicationsUserCacheTag(authData.user.id));
 
   return {
     data: {


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #376

## 📌 작업 내용

- 지원 목록, 통계, 차트 조회에 사용자 단위 applications 캐시 태그를 적용
- 지원 저장, 상태 변경, 공고 설명 수정, 메모 수정, 삭제 성공 시 updateTag로 관련 캐시를 즉시 무효화
- mutation 테스트에 캐시 무효화 호출 검증을 추가해 지원 데이터 갱신 회귀를 방지


