### PR TITLE
refactor: 에러 상태 색상 토큰 정리(#388)

### DIFF
--- a/app/(protected)/_components/ApplicationStatusSelector.tsx
+++ b/app/(protected)/_components/ApplicationStatusSelector.tsx
@@ -125,7 +125,7 @@ export function ApplicationStatusSelector({
               <p className="text-sm text-muted-foreground">저장하는 중...</p>
             )}
             {!mutation.isPending && errorMessage && (
-              <p className="text-sm text-red-600">{errorMessage}</p>
+              <p className="text-sm text-destructive">{errorMessage}</p>
             )}
           </div>
         </div>

--- a/app/(protected)/applications/[applicationId]/_components/DeleteApplicationButton.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/DeleteApplicationButton.tsx
@@ -108,7 +108,10 @@ export function DeleteApplicationButton({
             </p>
 
             {errorMessage !== null && (
-              <p className="mb-4 text-sm font-medium text-red-600" role="alert">
+              <p
+                className="mb-4 text-sm font-medium text-destructive"
+                role="alert"
+              >
                 {errorMessage}
               </p>
             )}

--- a/app/(protected)/applications/[applicationId]/_components/DeleteInterviewButton.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/DeleteInterviewButton.tsx
@@ -94,7 +94,10 @@ export function DeleteInterviewButton({
             </p>
 
             {errorMessage !== null && (
-              <p className="mb-4 text-sm font-medium text-red-600" role="alert">
+              <p
+                className="mb-4 text-sm font-medium text-destructive"
+                role="alert"
+              >
                 {errorMessage}
               </p>
             )}

--- a/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
@@ -305,7 +305,10 @@ export function InterviewFormSheet(props: InterviewFormSheetProps) {
               </div>
 
               {errorMessage !== null && (
-                <p className="text-sm font-medium text-red-600" role="alert">
+                <p
+                  className="text-sm font-medium text-destructive"
+                  role="alert"
+                >
                   {errorMessage}
                 </p>
               )}

--- a/app/(protected)/applications/[applicationId]/_components/JobDescriptionEditor.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/JobDescriptionEditor.tsx
@@ -137,7 +137,7 @@ export function JobDescriptionEditor({
 
       <div aria-atomic="true" aria-live="polite" className="min-h-0">
         {isEditing && errorMessage && (
-          <p className="mb-2 text-sm font-medium text-red-600">
+          <p className="mb-2 text-sm font-medium text-destructive">
             {errorMessage}
           </p>
         )}

--- a/app/(protected)/applications/[applicationId]/_components/MemoEditor.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/MemoEditor.tsx
@@ -134,7 +134,7 @@ export function MemoEditor({
 
       <div aria-atomic="true" aria-live="polite" className="min-h-0">
         {isEditing && errorMessage && (
-          <p className="mb-2 text-sm font-medium text-red-600">
+          <p className="mb-2 text-sm font-medium text-destructive">
             {errorMessage}
           </p>
         )}

--- a/app/(protected)/applications/_components/components/ApplicationPreviewSheet.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationPreviewSheet.tsx
@@ -228,7 +228,7 @@ export function ApplicationPreviewSheet({
               {visiblePreviewState.status === "error" && (
                 <section
                   aria-live="polite"
-                  className="rounded-2xl border border-red-200 bg-red-50 px-4 py-4 text-red-700"
+                  className="rounded-2xl border border-destructive/20 bg-destructive/5 px-4 py-4 text-destructive"
                 >
                   <div className="flex items-start gap-3">
                     <AlertCircleIcon

--- a/app/(protected)/applications/_components/components/ApplicationsPanelClient.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanelClient.tsx
@@ -241,7 +241,7 @@ export function ApplicationsPanelClient({
           role="status"
         >
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex items-start gap-2 text-sm text-red-700">
+            <div className="flex items-start gap-2 text-sm text-destructive">
               <AlertCircleIcon
                 aria-hidden="true"
                 className="mt-0.5 size-4 shrink-0"

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,8 @@
-@import "tailwindcss";
+@import "tailwindcss/theme";
+@import "tailwindcss/preflight";
+@import "tailwindcss/utilities";
+
+@source not "../**/*.stories.tsx";
 
 @layer base {
   html {


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #388

## 📌 작업 내용

- 지원 현황 및 지원서 상세 화면의 에러 메시지 색상을 `text-destructive` 계열 토큰으로 통일
- 미리보기/목록 에러 상태의 border, background, text 색상을 semantic destructive 토큰 기반으로 변경
- Tailwind import를 theme/preflight/utilities로 분리하고 Storybook 파일을 source scanning 대상에서 제외해 CSS 생성 범위를 명확히 함


