### PR TITLE
release: 활성 사용자 이벤트, 대시보드 로딩 경계, 지원 목록 데이터 흐름 정리

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,22 +265,23 @@ flowchart LR
 
 ### 이벤트 목록
 
-| 이벤트명                     | 발생 시점                      | 프로퍼티                           |
-| ---------------------------- | ------------------------------ | ---------------------------------- |
-| `login_attempted`            | Google 로그인 버튼 클릭        | -                                  |
-| `application_add_opened`     | 공고 추가 FAB 클릭             | -                                  |
-| `application_add_submitted`  | 수동 폼 제출 → 리뷰 단계 진입  | `has_url: boolean`                 |
-| `application_add_saved`      | 공고 저장 완료                 | -                                  |
-| `application_add_reset`      | 리뷰 단계에서 "다시 입력" 클릭 | -                                  |
-| `application_preview_opened` | 대시보드에서 지원 행 클릭      | -                                  |
-| `application_status_changed` | 지원 상태 변경 성공            | `from_status`, `to_status`         |
-| `application_deleted`        | 지원 삭제 완료                 | -                                  |
-| `interview_added`            | 면접 일정 추가 완료            | `interview_type`, `round`          |
-| `interview_edited`           | 면접 일정 수정 완료            | `interview_type`, `round`          |
-| `interview_deleted`          | 면접 일정 삭제 완료            | -                                  |
-| `job_description_saved`      | 공고 설명 저장 완료            | -                                  |
-| `memo_saved`                 | 개인 메모 저장 완료            | -                                  |
-| `applications_tab_changed`   | 지원 목록 탭 전환              | `tab: 'all' \| 'active' \| 'done'` |
+| 이벤트명                     | 발생 시점                             | 프로퍼티                           |
+| ---------------------------- | ------------------------------------- | ---------------------------------- |
+| `user_active`                | 인증된 사용자의 보호 영역 데이터 조회 | -                                  |
+| `login_attempted`            | Google 로그인 버튼 클릭               | -                                  |
+| `application_add_opened`     | 공고 추가 FAB 클릭                    | -                                  |
+| `application_add_submitted`  | 수동 폼 제출 → 리뷰 단계 진입         | `has_url: boolean`                 |
+| `application_add_saved`      | 공고 저장 완료                        | -                                  |
+| `application_add_reset`      | 리뷰 단계에서 "다시 입력" 클릭        | -                                  |
+| `application_preview_opened` | 대시보드에서 지원 행 클릭             | -                                  |
+| `application_status_changed` | 지원 상태 변경 성공                   | `from_status`, `to_status`         |
+| `application_deleted`        | 지원 삭제 완료                        | -                                  |
+| `interview_added`            | 면접 일정 추가 완료                   | `interview_type`, `round`          |
+| `interview_edited`           | 면접 일정 수정 완료                   | `interview_type`, `round`          |
+| `interview_deleted`          | 면접 일정 삭제 완료                   | -                                  |
+| `job_description_saved`      | 공고 설명 저장 완료                   | -                                  |
+| `memo_saved`                 | 개인 메모 저장 완료                   | -                                  |
+| `applications_tab_changed`   | 지원 목록 탭 전환                     | `tab: 'all' \| 'active' \| 'done'` |
 
 ### 퍼널 설정(PostHog 대시보드)
 

--- a/app/(protected)/applications/_components/ApplicationsView.tsx
+++ b/app/(protected)/applications/_components/ApplicationsView.tsx
@@ -1,19 +1,10 @@
 import { Suspense } from "react";
 
-import { getApplications } from "@/lib/actions/getApplications";
-
 import { parseApplicationsRouteState } from "../_utils/route-state";
 import { AddJobTrigger } from "./add-job";
 import { ApplicationFilters } from "./components/ApplicationFilters";
 import { ApplicationsPanel } from "./components/ApplicationsPanel";
 import { ApplicationsPanelFallback } from "./components/ApplicationsPanelFallback";
-import {
-  getPeriodDateRange,
-  PAGE_SIZE,
-  type PeriodPreset,
-  type SortValue,
-  type TabValue,
-} from "./constants";
 
 type SearchParams = Record<string, string | string[] | undefined>;
 
