### PR TITLE
release: Lighthouse Preview 측정 전환 및 지원 목록 갱신 수정

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -5,22 +5,20 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
+  contents: read
+  deployments: read
+  issues: write
   pull-requests: write
 
 jobs:
   lighthouse:
     name: Lighthouse Audit
     runs-on: ubuntu-latest
-
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       NEXT_PUBLIC_SUPABASE_URL: https://${{ secrets.SUPABASE_PROJECT_REF }}.supabase.co
       NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_PUBLISHABLE_KEY }}
-      NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
-      NEXT_PUBLIC_ENABLE_BROWSER_SENTRY: ${{ secrets.NEXT_PUBLIC_ENABLE_BROWSER_SENTRY }}
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: ${{ secrets.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN }}
-      NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}
+      VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
     steps:
       - name: Checkout
@@ -55,8 +53,73 @@ jobs:
           CHROMIUM_PATH=$(node -e "const { chromium } = require('playwright'); console.log(chromium.executablePath())")
           echo "CHROMIUM_PATH=$CHROMIUM_PATH" >> $GITHUB_ENV
 
-      - name: Build
-        run: pnpm build
+      - name: Resolve Vercel Preview URL
+        id: preview-url
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pull = context.payload.pull_request;
+            const refs = [pull.head.sha, pull.head.ref].filter(Boolean);
+
+            const isPreviewDeployment = (deployment) =>
+              deployment.environment?.toLowerCase() === 'preview';
+
+            const getReadyPreviewUrl = async () => {
+              for (const ref of refs) {
+                const { data: deployments } = await github.rest.repos.listDeployments({
+                  owner,
+                  repo,
+                  ref,
+                  per_page: 30,
+                });
+
+                for (const deployment of deployments.filter(isPreviewDeployment)) {
+                  const { data: statuses } = await github.rest.repos.listDeploymentStatuses({
+                    owner,
+                    repo,
+                    deployment_id: deployment.id,
+                    per_page: 10,
+                  });
+
+                  const readyStatus = statuses.find((status) =>
+                    status.state === 'success' && status.target_url
+                  );
+
+                  if (readyStatus) {
+                    return readyStatus.target_url;
+                  }
+                }
+              }
+
+              return null;
+            };
+
+            for (let attempt = 1; attempt <= 60; attempt += 1) {
+              const previewUrl = await getReadyPreviewUrl();
+
+              if (previewUrl) {
+                core.info(`Resolved Vercel Preview URL: ${previewUrl}`);
+                core.exportVariable('LHCI_BASE_URL', previewUrl);
+                core.setOutput('url', previewUrl);
+                return;
+              }
+
+              core.info(`Waiting for Vercel Preview deployment (${attempt}/60)...`);
+              await sleep(10000);
+            }
+
+            throw new Error('Timed out waiting for a successful Vercel Preview deployment.');
+
+      - name: Validate Vercel protection bypass
+        if: contains(env.LHCI_BASE_URL, '.vercel.app')
+        run: |
+          if [ -z "$VERCEL_AUTOMATION_BYPASS_SECRET" ]; then
+            echo "::error::VERCEL_AUTOMATION_BYPASS_SECRET is required to measure protected Vercel Preview deployments."
+            exit 1
+          fi
 
       - name: Run Lighthouse CI
         run: pnpm exec lhci autorun
@@ -74,6 +137,7 @@ jobs:
             const nodePath = require('path');
 
             const lhciDir = nodePath.join(process.env.GITHUB_WORKSPACE, '.lighthouseci');
