### PR TITLE
refactor: 전역 CSS 범위 축소(#386)

### DIFF
--- a/app/(protected)/applications/[applicationId]/_components/ApplicationDetailHero.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/ApplicationDetailHero.tsx
@@ -77,7 +77,7 @@ export function ApplicationDetailHero({
   ];
 
   return (
-    <section className="relative overflow-hidden rounded-[32px] border border-border/60 bg-background shadow-[0_36px_120px_-64px_rgba(23,23,23,0.45)] motion-safe:animate-fade-in">
+    <section className="relative overflow-hidden rounded-[32px] border border-border/60 bg-background shadow-[0_36px_120px_-64px_rgba(23,23,23,0.45)]">
       <div className="absolute inset-0" style={HERO_OVERLAY_STYLE} />
       <div className="relative grid gap-8 p-5 sm:p-8 lg:grid-cols-[minmax(0,1fr)_minmax(300px,360px)] lg:gap-10">
         <div className="space-y-8 motion-safe:animate-fade-up">

--- a/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.module.css
+++ b/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.module.css
@@ -1,0 +1,21 @@
+.mobileDatetimeLocalInput {
+  min-width: 0;
+}
+
+.mobileDatetimeLocalInput::-webkit-date-and-time-value {
+  min-width: 0;
+  text-align: left;
+}
+
+.mobileDatetimeLocalInput::-webkit-datetime-edit {
+  min-width: 0;
+  padding: 0;
+}
+
+.mobileDatetimeLocalInput::-webkit-datetime-edit-fields-wrapper {
+  min-width: 0;
+}
+
+.mobileDatetimeLocalInput::-webkit-calendar-picker-indicator {
+  margin: 0;
+}

--- a/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
@@ -19,6 +19,8 @@ import { INTERVIEW_TYPE_LABEL } from "@/lib/constants/interview-type";
 import { Constants } from "@/lib/types/supabase";
 import { cn, toDatetimeLocalValue } from "@/lib/utils";
 
+import styles from "./InterviewFormSheet.module.css";
+
 const INTERVIEW_TYPES = Constants.public.Enums.interview_type;
 const INPUT_CLASS = cn(
   "min-w-0 w-full rounded-md border border-input",
@@ -231,7 +233,10 @@ export function InterviewFormSheet(props: InterviewFormSheetProps) {
                   )}
                 >
                   <input
-                    className="mobile-datetime-local-input block w-full min-w-0 bg-transparent px-0 py-0 text-base text-foreground focus:outline-none disabled:cursor-not-allowed"
+                    className={cn(
+                      styles.mobileDatetimeLocalInput,
+                      "block w-full min-w-0 bg-transparent px-0 py-0 text-base text-foreground focus:outline-none disabled:cursor-not-allowed",
+                    )}
                     disabled={isSaving}
                     id="interview-scheduled-at"
                     onChange={(e) =>

--- a/app/globals.css
+++ b/app/globals.css
@@ -53,8 +53,6 @@
 
   /* Animations */
   --animate-fade-up: fade-up 0.5s ease-out both;
-  --animate-fade-in: fade-in 0.4s ease-out both;
-  --animate-slide-up: slide-up 0.5s ease-out both;
 }
 
 @layer base {
@@ -75,68 +73,13 @@
     --color-input: #31343c;
     --color-ring: #9db58d;
   }
-
-  input[type="datetime-local"].mobile-datetime-local-input {
-    min-width: 0;
-  }
-
-  input[type="datetime-local"].mobile-datetime-local-input::-webkit-date-and-time-value {
-    min-width: 0;
-    text-align: left;
-  }
-
-  input[type="datetime-local"].mobile-datetime-local-input::-webkit-datetime-edit {
-    min-width: 0;
-    padding: 0;
-  }
-
-  input[type="datetime-local"].mobile-datetime-local-input::-webkit-datetime-edit-fields-wrapper {
-    min-width: 0;
-  }
-
-  input[type="datetime-local"].mobile-datetime-local-input::-webkit-calendar-picker-indicator {
-    margin: 0;
-  }
-}
-
-@keyframes slide-up {
-  from {
-    transform: translateY(16px);
-  }
-  to {
-    transform: translateY(0);
-  }
 }
 
 @keyframes fade-up {
   from {
-    opacity: 0;
     transform: translateY(16px);
   }
   to {
-    opacity: 1;
     transform: translateY(0);
   }
-}
-
-@keyframes fade-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-.bg-dot-pattern {
-  background-image: radial-gradient(circle, #40513b18 1px, transparent 1px);
-  background-size: 24px 24px;
-}
-
-html[data-theme="dark"] .bg-dot-pattern {
-  background-image: radial-gradient(
-    circle,
-    rgb(157 181 141 / 0.14) 1px,
-    transparent 1px
-  );
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #386

## 📌 작업 내용

- 사용하지 않는 fade-in, slide-up 애니메이션과 dot pattern 전역 스타일을 제거
- 면접 일정 datetime-local 입력 스타일을 InterviewFormSheet CSS 모듈로 이동해 영향 범위를 컴포넌트로 제한
- 지원 상세 히어로의 fade-in 적용을 제거하고 fade-up 애니메이션에서 opacity 변경을 제외해 초기 렌더링 부담을 줄임