@@ -37,7 +28,7 @@ export function ApplicationsView({
             tab={tab}
           />
           <Suspense fallback={<ApplicationsPanelFallback />} key={panelKey}>
-            <ApplicationsPanelSection
+            <ApplicationsPanel
               period={period}
               previewApplicationId={previewApplicationId}
               search={search}
@@ -49,46 +40,5 @@ export function ApplicationsView({
       </div>
       <AddJobTrigger />
     </main>
-  );
-}
-
-async function ApplicationsPanelSection({
-  period,
-  previewApplicationId,
-  search,
-  sort,
-  tab,
-}: {
-  period: PeriodPreset;
-  previewApplicationId: null | string;
-  search: string;
-  sort: SortValue;
-  tab: TabValue;
-}) {
-  const dateRange = getPeriodDateRange(period);
-  const panelKey = JSON.stringify({ period, search, sort });
-  const initialPageResult = await getApplications({
-    limit: PAGE_SIZE,
-    offset: 0,
-    periodEnd: dateRange?.end,
-    periodStart: dateRange?.start,
-    search: search || undefined,
-    sort,
-  });
-
-  if (!initialPageResult.ok) {
-    throw new Error(initialPageResult.reason);
-  }
-
-  return (
-    <ApplicationsPanel
-      initialPage={initialPageResult.data}
-      key={panelKey}
-      period={period}
-      previewApplicationId={previewApplicationId}
-      search={search}
-      sort={sort}
-      tab={tab}
-    />
   );
 }

--- a/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanel.tsx
@@ -1,40 +1,13 @@
-"use client";
+import type { GetApplicationsPage } from "@/lib/types/application";
 
-import type { Route } from "next";
-
-import { AlertCircleIcon } from "lucide-react";
-import dynamic from "next/dynamic";
-import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
-import { flushSync } from "react-dom";
-
-import type {
-  ApplicationListItem,
-  GetApplicationsPage,
-} from "@/lib/types/application";
-import type { JobStatus } from "@/lib/types/job";
-
-import { Button } from "@/components/ui/button/Button";
 import { getApplications } from "@/lib/actions/getApplications";
 
 import type { PeriodPreset, SortValue, TabValue } from "../constants";
-import type { ApplicationTabsHandle } from "./ApplicationTabs";
 
-import { buildApplicationsHref } from "../../_utils/route-state";
 import { getPeriodDateRange, PAGE_SIZE } from "../constants";
-import { GoToTopFAB } from "../go-to-top";
-import { ApplicationTabs } from "./ApplicationTabs";
-
-const ApplicationPreviewSheet = dynamic(
-  () =>
-    import("./ApplicationPreviewSheet").then(
-      (module) => module.ApplicationPreviewSheet,
-    ),
-  { ssr: false },
-);
+import { ApplicationsPanelClient } from "./ApplicationsPanelClient";
 
 type ApplicationsPanelProps = {
-  initialPage: GetApplicationsPage;
   period: PeriodPreset;
   previewApplicationId: null | string;
   search: string;
@@ -42,230 +15,62 @@ type ApplicationsPanelProps = {
   tab: TabValue;
 };
 
-type RouteStateUpdate = {
-  period?: PeriodPreset;
-  previewApplicationId?: null | string;
+type LoadApplicationsPanelPageParams = {
+  periodEnd?: string;
+  periodStart?: string;
   search?: string;
   sort?: SortValue;
-  tab?: TabValue;
 };
 
-export function ApplicationsPanel({
-  initialPage,
+export async function ApplicationsPanel({
   period,
   previewApplicationId,
   search,
   sort,
   tab,
 }: ApplicationsPanelProps) {
-  const router = useRouter();
-
-  const tabsRef = useRef<ApplicationTabsHandle>(null);
-  const paginationSequenceRef = useRef(0);
-  const [isFetchingNextPage, setIsFetchingNextPage] = useState(false);
-  const [isListScrolled, setIsListScrolled] = useState(false);
-  const [isNavigatingFromPreview, setIsNavigatingFromPreview] = useState(false);
-  const [localPreviewApplicationId, setLocalPreviewApplicationId] = useState<
-    null | string
-  >(previewApplicationId);
-  const [pages, setPages] = useState<GetApplicationsPage[]>([initialPage]);
-  const [paginationError, setPaginationError] = useState<null | string>(null);
-
   const dateRange = getPeriodDateRange(period);
-  const applications = pages.flatMap((page) => page.items);
-  const hasNextPage = pages[pages.length - 1]?.hasMore ?? false;
-  const selectedApplication =
-    applications.find(
-      (application) => application.id === localPreviewApplicationId,
-    ) ?? null;
-  const shouldRenderPreview =
-    localPreviewApplicationId !== null &&
-    !isNavigatingFromPreview &&
-    selectedApplication !== null;
-
-  useEffect(() => {
-    setLocalPreviewApplicationId(previewApplicationId);
-  }, [previewApplicationId]);
-
-  function updateRoute(nextState: RouteStateUpdate) {
-    const nextPreviewApplicationId =
-      nextState.previewApplicationId !== undefined
-        ? nextState.previewApplicationId
-        : localPreviewApplicationId;
-
-    if (nextState.previewApplicationId !== undefined) {
-      setLocalPreviewApplicationId(nextPreviewApplicationId);
-    }
-
-    const href = buildApplicationsHref({
-      period: nextState.period ?? period,
-      previewApplicationId: nextPreviewApplicationId,
-      search: nextState.search ?? search,
-      sort: nextState.sort ?? sort,
-      tab: nextState.tab ?? tab,
-    });
-
-    router.replace(href as Route, { scroll: false });
-  }
-
-  function updatePreviewHistory(nextPreviewApplicationId: null | string) {
-    const href = buildApplicationsHref({
-      period,
-      previewApplicationId: nextPreviewApplicationId,
-      search,
-      sort,
-      tab,
-    });
-
-    window.history.replaceState(window.history.state, "", href);
-  }
-
-  function handleTabChange(nextTab: TabValue) {
-    updateRoute({
-      previewApplicationId: null,
-      tab: nextTab,
-    });
-  }
-
-  function handleSelectApplication(application: ApplicationListItem) {
-    setIsNavigatingFromPreview(false);
-    setLocalPreviewApplicationId(application.id);
-    // preview는 서버 데이터가 아니라 목록 위의 UI 상태이므로 App Router 재요청 없이 URL만 동기화합니다.
-    updatePreviewHistory(application.id);
-  }
-
-  function handleClosePreview() {
-    setIsNavigatingFromPreview(false);
-    setLocalPreviewApplicationId(null);
-    updatePreviewHistory(null);
-  }
-
-  function handleDetailNavigate() {
-    // iOS Safari bfcache가 "열린 시트" 상태를 스냅샷하지 않도록 상세 이동 직전에 프리뷰를 즉시 제거합니다.
-    flushSync(() => {
-      setIsNavigatingFromPreview(true);
-    });
-
-    const nextUrl = buildApplicationsHref({
-      period,
-      previewApplicationId: null,
-      search,
-      sort,
-      tab,
-    });
-
-    window.history.replaceState(window.history.state, "", nextUrl);
-  }
-
-  function handleStatusChange(applicationId: string, nextStatus: JobStatus) {
-    setPages((currentPages) =>
-      currentPages.map((page) => ({
-        ...page,
-        items: page.items.map((item) => {
-          if (item.id !== applicationId) {
-            return item;
-          }
-
-          return { ...item, status: nextStatus };
-        }),
-      })),
-    );
-  }
-
-  async function handleNearEnd() {
-    if (isFetchingNextPage || !hasNextPage) {
-      return;
-    }
-
-    const activeSequence = paginationSequenceRef.current;
-
-    setIsFetchingNextPage(true);
-    setPaginationError(null);
-
-    const result = await getApplications({
-      limit: PAGE_SIZE,
-      offset: applications.length,
-      periodEnd: dateRange?.end,
-      periodStart: dateRange?.start,
-      search: search || undefined,
-      sort,
-    });
-
-    if (paginationSequenceRef.current !== activeSequence) {
-      return;
-    }
-
-    if (!result.ok) {
-      setPaginationError(result.reason);
-      setIsFetchingNextPage(false);
-      return;
-    }
-
-    setPages((currentPages) => [...currentPages, result.data]);
-    setIsFetchingNextPage(false);
-  }
+  const initialPage = await loadApplicationsPanelPage({
+    periodEnd: dateRange?.end,
+    periodStart: dateRange?.start,
+    search: search || undefined,
+    sort,
+  });
 
   return (
     <div className="flex flex-col">
-      <ApplicationTabs
-        applications={applications}
-        className="h-[32rem] min-h-0 sm:h-[36rem] lg:h-[40rem]"
-        isFetchingNextPage={isFetchingNextPage}
-        onNearEndAction={() => {
-          void handleNearEnd();
-        }}
-        onRangeChangeAction={(startIndex: number) =>
-          setIsListScrolled(startIndex > 0)
-        }
-        onSelectApplicationAction={handleSelectApplication}
-        onTabChangeAction={handleTabChange}
-        ref={tabsRef}
+      <ApplicationsPanelClient
+        initialPage={initialPage}
+        period={period}
+        periodEnd={dateRange?.end}
+        periodStart={dateRange?.start}
+        previewApplicationId={previewApplicationId}
+        search={search}
+        sort={sort}
         tab={tab}
-      />
-
-      {paginationError ? (
-        <div
-          aria-live="polite"
-          className="border-t border-border/70 bg-muted/20 px-5 py-4 sm:px-6"
-          role="status"
-        >
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex items-start gap-2 text-sm text-red-700">
-              <AlertCircleIcon
-                aria-hidden="true"
-                className="mt-0.5 size-4 shrink-0"
-              />
-              <p>추가 목록을 불러오지 못했습니다. {paginationError}</p>
-            </div>
-            <Button
-              className="w-full sm:w-auto"
-              onClick={() => {
-                void handleNearEnd();
-              }}
-              size="sm"
-              variant="outline"
-            >
-              다시 시도
-            </Button>
-          </div>
-        </div>
-      ) : null}
-
-      {shouldRenderPreview ? (
-        <ApplicationPreviewSheet
-          application={selectedApplication}
-          isOpen={true}
-          onCloseAction={handleClosePreview}
-          onDetailNavigateAction={handleDetailNavigate}
-          onStatusChangeAction={handleStatusChange}
-        />
-      ) : null}
-
-      <GoToTopFAB
-        className="md:bottom-24"
-        isVisible={isListScrolled}
-        onScrollToTop={() => tabsRef.current?.scrollToTop()}
       />
     </div>
   );
+}
+
+async function loadApplicationsPanelPage({
+  periodEnd,
+  periodStart,
+  search,
+  sort,
+}: LoadApplicationsPanelPageParams): Promise<GetApplicationsPage> {
+  const result = await getApplications({
+    limit: PAGE_SIZE,
+    offset: 0,
+    periodEnd,
+    periodStart,
+    search,
+    sort,
+  });
+
+  if (!result.ok) {
+    throw new Error(result.reason);
+  }
+
+  return result.data;
 }

--- a/app/(protected)/applications/_components/components/ApplicationsPanelClient.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanelClient.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import type { Route } from "next";
+
+import { AlertCircleIcon } from "lucide-react";
+import dynamic from "next/dynamic";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import { flushSync } from "react-dom";
+
+import type {
+  ApplicationListItem,
+  GetApplicationsPage,
+} from "@/lib/types/application";
+import type { JobStatus } from "@/lib/types/job";
+
+import { Button } from "@/components/ui/button/Button";
+import { getApplications } from "@/lib/actions/getApplications";
+
+import type { PeriodPreset, SortValue, TabValue } from "../constants";
+import type { ApplicationTabsHandle } from "./ApplicationTabs";
+
+import { buildApplicationsHref } from "../../_utils/route-state";
+import { PAGE_SIZE } from "../constants";
+import { GoToTopFAB } from "../go-to-top";
+import { ApplicationTabs } from "./ApplicationTabs";
+
+const ApplicationPreviewSheet = dynamic(
+  () =>
+    import("./ApplicationPreviewSheet").then(
+      (module) => module.ApplicationPreviewSheet,
+    ),
+  { ssr: false },
+);
+
+type ApplicationsPanelClientProps = {
+  initialPage: GetApplicationsPage;
+  period: PeriodPreset;
+  periodEnd?: string;
+  periodStart?: string;
+  previewApplicationId: null | string;
+  search: string;
+  sort: SortValue;
+  tab: TabValue;
+};
+
+type RouteStateUpdate = {
+  period?: PeriodPreset;
+  previewApplicationId?: null | string;
+  search?: string;
+  sort?: SortValue;
+  tab?: TabValue;
+};
+
+export function ApplicationsPanelClient({
+  initialPage,
+  period,
+  periodEnd,
+  periodStart,
+  previewApplicationId,
+  search,
+  sort,
+  tab,
+}: ApplicationsPanelClientProps) {
+  const router = useRouter();
+
+  const tabsRef = useRef<ApplicationTabsHandle>(null);
+  const paginationSequenceRef = useRef(0);
+  const [isFetchingNextPage, setIsFetchingNextPage] = useState(false);
+  const [isListScrolled, setIsListScrolled] = useState(false);
+  const [isNavigatingFromPreview, setIsNavigatingFromPreview] = useState(false);
+  const [localPreviewApplicationId, setLocalPreviewApplicationId] = useState<
+    null | string
+  >(previewApplicationId);
+  const [pages, setPages] = useState<GetApplicationsPage[]>([initialPage]);
+  const [paginationError, setPaginationError] = useState<null | string>(null);
+
+  const applications = pages.flatMap((page) => page.items);
+  const hasNextPage = pages[pages.length - 1]?.hasMore ?? false;
+  const selectedApplication =
+    applications.find(
+      (application) => application.id === localPreviewApplicationId,
+    ) ?? null;
+  const shouldRenderPreview =
+    localPreviewApplicationId !== null &&
+    !isNavigatingFromPreview &&
+    selectedApplication !== null;
+
+  useEffect(() => {
+    setLocalPreviewApplicationId(previewApplicationId);
+  }, [previewApplicationId]);
+
+  function updateRoute(nextState: RouteStateUpdate) {
+    const nextPreviewApplicationId =
+      nextState.previewApplicationId !== undefined
+        ? nextState.previewApplicationId
+        : localPreviewApplicationId;
+
+    if (nextState.previewApplicationId !== undefined) {
+      setLocalPreviewApplicationId(nextPreviewApplicationId);
+    }
+
+    const href = buildApplicationsHref({
+      period: nextState.period ?? period,
+      previewApplicationId: nextPreviewApplicationId,
+      search: nextState.search ?? search,
+      sort: nextState.sort ?? sort,
+      tab: nextState.tab ?? tab,
+    });
+
+    router.replace(href as Route, { scroll: false });
+  }
+
+  function updatePreviewHistory(nextPreviewApplicationId: null | string) {
+    const href = buildApplicationsHref({
+      period,
+      previewApplicationId: nextPreviewApplicationId,
+      search,
+      sort,
+      tab,
+    });
+
+    window.history.replaceState(window.history.state, "", href);
+  }
+
+  function handleTabChange(nextTab: TabValue) {
+    updateRoute({
+      previewApplicationId: null,
+      tab: nextTab,
+    });
+  }
+
+  function handleSelectApplication(application: ApplicationListItem) {
+    setIsNavigatingFromPreview(false);
+    setLocalPreviewApplicationId(application.id);
+    // preview는 서버 데이터가 아니라 목록 위의 UI 상태이므로 App Router 재요청 없이 URL만 동기화합니다.
+    updatePreviewHistory(application.id);
+  }
+
+  function handleClosePreview() {
+    setIsNavigatingFromPreview(false);
+    setLocalPreviewApplicationId(null);
+    updatePreviewHistory(null);
+  }
+
+  function handleDetailNavigate() {
+    // iOS Safari bfcache가 "열린 시트" 상태를 스냅샷하지 않도록 상세 이동 직전에 프리뷰를 즉시 제거합니다.
+    flushSync(() => {
+      setIsNavigatingFromPreview(true);
+    });
+
+    const nextUrl = buildApplicationsHref({
+      period,
+      previewApplicationId: null,
+      search,
+      sort,
+      tab,
+    });
+
+    window.history.replaceState(window.history.state, "", nextUrl);
+  }
+
+  function handleStatusChange(applicationId: string, nextStatus: JobStatus) {
+    setPages((currentPages) =>
+      currentPages.map((page) => ({
+        ...page,
+        items: page.items.map((item) => {
+          if (item.id !== applicationId) {
+            return item;
+          }
+
+          return { ...item, status: nextStatus };
+        }),
+      })),
+    );
+  }
+
+  async function handleNearEnd() {
+    if (isFetchingNextPage || !hasNextPage) {
+      return;
+    }
+
+    const activeSequence = paginationSequenceRef.current;
+
+    setIsFetchingNextPage(true);
+    setPaginationError(null);
+
+    const result = await getApplications({
+      limit: PAGE_SIZE,
+      offset: applications.length,
+      periodEnd,
+      periodStart,
+      search: search || undefined,
+      sort,
+    });
+
+    if (paginationSequenceRef.current !== activeSequence) {
+      return;
+    }
+
+    if (!result.ok) {
+      setPaginationError(result.reason);
+      setIsFetchingNextPage(false);
+      return;
+    }
+
+    setPages((currentPages) => [...currentPages, result.data]);
+    setIsFetchingNextPage(false);
+  }
+
+  return (
+    <>
+      <ApplicationTabs
+        applications={applications}
+        className="h-[32rem] min-h-0 sm:h-[36rem] lg:h-[40rem]"
+        isFetchingNextPage={isFetchingNextPage}
+        onNearEndAction={() => {
+          void handleNearEnd();
+        }}
+        onRangeChangeAction={(startIndex: number) =>
+          setIsListScrolled(startIndex > 0)
+        }
+        onSelectApplicationAction={handleSelectApplication}
+        onTabChangeAction={handleTabChange}
+        ref={tabsRef}
+        tab={tab}
+      />
+
+      {paginationError ? (
+        <div
+          aria-live="polite"
+          className="border-t border-border/70 bg-muted/20 px-5 py-4 sm:px-6"
+          role="status"
+        >
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-start gap-2 text-sm text-red-700">
+              <AlertCircleIcon
+                aria-hidden="true"
+                className="mt-0.5 size-4 shrink-0"
+              />
+              <p>추가 목록을 불러오지 못했습니다. {paginationError}</p>
+            </div>
+            <Button
+              className="w-full sm:w-auto"
+              onClick={() => {
+                void handleNearEnd();
+              }}
+              size="sm"
+              variant="outline"
+            >
+              다시 시도
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {shouldRenderPreview ? (
+        <ApplicationPreviewSheet
+          application={selectedApplication}
+          isOpen={true}
+          onCloseAction={handleClosePreview}
+          onDetailNavigateAction={handleDetailNavigate}
+          onStatusChangeAction={handleStatusChange}
+        />
+      ) : null}
+
+      <GoToTopFAB
+        className="md:bottom-24"
+        isVisible={isListScrolled}
+        onScrollToTop={() => tabsRef.current?.scrollToTop()}
+      />
+    </>
+  );
+}

--- a/app/(protected)/applications/loading.tsx
+++ b/app/(protected)/applications/loading.tsx
@@ -1,0 +1,37 @@
+import { Skeleton } from "@/components/ui/skeleton/Skeleton";
+
+import { ApplicationsPanelFallback } from "./_components/components/ApplicationsPanelFallback";
+
+const PERIOD_CHIP_KEYS = [0, 1, 2, 3] as const;
+
+export default function ApplicationsLoading() {
+  return (
+    <main className="min-h-screen bg-background pb-20">
+      <div className="mx-auto flex w-full max-w-6xl flex-col px-4 pt-6 pb-10 sm:px-6 sm:pt-8 lg:px-8 lg:pt-10 lg:pb-12">
+        <section className="flex flex-col overflow-hidden rounded-3xl border border-border/70 bg-background">
+          <ApplicationFiltersFallback />
+          <ApplicationsPanelFallback />
+        </section>
+      </div>
+    </main>
+  );
+}
+
+function ApplicationFiltersFallback() {
+  return (
+    <section
+      aria-hidden="true"
+      className="bg-background/95 px-5 py-5 backdrop-blur-sm sm:px-6"
+    >
+      <div className="grid gap-4">
+        <Skeleton className="h-12 w-full rounded-2xl" />
+        <div className="flex flex-wrap items-center gap-2">
+          {PERIOD_CHIP_KEYS.map((key) => (
+            <Skeleton className="h-8 w-16 rounded-full" key={key} />
+          ))}
+          <Skeleton className="ml-auto h-8 w-28 rounded-full" />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/(protected)/dashboard/_components/dashboard-view/DashboardHeader.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DashboardHeader.tsx
@@ -1,0 +1,28 @@
+import { formatKoreanDate } from "@/lib/utils";
+
+export function DashboardHeader() {
+  return (
+    <section className="bg-muted/30">
+      <div className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6 lg:px-8 lg:py-12">
+        <header className="space-y-3">
+          <div className="space-y-3">
+            <p className="text-sm font-medium text-muted-foreground">
+              {formatKoreanDate(new Date())}
+            </p>
+            <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
+              지원 대시보드
+            </h1>
+            <p className="max-w-2xl text-sm leading-6 font-medium text-muted-foreground">
+              <span className="block break-keep">
+                전체 파이프라인 규모, 최근 12개월 지원 추이,
+              </span>
+              <span className="block break-keep">
+                단계별 전환 흐름을 한 화면에서 확인합니다.
+              </span>
+            </p>
+          </div>
+        </header>
+      </div>
+    </section>
+  );
+}

--- a/app/(protected)/dashboard/loading.tsx
+++ b/app/(protected)/dashboard/loading.tsx
@@ -1,0 +1,18 @@
+import { DashboardHeader } from "./_components/dashboard-view/DashboardHeader";
+import {
+  ChartsSkeleton,
+  StatCardsSkeleton,
+} from "./_components/dashboard-view/DashboardSkeleton";
+
+export default function DashboardLoading() {
+  return (
+    <main className="min-h-screen bg-background pb-20">
+      <DashboardHeader />
+
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 py-10 sm:px-6 lg:gap-20 lg:px-8 lg:py-12">
+        <StatCardsSkeleton />
+        <ChartsSkeleton />
+      </div>
+    </main>
+  );
+}

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1,18 +1,16 @@
-import { getDashboardData } from "@/lib/actions";
+import { Suspense } from "react";
+
+import { getChartData, getStatCounts } from "@/lib/actions";
 import { formatKoreanDate } from "@/lib/utils";
 
 import { DashboardCharts } from "./_components/dashboard-view/DashboardCharts";
 import { DashboardOverview } from "./_components/dashboard-view/DashboardOverview";
+import {
+  ChartsSkeleton,
+  StatCardsSkeleton,
+} from "./_components/dashboard-view/DashboardSkeleton";
 
-export default async function DashboardPage() {
-  const dashboardResult = await getDashboardData();
-
-  if (!dashboardResult.ok) {
-    throw new Error(dashboardResult.reason);
-  }
-
-  const { funnel, monthly, stats } = dashboardResult.data;
-
+export default function DashboardPage() {
   return (
     <main className="min-h-screen bg-background pb-20">
       <section className="bg-muted/30">
@@ -39,9 +37,38 @@ export default async function DashboardPage() {
       </section>
 
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 py-10 sm:px-6 lg:gap-20 lg:px-8 lg:py-12">
-        <DashboardOverview stats={stats} />
-        <DashboardCharts funnel={funnel} monthly={monthly} />
+        <Suspense fallback={<StatCardsSkeleton />}>
+          <DashboardOverviewSection />
+        </Suspense>
+        <Suspense fallback={<ChartsSkeleton />}>
+          <DashboardChartsSection />
+        </Suspense>
       </div>
     </main>
   );
+}
+
+async function DashboardChartsSection() {
+  const result = await getChartData();
+
+  if (!result.ok) {
+    throw new Error(result.reason);
+  }
+
+  return (
+    <DashboardCharts
+      funnel={result.data.funnel}
+      monthly={result.data.monthly}
+    />
+  );
+}
+
+async function DashboardOverviewSection() {
+  const result = await getStatCounts();
+
+  if (!result.ok) {
+    throw new Error(result.reason);
+  }
+
+  return <DashboardOverview stats={result.data} />;
 }

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1,9 +1,9 @@
 import { Suspense } from "react";
 
 import { getChartData, getStatCounts } from "@/lib/actions";
-import { formatKoreanDate } from "@/lib/utils";
 
 import { DashboardCharts } from "./_components/dashboard-view/DashboardCharts";
+import { DashboardHeader } from "./_components/dashboard-view/DashboardHeader";
 import { DashboardOverview } from "./_components/dashboard-view/DashboardOverview";
 import {
   ChartsSkeleton,
@@ -13,28 +13,7 @@ import {
 export default function DashboardPage() {
   return (
     <main className="min-h-screen bg-background pb-20">
-      <section className="bg-muted/30">
-        <div className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6 lg:px-8 lg:py-12">
-          <header className="space-y-3">
-            <div className="space-y-3">
-              <p className="text-sm font-medium text-muted-foreground">
-                {formatKoreanDate(new Date())}
-              </p>
-              <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
-                지원 대시보드
-              </h1>
-              <p className="max-w-2xl text-sm leading-6 font-medium text-muted-foreground">
-                <span className="block break-keep">
-                  전체 파이프라인 규모, 최근 12개월 지원 추이,
-                </span>
-                <span className="block break-keep">
-                  단계별 전환 흐름을 한 화면에서 확인합니다.
-                </span>
-              </p>
-            </div>
-          </header>
-        </div>
-      </section>
+      <DashboardHeader />
 
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 py-10 sm:px-6 lg:gap-20 lg:px-8 lg:py-12">
         <Suspense fallback={<StatCardsSkeleton />}>

--- a/lib/actions/__tests__/_verifyApplicationOwnership.test.ts
+++ b/lib/actions/__tests__/_verifyApplicationOwnership.test.ts
@@ -1,12 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AUTH_ERROR_CODE } from "@/lib/actions/_queryError";
-import { createClient } from "@/lib/supabase/server";
+import { createClientWithToken } from "@/lib/supabase/server";
 
+import { getAuthContext } from "../_authContext";
 import { verifyApplicationOwnership } from "../_verifyApplicationOwnership";
 
 vi.mock("@/lib/supabase/server", () => ({
-  createClient: vi.fn(),
+  createClientWithToken: vi.fn(),
+}));
+
+vi.mock("../_authContext", () => ({
+  getAuthContext: vi.fn(),
 }));
 
 const mockMaybeSingle = vi.fn();
@@ -14,21 +19,21 @@ const mockEqUserId = vi.fn(() => ({ maybeSingle: mockMaybeSingle }));
 const mockEqId = vi.fn(() => ({ eq: mockEqUserId }));
 const mockSelect = vi.fn(() => ({ eq: mockEqId }));
 const mockFrom = vi.fn(() => ({ select: mockSelect }));
-const mockGetClaims = vi.fn();
 const mockSupabase = {
-  auth: { getClaims: mockGetClaims },
   from: mockFrom,
 };
 
+const ACCESS_TOKEN = "access-token";
 const APPLICATION_ID = "550e8400-e29b-41d4-a716-446655440000";
 const USER_ID = "user-1";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(createClient).mockResolvedValue(mockSupabase as never);
-  mockGetClaims.mockResolvedValue({
-    data: { claims: { sub: USER_ID } },
-    error: null,
+  vi.mocked(createClientWithToken).mockReturnValue(mockSupabase as never);
+  vi.mocked(getAuthContext).mockResolvedValue({
+    accessToken: ACCESS_TOKEN,
+    ok: true,
+    userId: USER_ID,
   });
   mockMaybeSingle.mockResolvedValue({
     data: { id: APPLICATION_ID },
@@ -38,21 +43,10 @@ beforeEach(() => {
 
 describe("verifyApplicationOwnership", () => {
   describe("인증 실패", () => {
-    it("auth.getClaims가 에러를 반환하면 AUTH_REQUIRED를 반환한다", async () => {
-      mockGetClaims.mockResolvedValue({
-        data: { claims: null },
-        error: { message: "JWT expired" },
-      });
-
-      const result = await verifyApplicationOwnership(APPLICATION_ID);
-
-      expect(result).toMatchObject({ code: "AUTH_REQUIRED", ok: false });
-    });
-
-    it("claims.sub가 없으면 AUTH_REQUIRED를 반환한다", async () => {
-      mockGetClaims.mockResolvedValue({
-        data: { claims: {} },
-        error: null,
+    it("인증 컨텍스트가 실패하면 AUTH_REQUIRED를 반환한다", async () => {
+      vi.mocked(getAuthContext).mockResolvedValue({
+        ok: false,
+        reason: "로그인이 필요합니다.",
       });
 
       const result = await verifyApplicationOwnership(APPLICATION_ID);
@@ -61,13 +55,14 @@ describe("verifyApplicationOwnership", () => {
     });
 
     it("인증 실패 시 from을 호출하지 않는다", async () => {
-      mockGetClaims.mockResolvedValue({
-        data: { claims: {} },
-        error: null,
+      vi.mocked(getAuthContext).mockResolvedValue({
+        ok: false,
+        reason: "로그인이 필요합니다.",
       });
 
       await verifyApplicationOwnership(APPLICATION_ID);
 
+      expect(createClientWithToken).not.toHaveBeenCalled();
       expect(mockFrom).not.toHaveBeenCalled();
     });
   });
@@ -140,6 +135,12 @@ describe("verifyApplicationOwnership", () => {
         supabase: mockSupabase,
         userId: USER_ID,
       });
+    });
+
+    it("access token으로 Supabase 클라이언트를 생성한다", async () => {
+      await verifyApplicationOwnership(APPLICATION_ID);
+
+      expect(createClientWithToken).toHaveBeenCalledWith(ACCESS_TOKEN);
     });
 
     it("select 쿼리 시 applicationId와 userId를 올바르게 전달한다", async () => {

--- a/lib/actions/__tests__/saveJobApplication.test.ts
+++ b/lib/actions/__tests__/saveJobApplication.test.ts
@@ -1,3 +1,4 @@
+import { updateTag } from "next/cache";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { SaveJobApplicationInput } from "@/lib/types/jobApplication";
@@ -14,6 +15,10 @@ vi.mock("@/lib/analytics/server", () => ({
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  updateTag: vi.fn(),
 }));
 
 const mockRpc = vi.fn();
@@ -214,6 +219,7 @@ describe("saveJobApplication", () => {
         "user-1",
         "application_add_saved",
       );
+      expect(updateTag).toHaveBeenCalledWith("user-1");
     });
 
     it("선택 필드를 포함한 전체 입력도 성공적으로 처리한다", async () => {

--- a/lib/actions/__tests__/updateApplicationStatus.test.ts
+++ b/lib/actions/__tests__/updateApplicationStatus.test.ts
@@ -1,3 +1,4 @@
+import { updateTag } from "next/cache";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { UpdateApplicationStatusInput } from "@/lib/types/application";
@@ -14,6 +15,10 @@ vi.mock("@/lib/analytics/server", () => ({
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  updateTag: vi.fn(),
 }));
 
 const mockMaybeSingle = vi.fn();
@@ -175,6 +180,7 @@ describe("updateApplicationStatus", () => {
         "application_status_changed",
         { from_status: "SAVED", to_status: "APPLIED" },
       );
+      expect(updateTag).toHaveBeenCalledWith("user-1");
     });
 
     it.each<UpdateApplicationStatusInput["status"]>([

--- a/lib/actions/_auth.ts
+++ b/lib/actions/_auth.ts
@@ -2,6 +2,8 @@
 
 import type { createClient } from "@/lib/supabase/server";
 
+import { trackAuthenticatedUserActivity } from "@/lib/analytics/server";
+
 const AUTH_REQUIRED_REASON = "로그인이 필요합니다.";
 
 type AuthenticatedUserIdResult =
@@ -25,6 +27,8 @@ export async function getAuthenticatedUserId(
   if (error || typeof userId !== "string" || userId.length === 0) {
     return { ok: false, reason: AUTH_REQUIRED_REASON };
   }
+
+  trackAuthenticatedUserActivity(userId);
 
   return { ok: true, userId };
 }

--- a/lib/actions/_authContext.ts
+++ b/lib/actions/_authContext.ts
@@ -1,0 +1,30 @@
+import "server-only";
+import { cache } from "react";
+
+import { createClient } from "@/lib/supabase/server";
+
+import { getAuthenticatedUserId } from "./_auth";
+
+const AUTH_REQUIRED_REASON = "로그인이 필요합니다.";
+
+export type AuthContextResult =
+  | { accessToken: string; ok: true; userId: string }
+  | { ok: false; reason: string };
+
+export const getAuthContext = cache(async (): Promise<AuthContextResult> => {
+  const supabase = await createClient();
+  const authResult = await getAuthenticatedUserId(supabase);
+
+  if (!authResult.ok) {
+    return { ok: false, reason: authResult.reason };
+  }
+
+  const { data: sessionData } = await supabase.auth.getSession();
+  const accessToken = sessionData.session?.access_token;
+
+  if (!accessToken) {
+    return { ok: false, reason: AUTH_REQUIRED_REASON };
+  }
+
+  return { accessToken, ok: true, userId: authResult.userId };
+});

--- a/lib/actions/_cacheTags.ts
+++ b/lib/actions/_cacheTags.ts
@@ -1,0 +1,9 @@
+export const APPLICATIONS_CACHE_TAG = "applications";
+
+export function getApplicationsCacheTags(userId: string): [string, string] {
+  return [APPLICATIONS_CACHE_TAG, userId];
+}
+
+export function getApplicationsUserCacheTag(userId: string): string {
+  return userId;
+}

--- a/lib/actions/_verifyApplicationOwnership.ts
+++ b/lib/actions/_verifyApplicationOwnership.ts
@@ -1,7 +1,9 @@
-import { createClient } from "@/lib/supabase/server";
+import { createClientWithToken } from "@/lib/supabase/server";
 
-import { getAuthenticatedUserId } from "./_auth";
+import { getAuthContext } from "./_authContext";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
+
+type ServerSupabaseClient = ReturnType<typeof createClientWithToken>;
 
 type VerifyResult =
   | {
@@ -11,7 +13,7 @@ type VerifyResult =
     }
   | {
       ok: true;
-      supabase: Awaited<ReturnType<typeof createClient>>;
+      supabase: ServerSupabaseClient;
       userId: string;
     };
 
@@ -22,8 +24,7 @@ type VerifyResult =
 export async function verifyApplicationOwnership(
   applicationId: string,
 ): Promise<VerifyResult> {
-  const supabase = await createClient();
-  const authResult = await getAuthenticatedUserId(supabase);
+  const authResult = await getAuthContext();
 
   if (!authResult.ok) {
     return {
@@ -32,6 +33,8 @@ export async function verifyApplicationOwnership(
       reason: authResult.reason,
     };
   }
+
+  const supabase = createClientWithToken(authResult.accessToken);
 
   const { data: applicationData, error: applicationError } = await supabase
     .from("applications")

--- a/lib/actions/deleteApplication.ts
+++ b/lib/actions/deleteApplication.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { updateTag } from "next/cache";
 import { z } from "zod";
 
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
@@ -10,6 +11,7 @@ import {
   type DeleteApplicationResult,
 } from "@/lib/types/application";
 
+import { getApplicationsUserCacheTag } from "./_cacheTags";
 import { normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 import { verifyApplicationOwnership } from "./_verifyApplicationOwnership";
@@ -54,6 +56,7 @@ export async function deleteApplication(
   }
 
   trackServerEvent(userId, ANALYTICS_EVENTS.APPLICATION_DELETED);
+  updateTag(getApplicationsUserCacheTag(userId));
 
   return { ok: true };
 }

--- a/lib/actions/getApplicationDetail.ts
+++ b/lib/actions/getApplicationDetail.ts
@@ -1,13 +1,13 @@
 "use server";
 
-import { createClient } from "@/lib/supabase/server";
+import { createClientWithToken } from "@/lib/supabase/server";
 import {
   applicationDetailSchema,
   applicationIdSchema,
   type GetApplicationDetailResult,
 } from "@/lib/types/application";
 
-import { getAuthenticatedUserId } from "./_auth";
+import { getAuthContext } from "./_authContext";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 
@@ -32,8 +32,7 @@ export async function getApplicationDetail(
     };
   }
 
-  const supabase = await createClient();
-  const authResult = await getAuthenticatedUserId(supabase);
+  const authResult = await getAuthContext();
 
   if (!authResult.ok) {
     return {
@@ -42,6 +41,8 @@ export async function getApplicationDetail(
       reason: authResult.reason,
     };
   }
+
+  const supabase = createClientWithToken(authResult.accessToken);
 
   const { data, error } = await supabase
     .from("applications")

--- a/lib/actions/getApplications.ts
+++ b/lib/actions/getApplications.ts
@@ -5,8 +5,8 @@ import type {
   GetApplicationsResult,
 } from "@/lib/types/application";
 
-import { createClient } from "../supabase/server";
-import { getAuthenticatedUserId } from "./_auth";
+import { createClientWithToken } from "../supabase/server";
+import { getAuthContext } from "./_authContext";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 
@@ -25,8 +25,7 @@ export async function getApplications({
   search?: string;
   sort?: "applied_at_asc" | "applied_at_desc";
 }): Promise<GetApplicationsResult> {
-  const supabase = await createClient();
-  const authResult = await getAuthenticatedUserId(supabase);
+  const authResult = await getAuthContext();
 
   if (!authResult.ok) {
     return {
@@ -35,6 +34,8 @@ export async function getApplications({
       reason: authResult.reason,
     };
   }
+
+  const supabase = createClientWithToken(authResult.accessToken);
 
   let query = supabase
     .from("applications")

--- a/lib/actions/getApplications.ts
+++ b/lib/actions/getApplications.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { unstable_cache } from "next/cache";
+
 import type {
   ApplicationListItem,
   GetApplicationsResult,
@@ -7,24 +9,27 @@ import type {
 
 import { createClientWithToken } from "../supabase/server";
 import { getAuthContext } from "./_authContext";
+import { getApplicationsCacheTags } from "./_cacheTags";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 
-export async function getApplications({
-  limit,
-  offset,
-  periodEnd,
-  periodStart,
-  search,
-  sort = "applied_at_desc",
-}: {
+type ApplicationsPage = {
+  hasMore: boolean;
+  items: ApplicationListItem[];
+};
+
+type ApplicationsQueryParams = {
   limit: number;
   offset: number;
   periodEnd?: string;
   periodStart?: string;
   search?: string;
   sort?: "applied_at_asc" | "applied_at_desc";
-}): Promise<GetApplicationsResult> {
+};
+
+export async function getApplications(
+  params: ApplicationsQueryParams,
+): Promise<GetApplicationsResult> {
   const authResult = await getAuthContext();
 
   if (!authResult.ok) {
@@ -35,53 +40,76 @@ export async function getApplications({
     };
   }
 
-  const supabase = createClientWithToken(authResult.accessToken);
+  const { accessToken, userId } = authResult;
 
-  let query = supabase
-    .from("applications")
-    .select("id, applied_at, company_name, platform, position_title, status")
-    .eq("user_id", authResult.userId)
-    .order("applied_at", { ascending: sort === "applied_at_asc" })
-    .range(offset, offset + limit);
+  // cookies()를 사용하지 않으므로 unstable_cache 안에서 안전하게 실행됩니다.
+  const getCachedApplications = unstable_cache(
+    async (
+      cachedParams: ApplicationsQueryParams,
+    ): Promise<ApplicationsPage> => {
+      const supabase = createClientWithToken(accessToken);
+      const {
+        limit,
+        offset,
+        periodEnd,
+        periodStart,
+        search,
+        sort = "applied_at_desc",
+      } = cachedParams;
 
-  if (search) {
-    query = query.ilike("company_name", `%${search}%`);
-  }
-  if (periodStart) {
-    query = query.gte("applied_at", periodStart);
-  }
-  if (periodEnd) {
-    query = query.lte("applied_at", periodEnd);
-  }
+      let query = supabase
+        .from("applications")
+        .select(
+          "id, applied_at, company_name, platform, position_title, status",
+        )
+        .eq("user_id", userId)
+        .order("applied_at", { ascending: sort === "applied_at_asc" })
+        .range(offset, offset + limit);
 
-  const { data, error } = await query;
+      if (search) {
+        query = query.ilike("company_name", `%${search}%`);
+      }
+      if (periodStart) {
+        query = query.gte("applied_at", periodStart);
+      }
+      if (periodEnd) {
+        query = query.lte("applied_at", periodEnd);
+      }
 
-  if (error) {
-    const code =
-      error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
-    const reason = normalizeQueryError(error);
-    if (code === "QUERY_ERROR") {
-      reportQueryError("getApplications", reason);
-    }
-    return { code, ok: false, reason };
-  }
+      const { data, error } = await query;
 
-  const items: ApplicationListItem[] = data
-    .map((row) => {
-      return {
+      if (error) {
+        const reason = normalizeQueryError(error);
+        if (error.code !== AUTH_ERROR_CODE) {
+          reportQueryError("getApplications", reason);
+        }
+        throw new Error(reason);
+      }
+
+      const items: ApplicationListItem[] = data.map((row) => ({
         appliedAt: row.applied_at,
         companyName: row.company_name,
         id: row.id,
         platform: row.platform,
         positionTitle: row.position_title,
         status: row.status,
-      };
-    })
-    .filter((item) => item !== null);
+      }));
 
-  // limit + 1개를 요청해 실제로 limit개만 반환하고, 초과분이 있으면 hasMore = true
-  const hasMore = items.length > limit;
-  const pageItems = hasMore ? items.slice(0, limit) : items;
+      // limit + 1개를 요청해 실제로 limit개만 반환하고, 초과분이 있으면 hasMore = true
+      const hasMore = items.length > limit;
+      const pageItems = hasMore ? items.slice(0, limit) : items;
 
-  return { data: { hasMore, items: pageItems }, ok: true };
+      return { hasMore, items: pageItems };
+    },
+    ["applications-page", userId],
+    { revalidate: 60, tags: getApplicationsCacheTags(userId) },
+  );
+
+  try {
+    const data = await getCachedApplications(params);
+    return { data, ok: true };
+  } catch (e) {
+    const reason = e instanceof Error ? e.message : "알 수 없는 오류";
+    return { code: "QUERY_ERROR", ok: false, reason };
+  }
 }

--- a/lib/actions/getApplicationsStats.ts
+++ b/lib/actions/getApplicationsStats.ts
@@ -7,8 +7,8 @@ import {
   DOCS_STATUSES,
 } from "@/lib/constants/application-status";
 
-import { createClient } from "../supabase/server";
-import { getAuthenticatedUserId } from "./_auth";
+import { createClientWithToken } from "../supabase/server";
+import { getAuthContext } from "./_authContext";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 
@@ -17,8 +17,7 @@ import { reportQueryError } from "./_reportQueryError";
  * 페이지네이션과 무관하게 전체 데이터 기준으로 집계합니다.
  */
 export async function getApplicationsStats(): Promise<GetApplicationsStatsResult> {
-  const supabase = await createClient();
-  const authResult = await getAuthenticatedUserId(supabase);
+  const authResult = await getAuthContext();
 
   if (!authResult.ok) {
     return {
@@ -28,6 +27,7 @@ export async function getApplicationsStats(): Promise<GetApplicationsStatsResult
     };
   }
 
+  const supabase = createClientWithToken(authResult.accessToken);
   const userId = authResult.userId;
 
   const { data, error } = await supabase

--- a/lib/actions/getChartData.ts
+++ b/lib/actions/getChartData.ts
@@ -13,14 +13,10 @@ import {
   INTERVIEW_STATUSES,
 } from "@/lib/constants/application-status";
 
-import { createClient, createClientWithToken } from "../supabase/server";
-import { getAuthenticatedUserId } from "./_auth";
+import { createClientWithToken } from "../supabase/server";
+import { getAuthContext } from "./_authContext";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
-
-const ERROR_MESSAGES = {
-  AUTH_REQUIRED: "로그인이 필요합니다.",
-} as const;
 
 function getMonthCutoff(): string {
   const d = new Date();
@@ -111,8 +107,7 @@ const getCachedChartData = unstable_cache(
 );
 
 export async function getChartData(): Promise<GetChartDataResult> {
-  const supabase = await createClient();
-  const authResult = await getAuthenticatedUserId(supabase);
+  const authResult = await getAuthContext();
 
   if (!authResult.ok) {
     return {
@@ -122,19 +117,11 @@ export async function getChartData(): Promise<GetChartDataResult> {
     };
   }
 
-  const { data: sessionData } = await supabase.auth.getSession();
-  const accessToken = sessionData.session?.access_token;
-
-  if (!accessToken) {
-    return {
-      code: "AUTH_REQUIRED",
-      ok: false,
-      reason: ERROR_MESSAGES.AUTH_REQUIRED,
-    };
-  }
-
   try {
-    const data = await getCachedChartData(authResult.userId, accessToken);
+    const data = await getCachedChartData(
+      authResult.userId,
+      authResult.accessToken,
+    );
     return { data, ok: true };
   } catch (e) {
     const reason = e instanceof Error ? e.message : "알 수 없는 오류";

--- a/lib/actions/getChartData.ts
+++ b/lib/actions/getChartData.ts
@@ -15,96 +15,9 @@ import {
 
 import { createClientWithToken } from "../supabase/server";
 import { getAuthContext } from "./_authContext";
+import { getApplicationsCacheTags } from "./_cacheTags";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
-
-function getMonthCutoff(): string {
-  const d = new Date();
-  d.setFullYear(d.getFullYear() - 1);
-  return d.toISOString().slice(0, 10);
-}
-
-// cookies()를 사용하지 않으므로 unstable_cache 안에서 안전하게 실행됩니다.
-const getCachedChartData = unstable_cache(
-  async (userId: string, accessToken: string): Promise<ChartData> => {
-    const supabase = createClientWithToken(accessToken);
-
-    const [
-      appliedRes,
-      docsPassedRes,
-      interviewingOrOfferedRes,
-      offeredRes,
-      monthlyRes,
-    ] = await Promise.all([
-      supabase
-        .from("applications")
-        .select("*", { count: "exact", head: true })
-        .eq("user_id", userId)
-        .neq("status", "SAVED"),
-      supabase
-        .from("applications")
-        .select("*", { count: "exact", head: true })
-        .eq("user_id", userId)
-        .in("status", DOCS_PASSED_STATUSES),
-      supabase
-        .from("applications")
-        .select("*", { count: "exact", head: true })
-        .eq("user_id", userId)
-        .in("status", INTERVIEW_STATUSES),
-      supabase
-        .from("applications")
-        .select("*", { count: "exact", head: true })
-        .eq("user_id", userId)
-        .eq("status", "OFFERED"),
-      supabase
-        .from("applications")
-        .select("applied_at")
-        .eq("user_id", userId)
-        .not("applied_at", "is", null)
-        .gte("applied_at", getMonthCutoff()),
-    ]);
-
-    const firstError =
-      appliedRes.error ??
-      docsPassedRes.error ??
-      interviewingOrOfferedRes.error ??
-      offeredRes.error ??
-      monthlyRes.error;
-
-    if (firstError) {
-      const code =
-        firstError.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
-      const reason = normalizeQueryError(firstError);
-      if (code === "QUERY_ERROR") {
-        reportQueryError("getChartData", reason);
-      }
-      throw new Error(reason);
-    }
-
-    const monthlyMap = new Map<string, number>();
-    for (const row of monthlyRes.data ?? []) {
-      if (row.applied_at) {
-        const month = (row.applied_at as string).slice(0, 7);
-        monthlyMap.set(month, (monthlyMap.get(month) ?? 0) + 1);
-      }
-    }
-
-    const monthly: MonthlyCount[] = Array.from(monthlyMap.entries())
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([month, count]) => ({ count, month }));
-
-    const funnel = [
-      { count: appliedRes.count ?? 0, label: "지원" },
-      { count: docsPassedRes.count ?? 0, label: "서류 통과" },
-      { count: interviewingOrOfferedRes.count ?? 0, label: "면접" },
-      { count: offeredRes.count ?? 0, label: "합격" },
-    ];
-
-    return { funnel, monthly };
-  },
-  ["chart-data"],
-  { revalidate: 60 },
-);
 
 export async function getChartData(): Promise<GetChartDataResult> {
   const authResult = await getAuthContext();
@@ -117,14 +30,101 @@ export async function getChartData(): Promise<GetChartDataResult> {
     };
   }
 
+  const { accessToken, userId } = authResult;
+
+  // cookies()를 사용하지 않으므로 unstable_cache 안에서 안전하게 실행됩니다.
+  const getCachedChartData = unstable_cache(
+    async (): Promise<ChartData> => {
+      const supabase = createClientWithToken(accessToken);
+
+      const [
+        appliedRes,
+        docsPassedRes,
+        interviewingOrOfferedRes,
+        offeredRes,
+        monthlyRes,
+      ] = await Promise.all([
+        supabase
+          .from("applications")
+          .select("*", { count: "exact", head: true })
+          .eq("user_id", userId)
+          .neq("status", "SAVED"),
+        supabase
+          .from("applications")
+          .select("*", { count: "exact", head: true })
+          .eq("user_id", userId)
+          .in("status", DOCS_PASSED_STATUSES),
+        supabase
+          .from("applications")
+          .select("*", { count: "exact", head: true })
+          .eq("user_id", userId)
+          .in("status", INTERVIEW_STATUSES),
+        supabase
+          .from("applications")
+          .select("*", { count: "exact", head: true })
+          .eq("user_id", userId)
+          .eq("status", "OFFERED"),
+        supabase
+          .from("applications")
+          .select("applied_at")
+          .eq("user_id", userId)
+          .not("applied_at", "is", null)
+          .gte("applied_at", getMonthCutoff()),
+      ]);
+
+      const firstError =
+        appliedRes.error ??
+        docsPassedRes.error ??
+        interviewingOrOfferedRes.error ??
+        offeredRes.error ??
+        monthlyRes.error;
+
+      if (firstError) {
+        const code =
+          firstError.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
+        const reason = normalizeQueryError(firstError);
+        if (code === "QUERY_ERROR") {
+          reportQueryError("getChartData", reason);
+        }
+        throw new Error(reason);
+      }
+
+      const monthlyMap = new Map<string, number>();
+      for (const row of monthlyRes.data ?? []) {
+        if (row.applied_at) {
+          const month = (row.applied_at as string).slice(0, 7);
+          monthlyMap.set(month, (monthlyMap.get(month) ?? 0) + 1);
+        }
+      }
+
+      const monthly: MonthlyCount[] = Array.from(monthlyMap.entries())
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([month, count]) => ({ count, month }));
+
+      const funnel = [
+        { count: appliedRes.count ?? 0, label: "지원" },
+        { count: docsPassedRes.count ?? 0, label: "서류 통과" },
+        { count: interviewingOrOfferedRes.count ?? 0, label: "면접" },
+        { count: offeredRes.count ?? 0, label: "합격" },
+      ];
+
+      return { funnel, monthly };
+    },
+    ["chart-data", userId],
+    { revalidate: 60, tags: getApplicationsCacheTags(userId) },
+  );
+
   try {
-    const data = await getCachedChartData(
-      authResult.userId,
-      authResult.accessToken,
-    );
+    const data = await getCachedChartData();
     return { data, ok: true };
   } catch (e) {
     const reason = e instanceof Error ? e.message : "알 수 없는 오류";
     return { code: "QUERY_ERROR", ok: false, reason };
   }
+}
+
+function getMonthCutoff(): string {
+  const d = new Date();
+  d.setFullYear(d.getFullYear() - 1);
+  return d.toISOString().slice(0, 10);
 }

--- a/lib/actions/getDashboardData.ts
+++ b/lib/actions/getDashboardData.ts
@@ -15,14 +15,10 @@ import {
   DOCS_STATUSES,
 } from "@/lib/constants/application-status";
 
-import { createClient, createClientWithToken } from "../supabase/server";
-import { getAuthenticatedUserId } from "./_auth";
+import { createClientWithToken } from "../supabase/server";
+import { getAuthContext } from "./_authContext";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
-
-const ERROR_MESSAGES = {
-  AUTH_REQUIRED: "로그인이 필요합니다.",
-} as const;
 
 type DashboardApplicationRow = {
   applied_at: null | string;
@@ -58,8 +54,7 @@ const getCachedDashboardData = unstable_cache(
 );
 
 export async function getDashboardData(): Promise<GetDashboardDataResult> {
-  const supabase = await createClient();
-  const authResult = await getAuthenticatedUserId(supabase);
+  const authResult = await getAuthContext();
 
   if (!authResult.ok) {
     return {
@@ -69,19 +64,11 @@ export async function getDashboardData(): Promise<GetDashboardDataResult> {
     };
   }
 
-  const { data: sessionData } = await supabase.auth.getSession();
-  const accessToken = sessionData.session?.access_token;
-
-  if (!accessToken) {
-    return {
-      code: "AUTH_REQUIRED",
-      ok: false,
-      reason: ERROR_MESSAGES.AUTH_REQUIRED,
-    };
-  }
-
   try {
-    const data = await getCachedDashboardData(authResult.userId, accessToken);
+    const data = await getCachedDashboardData(
+      authResult.userId,
+      authResult.accessToken,
+    );
 
     return { data, ok: true };
   } catch (e) {

--- a/lib/actions/getStatCounts.ts
+++ b/lib/actions/getStatCounts.ts
@@ -11,75 +11,9 @@ import {
 
 import { createClientWithToken } from "../supabase/server";
 import { getAuthContext } from "./_authContext";
+import { getApplicationsCacheTags } from "./_cacheTags";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
-
-// cookies()를 사용하지 않으므로 unstable_cache 안에서 안전하게 실행됩니다.
-const getCachedStatCounts = unstable_cache(
-  async (userId: string, accessToken: string): Promise<StatCounts> => {
-    const supabase = createClientWithToken(accessToken);
-
-    const { data, error } = await supabase
-      .from("applications")
-      .select("status")
-      .eq("user_id", userId);
-
-    if (error) {
-      const code =
-        error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
-      const reason = normalizeQueryError(error);
-      if (code === "QUERY_ERROR") {
-        reportQueryError("getStatCounts", reason);
-      }
-      throw new Error(reason);
-    }
-
-    let applied = 0;
-    let docs = 0;
-    let docsPassed = 0;
-    let interviewing = 0;
-    let offered = 0;
-    let saved = 0;
-
-    for (const row of data ?? []) {
-      const { status } = row;
-
-      if (status === "SAVED") {
-        saved++;
-      } else {
-        applied++;
-      }
-
-      if ((DOCS_STATUSES as readonly string[]).includes(status)) {
-        docs++;
-      }
-
-      if ((DOCS_PASSED_STATUSES as readonly string[]).includes(status)) {
-        docsPassed++;
-      }
-
-      if (status === "INTERVIEWING") {
-        interviewing++;
-      }
-
-      if (status === "OFFERED") {
-        offered++;
-      }
-    }
-
-    return {
-      applied,
-      docs,
-      docsPassed,
-      interviewing,
-      offered,
-      saved,
-      total: (data ?? []).length,
-    };
-  },
-  ["stat-counts"],
-  { revalidate: 60 },
-);
 
 export async function getStatCounts(): Promise<GetStatCountsResult> {
   const authResult = await getAuthContext();
@@ -92,11 +26,77 @@ export async function getStatCounts(): Promise<GetStatCountsResult> {
     };
   }
 
+  const { accessToken, userId } = authResult;
+
+  // cookies()를 사용하지 않으므로 unstable_cache 안에서 안전하게 실행됩니다.
+  const getCachedStatCounts = unstable_cache(
+    async (): Promise<StatCounts> => {
+      const supabase = createClientWithToken(accessToken);
+
+      const { data, error } = await supabase
+        .from("applications")
+        .select("status")
+        .eq("user_id", userId);
+
+      if (error) {
+        const code =
+          error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
+        const reason = normalizeQueryError(error);
+        if (code === "QUERY_ERROR") {
+          reportQueryError("getStatCounts", reason);
+        }
+        throw new Error(reason);
+      }
+
+      let applied = 0;
+      let docs = 0;
+      let docsPassed = 0;
+      let interviewing = 0;
+      let offered = 0;
+      let saved = 0;
+
+      for (const row of data ?? []) {
+        const { status } = row;
+
+        if (status === "SAVED") {
+          saved++;
+        } else {
+          applied++;
+        }
+
+        if ((DOCS_STATUSES as readonly string[]).includes(status)) {
+          docs++;
+        }
+
+        if ((DOCS_PASSED_STATUSES as readonly string[]).includes(status)) {
+          docsPassed++;
+        }
+
+        if (status === "INTERVIEWING") {
+          interviewing++;
+        }
+
+        if (status === "OFFERED") {
+          offered++;
+        }
+      }
+
+      return {
+        applied,
+        docs,
+        docsPassed,
+        interviewing,
+        offered,
+        saved,
+        total: (data ?? []).length,
+      };
+    },
+    ["stat-counts", userId],
+    { revalidate: 60, tags: getApplicationsCacheTags(userId) },
+  );
+
   try {
-    const data = await getCachedStatCounts(
-      authResult.userId,
-      authResult.accessToken,
-    );
+    const data = await getCachedStatCounts();
     return { data, ok: true };
   } catch (e) {
     const reason = e instanceof Error ? e.message : "알 수 없는 오류";

--- a/lib/actions/getStatCounts.ts
+++ b/lib/actions/getStatCounts.ts
@@ -9,14 +9,10 @@ import {
   DOCS_STATUSES,
 } from "@/lib/constants/application-status";
 
-import { createClient, createClientWithToken } from "../supabase/server";
-import { getAuthenticatedUserId } from "./_auth";
+import { createClientWithToken } from "../supabase/server";
+import { getAuthContext } from "./_authContext";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
-
-const ERROR_MESSAGES = {
-  AUTH_REQUIRED: "로그인이 필요합니다.",
-} as const;
 
 // cookies()를 사용하지 않으므로 unstable_cache 안에서 안전하게 실행됩니다.
 const getCachedStatCounts = unstable_cache(
@@ -86,8 +82,7 @@ const getCachedStatCounts = unstable_cache(
 );
 
 export async function getStatCounts(): Promise<GetStatCountsResult> {
-  const supabase = await createClient();
-  const authResult = await getAuthenticatedUserId(supabase);
+  const authResult = await getAuthContext();
 
   if (!authResult.ok) {
     return {
@@ -97,19 +92,11 @@ export async function getStatCounts(): Promise<GetStatCountsResult> {
     };
   }
 
-  const { data: sessionData } = await supabase.auth.getSession();
-  const accessToken = sessionData.session?.access_token;
-
-  if (!accessToken) {
-    return {
-      code: "AUTH_REQUIRED",
-      ok: false,
-      reason: ERROR_MESSAGES.AUTH_REQUIRED,
-    };
-  }
-
   try {
-    const data = await getCachedStatCounts(authResult.userId, accessToken);
+    const data = await getCachedStatCounts(
+      authResult.userId,
+      authResult.accessToken,
+    );
     return { data, ok: true };
   } catch (e) {
     const reason = e instanceof Error ? e.message : "알 수 없는 오류";

--- a/lib/actions/saveJobApplication.ts
+++ b/lib/actions/saveJobApplication.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { updateTag } from "next/cache";
 import { z } from "zod";
 
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
@@ -13,6 +14,7 @@ import {
   type SaveJobApplicationResult,
 } from "@/lib/types/jobApplication";
 
+import { getApplicationsUserCacheTag } from "./_cacheTags";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 
@@ -86,6 +88,7 @@ export async function saveJobApplication(
   }
 
   trackServerEvent(authData.user.id, ANALYTICS_EVENTS.APPLICATION_ADD_SAVED);
+  updateTag(getApplicationsUserCacheTag(authData.user.id));
 
   return {
     data: parsedPayload.data,

--- a/lib/actions/updateApplicationNotes.ts
+++ b/lib/actions/updateApplicationNotes.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { updateTag } from "next/cache";
 import { z } from "zod";
 
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
@@ -11,6 +12,7 @@ import {
   type UpdateApplicationNotesResult,
 } from "@/lib/types/application";
 
+import { getApplicationsUserCacheTag } from "./_cacheTags";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 
@@ -78,6 +80,7 @@ export async function updateApplicationNotes(
   }
 
   trackServerEvent(authData.user.id, ANALYTICS_EVENTS.MEMO_SAVED);
+  updateTag(getApplicationsUserCacheTag(authData.user.id));
 
   return {
     data: {

--- a/lib/actions/updateApplicationStatus.ts
+++ b/lib/actions/updateApplicationStatus.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { updateTag } from "next/cache";
 import { z } from "zod";
 
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
@@ -11,6 +12,7 @@ import {
   type UpdateApplicationStatusResult,
 } from "@/lib/types/application";
 
+import { getApplicationsUserCacheTag } from "./_cacheTags";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 
@@ -87,6 +89,7 @@ export async function updateApplicationStatus(
         }
       : { to_status: parsedInput.data.status },
   );
+  updateTag(getApplicationsUserCacheTag(authData.user.id));
 
   return {
     ok: true,

--- a/lib/actions/updateJobDescription.ts
+++ b/lib/actions/updateJobDescription.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { updateTag } from "next/cache";
 import { z } from "zod";
 
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
@@ -11,6 +12,7 @@ import {
   type UpdateJobDescriptionResult,
 } from "@/lib/types/application";
 
+import { getApplicationsUserCacheTag } from "./_cacheTags";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 
@@ -76,6 +78,7 @@ export async function updateJobDescription(
   }
 
   trackServerEvent(authData.user.id, ANALYTICS_EVENTS.JOB_DESCRIPTION_SAVED);
+  updateTag(getApplicationsUserCacheTag(authData.user.id));
 
   return {
     data: {

--- a/lib/analytics/events.ts
+++ b/lib/analytics/events.ts
@@ -22,6 +22,8 @@ export const ANALYTICS_EVENTS = {
   LOGIN_ATTEMPTED: "login_attempted",
   LOGOUT_CLICKED: "logout_clicked",
   MEMO_SAVED: "memo_saved",
+  // 사용자 활성
+  USER_ACTIVE: "user_active",
 } as const;
 
 export type AnalyticsEvent =

--- a/lib/analytics/server.ts
+++ b/lib/analytics/server.ts
@@ -3,12 +3,16 @@
 import { after } from "next/server";
 import { PostHog } from "posthog-node";
 
-import type { AnalyticsEvent } from "./events";
+import { ANALYTICS_EVENTS, type AnalyticsEvent } from "./events";
 
 const POSTHOG_TOKEN = process.env.POSTHOG_PROJECT_TOKEN;
 const POSTHOG_HOST = process.env.POSTHOG_HOST;
 
 let _client: null | PostHog = null;
+
+export function trackAuthenticatedUserActivity(userId: string): void {
+  trackServerEvent(userId, ANALYTICS_EVENTS.USER_ACTIVE);
+}
 
 export function trackServerEvent(
   distinctId: string,


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #366, #368, #370, #372, #374, #376, #378

## 📌 작업 내용

- 서버 기반 `user_active` 이벤트를 추가해 보호 영역 조회 시 MAU 집계 기준을 마련
- 대시보드 데이터 로딩 경계를 통계/차트 섹션과 헤더/로딩 상태로 분리해 초기 렌더 흐름과 스켈레톤 상태를 명확히 정리
- 서버 액션 인증 컨텍스트를 통합하고 access token 기반 Supabase 클라이언트 사용 흐름을 정리
- 지원 목록 로딩 화면과 applications 캐시 태그 무효화를 추가해 데이터 갱신 및 로딩 상태 표현을 개선
- ApplicationsPanel을 서버 셸과 클라이언트 파츠로 분리해 초기 조회 기준, URL 동기화, 무한 스크롤, 프리뷰 상태의 책임을 명확히 분리