+            const baseUrl = process.env.LHCI_BASE_URL?.replace(/\/+$/, '');
 
             if (!fs.existsSync(lhciDir)) {
               core.warning(`${lhciDir} not found — Lighthouse CI may have failed before producing results.`);
@@ -91,7 +155,7 @@ jobs:
             const byUrl = {};
             for (const file of lhrFiles) {
               const lhr = JSON.parse(fs.readFileSync(nodePath.join(lhciDir, file), 'utf8'));
-              const url = lhr.finalUrl || lhr.requestedUrl;
+              const url = lhr.requestedUrl || lhr.finalUrl;
               if (!byUrl[url]) byUrl[url] = [];
               byUrl[url].push(lhr);
             }
@@ -108,26 +172,43 @@ jobs:
 
             const emoji = (v) => v >= 0.9 ? '🟢' : v >= 0.5 ? '🟡' : '🔴';
             const score = (v) => Math.round(v * 100);
-            const pagePath = (url) => url.replace('http://localhost:3000', '') || '/';
-            const pageCell = (url) => {
+            const pagePath = (url) => {
+              if (!baseUrl) return url;
+
+              try {
+                const base = new URL(baseUrl);
+                const current = new URL(url);
+
+                if (current.origin !== base.origin) return url;
+
+                return `${current.pathname}${current.search}` || '/';
+              } catch {
+                return url;
+              }
+            };
+            const pageCell = (url, reportUrl) => {
               const p = pagePath(url);
-              return links[url] ? `[\`${p}\`](${links[url]})` : `\`${p}\``;
+              return reportUrl ? `[\`${p}\`](${reportUrl})` : `\`${p}\``;
             };
             const metric = (audit) => audit ? `${emoji(audit.score)}${audit.displayValue}` : '-';
 
             const perfRows = representativeRuns.map(({ url, lhr }) => {
               const c = lhr.categories;
               const a = lhr.audits;
-              return `| ${pageCell(url)} | ${emoji(c.performance.score)}${score(c.performance.score)} | ${metric(a['first-contentful-paint'])} | ${metric(a['largest-contentful-paint'])} | ${metric(a['total-blocking-time'])} | ${metric(a['cumulative-layout-shift'])} | ${metric(a['speed-index'])} |`;
+              const reportUrl = links[url] ?? links[lhr.requestedUrl] ?? links[lhr.finalUrl];
+              return `| ${pageCell(url, reportUrl)} | ${emoji(c.performance.score)}${score(c.performance.score)} | ${metric(a['first-contentful-paint'])} | ${metric(a['largest-contentful-paint'])} | ${metric(a['total-blocking-time'])} | ${metric(a['cumulative-layout-shift'])} | ${metric(a['speed-index'])} |`;
             }).join('\n');
 
             const categoryRows = representativeRuns.map(({ url, lhr }) => {
               const c = lhr.categories;
-              return `| ${pageCell(url)} | ${emoji(c.accessibility.score)}${score(c.accessibility.score)} | ${emoji(c['best-practices'].score)}${score(c['best-practices'].score)} | ${emoji(c.seo.score)}${score(c.seo.score)} |`;
+              const reportUrl = links[url] ?? links[lhr.requestedUrl] ?? links[lhr.finalUrl];
+              return `| ${pageCell(url, reportUrl)} | ${emoji(c.accessibility.score)}${score(c.accessibility.score)} | ${emoji(c['best-practices'].score)}${score(c['best-practices'].score)} | ${emoji(c.seo.score)}${score(c.seo.score)} |`;
             }).join('\n');
 
             const body = [
               '## Lighthouse CI 결과',
+              '',
+              `측정 대상: ${baseUrl ? `[Vercel Preview](${baseUrl})` : 'Preview deployment'}`,
               '',
               '### Performance',
               '| 페이지 | Score | First Contentful Paint | Largest Contentful Paint | Total Blocking Time | Cumulative Layout Shift | Speed Index |',
@@ -154,29 +235,34 @@ jobs:
               '</details>',
             ].join('\n');
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const existing = comments.find(c =>
-              c.user.login === 'github-actions[bot]' &&
-              c.body.startsWith('## Lighthouse CI 결과')
-            );
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body,
               });
+
+              const existing = comments.find(c =>
+                c.user.login === 'github-actions[bot]' &&
+                c.body.startsWith('## Lighthouse CI 결과')
+              );
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body,
+                });
+              }
+            } catch (error) {
+              core.warning(`Unable to post Lighthouse PR comment: ${error.message}`);
+              await core.summary.addRaw(body).write();
             }

