### PR TITLE
refactor: ApplicationsPanel 서버 셸과 클라이언트 파츠 분리(#378)

### DIFF
--- a/app/(protected)/applications/_components/ApplicationsView.tsx
+++ b/app/(protected)/applications/_components/ApplicationsView.tsx
@@ -1,19 +1,10 @@
 import { Suspense } from "react";
 
-import { getApplications } from "@/lib/actions/getApplications";
-
 import { parseApplicationsRouteState } from "../_utils/route-state";
 import { AddJobTrigger } from "./add-job";
 import { ApplicationFilters } from "./components/ApplicationFilters";
 import { ApplicationsPanel } from "./components/ApplicationsPanel";
 import { ApplicationsPanelFallback } from "./components/ApplicationsPanelFallback";
-import {
-  getPeriodDateRange,
-  PAGE_SIZE,
-  type PeriodPreset,
-  type SortValue,
-  type TabValue,
-} from "./constants";
 
 type SearchParams = Record<string, string | string[] | undefined>;
 
@@ -37,7 +28,7 @@ export function ApplicationsView({
             tab={tab}
           />
           <Suspense fallback={<ApplicationsPanelFallback />} key={panelKey}>
-            <ApplicationsPanelSection
+            <ApplicationsPanel
               period={period}
               previewApplicationId={previewApplicationId}
               search={search}
@@ -49,46 +40,5 @@ export function ApplicationsView({
       </div>
       <AddJobTrigger />
     </main>
-  );
-}
-
-async function ApplicationsPanelSection({
-  period,
-  previewApplicationId,
-  search,
-  sort,
-  tab,
-}: {
-  period: PeriodPreset;
-  previewApplicationId: null | string;
-  search: string;
-  sort: SortValue;
-  tab: TabValue;
-}) {
-  const dateRange = getPeriodDateRange(period);
-  const panelKey = JSON.stringify({ period, search, sort });
-  const initialPageResult = await getApplications({
-    limit: PAGE_SIZE,
-    offset: 0,
-    periodEnd: dateRange?.end,
-    periodStart: dateRange?.start,
-    search: search || undefined,
-    sort,
-  });
-
-  if (!initialPageResult.ok) {
-    throw new Error(initialPageResult.reason);
-  }
-
-  return (
-    <ApplicationsPanel
-      initialPage={initialPageResult.data}
-      key={panelKey}
-      period={period}
-      previewApplicationId={previewApplicationId}
-      search={search}
-      sort={sort}
-      tab={tab}
-    />
   );
 }

--- a/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
@@ -1,40 +1,13 @@
-"use client";
+import type { GetApplicationsPage } from "@/lib/types/application";
 
-import type { Route } from "next";
-
-import { AlertCircleIcon } from "lucide-react";
-import dynamic from "next/dynamic";
-import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
-import { flushSync } from "react-dom";
-
-import type {
-  ApplicationListItem,
-  GetApplicationsPage,
-} from "@/lib/types/application";
-import type { JobStatus } from "@/lib/types/job";
-
-import { Button } from "@/components/ui/button/Button";
 import { getApplications } from "@/lib/actions/getApplications";
 
 import type { PeriodPreset, SortValue, TabValue } from "../constants";
-import type { ApplicationTabsHandle } from "./ApplicationTabs";
 
-import { buildApplicationsHref } from "../../_utils/route-state";
 import { getPeriodDateRange, PAGE_SIZE } from "../constants";
-import { GoToTopFAB } from "../go-to-top";
-import { ApplicationTabs } from "./ApplicationTabs";
-
-const ApplicationPreviewSheet = dynamic(
-  () =>
-    import("./ApplicationPreviewSheet").then(
-      (module) => module.ApplicationPreviewSheet,
-    ),
-  { ssr: false },
-);
+import { ApplicationsPanelClient } from "./ApplicationsPanelClient";
 
 type ApplicationsPanelProps = {
-  initialPage: GetApplicationsPage;
   period: PeriodPreset;
   previewApplicationId: null | string;
   search: string;
@@ -42,230 +15,62 @@ type ApplicationsPanelProps = {
   tab: TabValue;
 };
 
-type RouteStateUpdate = {
-  period?: PeriodPreset;
-  previewApplicationId?: null | string;
+type LoadApplicationsPanelPageParams = {
+  periodEnd?: string;
+  periodStart?: string;
   search?: string;
   sort?: SortValue;
-  tab?: TabValue;
 };
 
-export function ApplicationsPanel({
-  initialPage,
+export async function ApplicationsPanel({
   period,
   previewApplicationId,
   search,
   sort,
   tab,
 }: ApplicationsPanelProps) {
-  const router = useRouter();
-
-  const tabsRef = useRef<ApplicationTabsHandle>(null);
-  const paginationSequenceRef = useRef(0);
-  const [isFetchingNextPage, setIsFetchingNextPage] = useState(false);
-  const [isListScrolled, setIsListScrolled] = useState(false);
-  const [isNavigatingFromPreview, setIsNavigatingFromPreview] = useState(false);
-  const [localPreviewApplicationId, setLocalPreviewApplicationId] = useState<
-    null | string
-  >(previewApplicationId);
-  const [pages, setPages] = useState<GetApplicationsPage[]>([initialPage]);
-  const [paginationError, setPaginationError] = useState<null | string>(null);
-
   const dateRange = getPeriodDateRange(period);
-  const applications = pages.flatMap((page) => page.items);
-  const hasNextPage = pages[pages.length - 1]?.hasMore ?? false;
-  const selectedApplication =
-    applications.find(
-      (application) => application.id === localPreviewApplicationId,
-    ) ?? null;
-  const shouldRenderPreview =
-    localPreviewApplicationId !== null &&
-    !isNavigatingFromPreview &&
-    selectedApplication !== null;
-
-  useEffect(() => {
-    setLocalPreviewApplicationId(previewApplicationId);
-  }, [previewApplicationId]);
-
-  function updateRoute(nextState: RouteStateUpdate) {
-    const nextPreviewApplicationId =
-      nextState.previewApplicationId !== undefined
-        ? nextState.previewApplicationId
-        : localPreviewApplicationId;
-
-    if (nextState.previewApplicationId !== undefined) {
-      setLocalPreviewApplicationId(nextPreviewApplicationId);
-    }
-
-    const href = buildApplicationsHref({
-      period: nextState.period ?? period,
-      previewApplicationId: nextPreviewApplicationId,
-      search: nextState.search ?? search,
-      sort: nextState.sort ?? sort,
-      tab: nextState.tab ?? tab,
-    });
-
-    router.replace(href as Route, { scroll: false });
-  }
-
-  function updatePreviewHistory(nextPreviewApplicationId: null | string) {
-    const href = buildApplicationsHref({
-      period,
-      previewApplicationId: nextPreviewApplicationId,
-      search,
-      sort,
-      tab,
-    });
-
-    window.history.replaceState(window.history.state, "", href);
-  }
-
-  function handleTabChange(nextTab: TabValue) {
-    updateRoute({
-      previewApplicationId: null,
-      tab: nextTab,
-    });
-  }
-
-  function handleSelectApplication(application: ApplicationListItem) {
-    setIsNavigatingFromPreview(false);
-    setLocalPreviewApplicationId(application.id);
-    // preview는 서버 데이터가 아니라 목록 위의 UI 상태이므로 App Router 재요청 없이 URL만 동기화합니다.
-    updatePreviewHistory(application.id);
-  }
-
-  function handleClosePreview() {
-    setIsNavigatingFromPreview(false);
-    setLocalPreviewApplicationId(null);
-    updatePreviewHistory(null);
-  }
-
-  function handleDetailNavigate() {
-    // iOS Safari bfcache가 "열린 시트" 상태를 스냅샷하지 않도록 상세 이동 직전에 프리뷰를 즉시 제거합니다.
-    flushSync(() => {
-      setIsNavigatingFromPreview(true);
-    });
-
-    const nextUrl = buildApplicationsHref({
-      period,
-      previewApplicationId: null,
-      search,
-      sort,
-      tab,
-    });
-
-    window.history.replaceState(window.history.state, "", nextUrl);
-  }
-
-  function handleStatusChange(applicationId: string, nextStatus: JobStatus) {
-    setPages((currentPages) =>
-      currentPages.map((page) => ({
-        ...page,
-        items: page.items.map((item) => {
-          if (item.id !== applicationId) {
-            return item;
-          }
-
-          return { ...item, status: nextStatus };
-        }),
-      })),
-    );
-  }
-
-  async function handleNearEnd() {
-    if (isFetchingNextPage || !hasNextPage) {
-      return;
-    }
-
-    const activeSequence = paginationSequenceRef.current;
-
-    setIsFetchingNextPage(true);
-    setPaginationError(null);
-
-    const result = await getApplications({
-      limit: PAGE_SIZE,
-      offset: applications.length,
-      periodEnd: dateRange?.end,
-      periodStart: dateRange?.start,
-      search: search || undefined,
-      sort,
-    });
-
-    if (paginationSequenceRef.current !== activeSequence) {
-      return;
-    }
-
-    if (!result.ok) {
-      setPaginationError(result.reason);
-      setIsFetchingNextPage(false);
-      return;
-    }
-
-    setPages((currentPages) => [...currentPages, result.data]);
-    setIsFetchingNextPage(false);
-  }
+  const initialPage = await loadApplicationsPanelPage({
+    periodEnd: dateRange?.end,
+    periodStart: dateRange?.start,
+    search: search || undefined,
+    sort,
+  });
 
   return (
     <div className="flex flex-col">
-      <ApplicationTabs
-        applications={applications}
-        className="h-[32rem] min-h-0 sm:h-[36rem] lg:h-[40rem]"
-        isFetchingNextPage={isFetchingNextPage}
-        onNearEndAction={() => {
-          void handleNearEnd();
-        }}
-        onRangeChangeAction={(startIndex: number) =>
-          setIsListScrolled(startIndex > 0)
-        }
-        onSelectApplicationAction={handleSelectApplication}
-        onTabChangeAction={handleTabChange}
-        ref={tabsRef}
+      <ApplicationsPanelClient
+        initialPage={initialPage}
+        period={period}
+        periodEnd={dateRange?.end}
+        periodStart={dateRange?.start}
+        previewApplicationId={previewApplicationId}
+        search={search}
+        sort={sort}
         tab={tab}
-      />
-
-      {paginationError ? (
-        <div
-          aria-live="polite"
-          className="border-t border-border/70 bg-muted/20 px-5 py-4 sm:px-6"
-          role="status"
-        >
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex items-start gap-2 text-sm text-red-700">
-              <AlertCircleIcon
-                aria-hidden="true"
-                className="mt-0.5 size-4 shrink-0"
-              />
-              <p>추가 목록을 불러오지 못했습니다. {paginationError}</p>
-            </div>
-            <Button
-              className="w-full sm:w-auto"
-              onClick={() => {
-                void handleNearEnd();
-              }}
-              size="sm"
-              variant="outline"
-            >
-              다시 시도
-            </Button>
-          </div>
-        </div>
-      ) : null}
-
-      {shouldRenderPreview ? (
-        <ApplicationPreviewSheet
-          application={selectedApplication}
-          isOpen={true}
-          onCloseAction={handleClosePreview}
-          onDetailNavigateAction={handleDetailNavigate}
-          onStatusChangeAction={handleStatusChange}
-        />
-      ) : null}
-
-      <GoToTopFAB
-        className="md:bottom-24"
-        isVisible={isListScrolled}
-        onScrollToTop={() => tabsRef.current?.scrollToTop()}
       />
     </div>
   );
+}
+
+async function loadApplicationsPanelPage({
+  periodEnd,
+  periodStart,
+  search,
+  sort,
+}: LoadApplicationsPanelPageParams): Promise<GetApplicationsPage> {
+  const result = await getApplications({
+    limit: PAGE_SIZE,
+    offset: 0,
+    periodEnd,
+    periodStart,
+    search,
+    sort,
+  });
+
+  if (!result.ok) {
+    throw new Error(result.reason);
+  }
+
+  return result.data;
 }

--- a/app/(protected)/applications/_components/components/ApplicationsPanelClient.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanelClient.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import type { Route } from "next";
+
+import { AlertCircleIcon } from "lucide-react";
+import dynamic from "next/dynamic";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import { flushSync } from "react-dom";
+
+import type {
+  ApplicationListItem,
+  GetApplicationsPage,
+} from "@/lib/types/application";
+import type { JobStatus } from "@/lib/types/job";
+
+import { Button } from "@/components/ui/button/Button";
+import { getApplications } from "@/lib/actions/getApplications";
+
+import type { PeriodPreset, SortValue, TabValue } from "../constants";
+import type { ApplicationTabsHandle } from "./ApplicationTabs";
+
+import { buildApplicationsHref } from "../../_utils/route-state";
+import { PAGE_SIZE } from "../constants";
+import { GoToTopFAB } from "../go-to-top";
+import { ApplicationTabs } from "./ApplicationTabs";
+
+const ApplicationPreviewSheet = dynamic(
+  () =>
+    import("./ApplicationPreviewSheet").then(
+      (module) => module.ApplicationPreviewSheet,
+    ),
+  { ssr: false },
+);
+
+type ApplicationsPanelClientProps = {
+  initialPage: GetApplicationsPage;
+  period: PeriodPreset;
+  periodEnd?: string;
+  periodStart?: string;
+  previewApplicationId: null | string;
+  search: string;
+  sort: SortValue;
+  tab: TabValue;
+};
+
+type RouteStateUpdate = {
+  period?: PeriodPreset;
+  previewApplicationId?: null | string;
+  search?: string;
+  sort?: SortValue;
+  tab?: TabValue;
+};
+
+export function ApplicationsPanelClient({
+  initialPage,
+  period,
+  periodEnd,
+  periodStart,
+  previewApplicationId,
+  search,
+  sort,
+  tab,
+}: ApplicationsPanelClientProps) {
+  const router = useRouter();
+
+  const tabsRef = useRef<ApplicationTabsHandle>(null);
+  const paginationSequenceRef = useRef(0);
+  const [isFetchingNextPage, setIsFetchingNextPage] = useState(false);
+  const [isListScrolled, setIsListScrolled] = useState(false);
+  const [isNavigatingFromPreview, setIsNavigatingFromPreview] = useState(false);
+  const [localPreviewApplicationId, setLocalPreviewApplicationId] = useState<
+    null | string
+  >(previewApplicationId);
+  const [pages, setPages] = useState<GetApplicationsPage[]>([initialPage]);
+  const [paginationError, setPaginationError] = useState<null | string>(null);
+
+  const applications = pages.flatMap((page) => page.items);
+  const hasNextPage = pages[pages.length - 1]?.hasMore ?? false;
+  const selectedApplication =
+    applications.find(
+      (application) => application.id === localPreviewApplicationId,
+    ) ?? null;
+  const shouldRenderPreview =
+    localPreviewApplicationId !== null &&
+    !isNavigatingFromPreview &&
+    selectedApplication !== null;
+
+  useEffect(() => {
+    setLocalPreviewApplicationId(previewApplicationId);
+  }, [previewApplicationId]);
+
+  function updateRoute(nextState: RouteStateUpdate) {
+    const nextPreviewApplicationId =
+      nextState.previewApplicationId !== undefined
+        ? nextState.previewApplicationId
+        : localPreviewApplicationId;
+
+    if (nextState.previewApplicationId !== undefined) {
+      setLocalPreviewApplicationId(nextPreviewApplicationId);
+    }
+
+    const href = buildApplicationsHref({
+      period: nextState.period ?? period,
+      previewApplicationId: nextPreviewApplicationId,
+      search: nextState.search ?? search,
+      sort: nextState.sort ?? sort,
+      tab: nextState.tab ?? tab,
+    });
+
+    router.replace(href as Route, { scroll: false });
+  }
+
+  function updatePreviewHistory(nextPreviewApplicationId: null | string) {
+    const href = buildApplicationsHref({
+      period,
+      previewApplicationId: nextPreviewApplicationId,
+      search,
+      sort,
+      tab,
+    });
+
+    window.history.replaceState(window.history.state, "", href);
+  }
+
+  function handleTabChange(nextTab: TabValue) {
+    updateRoute({
+      previewApplicationId: null,
+      tab: nextTab,
+    });
+  }
+
+  function handleSelectApplication(application: ApplicationListItem) {
+    setIsNavigatingFromPreview(false);
+    setLocalPreviewApplicationId(application.id);
+    // preview는 서버 데이터가 아니라 목록 위의 UI 상태이므로 App Router 재요청 없이 URL만 동기화합니다.
+    updatePreviewHistory(application.id);
+  }
+
+  function handleClosePreview() {
+    setIsNavigatingFromPreview(false);
+    setLocalPreviewApplicationId(null);
+    updatePreviewHistory(null);
+  }
+
+  function handleDetailNavigate() {
+    // iOS Safari bfcache가 "열린 시트" 상태를 스냅샷하지 않도록 상세 이동 직전에 프리뷰를 즉시 제거합니다.
+    flushSync(() => {
+      setIsNavigatingFromPreview(true);
+    });
+
+    const nextUrl = buildApplicationsHref({
+      period,
+      previewApplicationId: null,
+      search,
+      sort,
+      tab,
+    });
+
+    window.history.replaceState(window.history.state, "", nextUrl);
+  }
+
+  function handleStatusChange(applicationId: string, nextStatus: JobStatus) {
+    setPages((currentPages) =>
+      currentPages.map((page) => ({
+        ...page,
+        items: page.items.map((item) => {
+          if (item.id !== applicationId) {
+            return item;
+          }
+
+          return { ...item, status: nextStatus };
+        }),
+      })),
+    );
+  }
+
+  async function handleNearEnd() {
+    if (isFetchingNextPage || !hasNextPage) {
+      return;
+    }
+
+    const activeSequence = paginationSequenceRef.current;
+
+    setIsFetchingNextPage(true);
+    setPaginationError(null);
+
+    const result = await getApplications({
+      limit: PAGE_SIZE,
+      offset: applications.length,
+      periodEnd,
+      periodStart,
+      search: search || undefined,
+      sort,
+    });
+
+    if (paginationSequenceRef.current !== activeSequence) {
+      return;
+    }
+
+    if (!result.ok) {
+      setPaginationError(result.reason);
+      setIsFetchingNextPage(false);
+      return;
+    }
+
+    setPages((currentPages) => [...currentPages, result.data]);
+    setIsFetchingNextPage(false);
+  }
+
+  return (
+    <>
+      <ApplicationTabs
+        applications={applications}
+        className="h-[32rem] min-h-0 sm:h-[36rem] lg:h-[40rem]"
+        isFetchingNextPage={isFetchingNextPage}
+        onNearEndAction={() => {
+          void handleNearEnd();
+        }}
+        onRangeChangeAction={(startIndex: number) =>
+          setIsListScrolled(startIndex > 0)
+        }
+        onSelectApplicationAction={handleSelectApplication}
+        onTabChangeAction={handleTabChange}
+        ref={tabsRef}
+        tab={tab}
+      />
+
+      {paginationError ? (
+        <div
+          aria-live="polite"
+          className="border-t border-border/70 bg-muted/20 px-5 py-4 sm:px-6"
+          role="status"
+        >
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-start gap-2 text-sm text-red-700">
+              <AlertCircleIcon
+                aria-hidden="true"
+                className="mt-0.5 size-4 shrink-0"
+              />
+              <p>추가 목록을 불러오지 못했습니다. {paginationError}</p>
+            </div>
+            <Button
+              className="w-full sm:w-auto"
+              onClick={() => {
+                void handleNearEnd();
+              }}
+              size="sm"
+              variant="outline"
+            >
+              다시 시도
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {shouldRenderPreview ? (
+        <ApplicationPreviewSheet
+          application={selectedApplication}
+          isOpen={true}
+          onCloseAction={handleClosePreview}
+          onDetailNavigateAction={handleDetailNavigate}
+          onStatusChangeAction={handleStatusChange}
+        />
+      ) : null}
+
+      <GoToTopFAB
+        className="md:bottom-24"
+        isVisible={isListScrolled}
+        onScrollToTop={() => tabsRef.current?.scrollToTop()}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #378

## 📌 작업 내용

- ApplicationsPanel을 서버 컴포넌트로 전환해 초기 지원 목록 조회와 기간 범위 계산 책임을 담당하도록 정리
- 탭 전환, 프리뷰, 무한 스크롤, 상태 낙관 갱신, URL 동기화 로직을 ApplicationsPanelClient로 분리
- ApplicationsView의 중간 서버 섹션을 제거해 Suspense 내부 렌더링 흐름을 단순화
- 초기 조회와 추가 페이지 조회가 같은 periodStart/periodEnd 기준을 사용하도록 데이터 흐름을 명시화


