### PR TITLE
fix: 공고 추가 후 지원 목록 갱신 누락 수정(#383)

### DIFF
--- a/app/(protected)/applications/_components/components/ApplicationsPanelClient.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanelClient.tsx
@@ -90,6 +90,14 @@ export function ApplicationsPanelClient({
     setLocalPreviewApplicationId(previewApplicationId);
   }, [previewApplicationId]);
 
+  useEffect(() => {
+    paginationSequenceRef.current += 1;
+    setPages([initialPage]);
+    setPaginationError(null);
+    setIsFetchingNextPage(false);
+    setIsListScrolled(false);
+  }, [initialPage]);
+
   function updateRoute(nextState: RouteStateUpdate) {
     const nextPreviewApplicationId =
       nextState.previewApplicationId !== undefined


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #383

## 📌 작업 내용

- 지원 목록 클라이언트 상태가 서버에서 새로 받은 `initialPage`를 반영하도록 동기화
- 공고 저장 후 `router.refresh()`로 내려온 최신 목록이 기존 페이지네이션 상태에 가려지지 않도록 수정
- 페이지네이션 요청, 에러, 스크롤 상태를 함께 초기화해 갱신 후 목록 상태를 예측 가능하게 유지