--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -1,3 +1,21 @@
+const DEFAULT_BASE_URL = "http://localhost:3000";
+
+const baseUrl = (process.env.LHCI_BASE_URL ?? DEFAULT_BASE_URL).replace(
+  /\/+$/,
+  "",
+);
+const baseHostname = new URL(baseUrl).hostname;
+const isLocalMeasure =
+  baseHostname === "localhost" || baseHostname === "127.0.0.1";
+const vercelAutomationBypassSecret =
+  process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+const extraHeaders = vercelAutomationBypassSecret
+  ? {
+      "x-vercel-protection-bypass": vercelAutomationBypassSecret,
+      "x-vercel-set-bypass-cookie": "true",
+    }
+  : undefined;
+
 /** @type {import('@lhci/cli').LighthouseRcConfig} */
 module.exports = {
   ci: {
@@ -19,13 +37,22 @@ module.exports = {
         args: ["--no-sandbox", "--disable-setuid-sandbox"],
       },
       puppeteerScript: "./lighthouse-auth.js",
-      startServerCommand: "pnpm start",
-      startServerReadyPattern: "Ready in",
+      settings: extraHeaders
+        ? {
+            extraHeaders,
+          }
+        : {},
+      ...(isLocalMeasure
+        ? {
+            startServerCommand: "pnpm start",
+            startServerReadyPattern: "Ready in",
+          }
+        : {}),
       url: [
-        "http://localhost:3000",
-        "http://localhost:3000/login",
-        "http://localhost:3000/dashboard",
-        "http://localhost:3000/applications",
+        baseUrl,
+        `${baseUrl}/login`,
+        `${baseUrl}/dashboard`,
+        `${baseUrl}/applications`,
       ],
     },
     upload: {

--- a/app/(protected)/applications/_components/components/ApplicationsPanelClient.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanelClient.tsx
@@ -90,6 +90,14 @@ export function ApplicationsPanelClient({
     setLocalPreviewApplicationId(previewApplicationId);
   }, [previewApplicationId]);
 
+  useEffect(() => {
+    paginationSequenceRef.current += 1;
+    setPages([initialPage]);
+    setPaginationError(null);
+    setIsFetchingNextPage(false);
+    setIsListScrolled(false);
+  }, [initialPage]);
+
   function updateRoute(nextState: RouteStateUpdate) {
     const nextPreviewApplicationId =
       nextState.previewApplicationId !== undefined

--- a/lighthouse-auth.js
+++ b/lighthouse-auth.js
@@ -7,18 +7,29 @@
  * @param {{ url: string }} context
  */
 module.exports = async (browser, context) => {
-  // 랜딩 페이지는 비인증 상태로 측정합니다.
-  if (context.url === "http://localhost:3000") {
+  const targetUrl = new URL(context.url);
+  const publicPaths = new Set(["/", "/login"]);
+
+  // 공개 페이지는 비인증 상태로 측정합니다.
+  if (publicPaths.has(targetUrl.pathname)) {
     return;
   }
+
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const publishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+  const testEmail = process.env.LHCI_TEST_EMAIL;
+  const testPassword = process.env.LHCI_TEST_PASSWORD;
+
+  if (!supabaseUrl || !publishableKey || !testEmail || !testPassword) {
+    throw new Error("Lighthouse 인증에 필요한 환경변수가 누락되었습니다.");
+  }
+
   const projectRef = new URL(supabaseUrl).hostname.split(".")[0];
 
   const res = await fetch(`${supabaseUrl}/auth/v1/token?grant_type=password`, {
     body: JSON.stringify({
-      email: process.env.LHCI_TEST_EMAIL,
-      password: process.env.LHCI_TEST_PASSWORD,
+      email: testEmail,
+      password: testPassword,
     }),
     headers: {
       apikey: publishableKey,
@@ -40,11 +51,11 @@ module.exports = async (browser, context) => {
   const page = await browser.newPage();
 
   await page.setCookie({
-    domain: "localhost",
     httpOnly: true,
     name: `sb-${projectRef}-auth-token`,
     path: "/",
-    secure: false,
+    secure: targetUrl.protocol === "https:",
+    url: targetUrl.origin,
     value: JSON.stringify({
       access_token: session.access_token,
       expires_at: session.expires_at,


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #381, #383

## 📌 작업 내용

- Lighthouse CI 측정 대상을 로컬 앱 서버가 아닌 Vercel Preview 배포 URL로 전환해 실제 PR 미리보기 환경 기준으로 성능을 측정하도록 정리
- Lighthouse 워크플로우에서 Preview 배포 대기, URL 추출, 인증 준비 흐름을 명확히 분리해 CI 실행 기준을 안정화
- Lighthouse 인증 스크립트와 설정을 Preview 측정 흐름에 맞게 조정해 보호 페이지 측정 준비 과정을 보완
- 공고 추가 후 서버에서 내려온 지원 목록 데이터가 클라이언트 목록 상태에 반영되지 않던 문제를 수정해 새 공고가 목록에 즉시 표시되도록 정리