### PR TITLE
release: 전역 CSS 범위 축소와 클라이언트 관측 번들 경량화

### DIFF
--- a/app/(protected)/_components/ApplicationStatusSelector.tsx
+++ b/app/(protected)/_components/ApplicationStatusSelector.tsx
@@ -125,7 +125,7 @@ export function ApplicationStatusSelector({
               <p className="text-sm text-muted-foreground">저장하는 중...</p>
             )}
             {!mutation.isPending && errorMessage && (
-              <p className="text-sm text-red-600">{errorMessage}</p>
+              <p className="text-sm text-destructive">{errorMessage}</p>
             )}
           </div>
         </div>

--- a/app/(protected)/applications/[applicationId]/_components/ApplicationDetailHero.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/ApplicationDetailHero.tsx
@@ -77,7 +77,7 @@ export function ApplicationDetailHero({
   ];
 
   return (
-    <section className="relative overflow-hidden rounded-[32px] border border-border/60 bg-background shadow-[0_36px_120px_-64px_rgba(23,23,23,0.45)] motion-safe:animate-fade-in">
+    <section className="relative overflow-hidden rounded-[32px] border border-border/60 bg-background shadow-[0_36px_120px_-64px_rgba(23,23,23,0.45)]">
       <div className="absolute inset-0" style={HERO_OVERLAY_STYLE} />
       <div className="relative grid gap-8 p-5 sm:p-8 lg:grid-cols-[minmax(0,1fr)_minmax(300px,360px)] lg:gap-10">
         <div className="space-y-8 motion-safe:animate-fade-up">

--- a/app/(protected)/applications/[applicationId]/_components/DeleteApplicationButton.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/DeleteApplicationButton.tsx
@@ -108,7 +108,10 @@ export function DeleteApplicationButton({
             </p>
 
             {errorMessage !== null && (
-              <p className="mb-4 text-sm font-medium text-red-600" role="alert">
+              <p
+                className="mb-4 text-sm font-medium text-destructive"
+                role="alert"
+              >
                 {errorMessage}
               </p>
             )}

--- a/app/(protected)/applications/[applicationId]/_components/DeleteInterviewButton.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/DeleteInterviewButton.tsx
@@ -94,7 +94,10 @@ export function DeleteInterviewButton({
             </p>
 
             {errorMessage !== null && (
-              <p className="mb-4 text-sm font-medium text-red-600" role="alert">
+              <p
+                className="mb-4 text-sm font-medium text-destructive"
+                role="alert"
+              >
                 {errorMessage}
               </p>
             )}

--- a/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.module.css
+++ b/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.module.css
@@ -1,0 +1,21 @@
+.mobileDatetimeLocalInput {
+  min-width: 0;
+}
+
+.mobileDatetimeLocalInput::-webkit-date-and-time-value {
+  min-width: 0;
+  text-align: left;
+}
+
+.mobileDatetimeLocalInput::-webkit-datetime-edit {
+  min-width: 0;
+  padding: 0;
+}
+
+.mobileDatetimeLocalInput::-webkit-datetime-edit-fields-wrapper {
+  min-width: 0;
+}
+
+.mobileDatetimeLocalInput::-webkit-calendar-picker-indicator {
+  margin: 0;
+}

--- a/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
@@ -305,7 +305,10 @@ export function InterviewFormSheet(props: InterviewFormSheetProps) {
               </div>
 
               {errorMessage !== null && (
-                <p className="text-sm font-medium text-red-600" role="alert">
+                <p
+                  className="text-sm font-medium text-destructive"
+                  role="alert"
+                >
                   {errorMessage}
                 </p>
               )}

--- a/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/InterviewFormSheet.tsx
@@ -19,6 +19,8 @@ import { INTERVIEW_TYPE_LABEL } from "@/lib/constants/interview-type";
 import { Constants } from "@/lib/types/supabase";
 import { cn, toDatetimeLocalValue } from "@/lib/utils";
 
+import styles from "./InterviewFormSheet.module.css";
+
 const INTERVIEW_TYPES = Constants.public.Enums.interview_type;
 const INPUT_CLASS = cn(
   "min-w-0 w-full rounded-md border border-input",
@@ -231,7 +233,10 @@ export function InterviewFormSheet(props: InterviewFormSheetProps) {
                   )}
                 >
                   <input
-                    className="mobile-datetime-local-input block w-full min-w-0 bg-transparent px-0 py-0 text-base text-foreground focus:outline-none disabled:cursor-not-allowed"
+                    className={cn(
+                      styles.mobileDatetimeLocalInput,
+                      "block w-full min-w-0 bg-transparent px-0 py-0 text-base text-foreground focus:outline-none disabled:cursor-not-allowed",
+                    )}
                     disabled={isSaving}
                     id="interview-scheduled-at"
                     onChange={(e) =>

--- a/app/(protected)/applications/[applicationId]/_components/JobDescriptionEditor.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/JobDescriptionEditor.tsx
@@ -137,7 +137,7 @@ export function JobDescriptionEditor({
 
       <div aria-atomic="true" aria-live="polite" className="min-h-0">
         {isEditing && errorMessage && (
-          <p className="mb-2 text-sm font-medium text-red-600">
+          <p className="mb-2 text-sm font-medium text-destructive">
             {errorMessage}
           </p>
         )}

--- a/app/(protected)/applications/[applicationId]/_components/MemoEditor.tsx
+++ b/app/(protected)/applications/[applicationId]/_components/MemoEditor.tsx
@@ -134,7 +134,7 @@ export function MemoEditor({
 
       <div aria-atomic="true" aria-live="polite" className="min-h-0">
         {isEditing && errorMessage && (
-          <p className="mb-2 text-sm font-medium text-red-600">
+          <p className="mb-2 text-sm font-medium text-destructive">
             {errorMessage}
           </p>
         )}

--- a/app/(protected)/applications/_components/components/ApplicationPreviewSheet.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationPreviewSheet.tsx
@@ -228,7 +228,7 @@ export function ApplicationPreviewSheet({
               {visiblePreviewState.status === "error" && (
                 <section
                   aria-live="polite"
-                  className="rounded-2xl border border-red-200 bg-red-50 px-4 py-4 text-red-700"
+                  className="rounded-2xl border border-destructive/20 bg-destructive/5 px-4 py-4 text-destructive"
                 >
                   <div className="flex items-start gap-3">
                     <AlertCircleIcon

--- a/app/(protected)/applications/_components/components/ApplicationsPanelClient.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanelClient.tsx
@@ -241,7 +241,7 @@ export function ApplicationsPanelClient({
           role="status"
         >
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex items-start gap-2 text-sm text-red-700">
+            <div className="flex items-start gap-2 text-sm text-destructive">
               <AlertCircleIcon
                 aria-hidden="true"
                 className="mt-0.5 size-4 shrink-0"

--- a/app/_components/ErrorPageFallback.tsx
+++ b/app/_components/ErrorPageFallback.tsx
@@ -2,10 +2,10 @@
 
 import type { Route } from "next";
 
-import * as Sentry from "@sentry/nextjs";
 import { useEffect, useRef } from "react";
 
 import { Button } from "@/components/ui/button/Button";
+import { captureClientException } from "@/lib/sentry/client";
 import { cn } from "@/lib/utils/cn";
 
 type ErrorPageFallbackProps = {
@@ -41,7 +41,7 @@ export function ErrorPageFallback({
 
     capturedErrorRef.current = error;
 
-    Sentry.withScope((scope) => {
+    captureClientException(error, (scope) => {
       scope.setTag("error_boundary_source", reportSource);
 
       if (error.digest) {
@@ -50,7 +50,6 @@ export function ErrorPageFallback({
 
       scope.setExtra("boundary_title", title);
       scope.setExtra("pathname", window.location.pathname);
-      Sentry.captureException(error);
     });
   }, [error, reportSource, title]);
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,8 @@
-@import "tailwindcss";
+@import "tailwindcss/theme";
+@import "tailwindcss/preflight";
+@import "tailwindcss/utilities";
+
+@source not "../**/*.stories.tsx";
 
 @layer base {
   html {

--- a/app/globals.css
+++ b/app/globals.css
@@ -53,8 +53,6 @@
 
   /* Animations */
   --animate-fade-up: fade-up 0.5s ease-out both;
-  --animate-fade-in: fade-in 0.4s ease-out both;
-  --animate-slide-up: slide-up 0.5s ease-out both;
 }
 
 @layer base {
@@ -75,68 +73,13 @@
     --color-input: #31343c;
     --color-ring: #9db58d;
   }
-
-  input[type="datetime-local"].mobile-datetime-local-input {
-    min-width: 0;
-  }
-
-  input[type="datetime-local"].mobile-datetime-local-input::-webkit-date-and-time-value {
-    min-width: 0;
-    text-align: left;
-  }
-
-  input[type="datetime-local"].mobile-datetime-local-input::-webkit-datetime-edit {
-    min-width: 0;
-    padding: 0;
-  }
-
-  input[type="datetime-local"].mobile-datetime-local-input::-webkit-datetime-edit-fields-wrapper {
-    min-width: 0;
-  }
-
-  input[type="datetime-local"].mobile-datetime-local-input::-webkit-calendar-picker-indicator {
-    margin: 0;
-  }
-}
-
-@keyframes slide-up {
-  from {
-    transform: translateY(16px);
-  }
-  to {
-    transform: translateY(0);
-  }
 }
 
 @keyframes fade-up {
   from {
-    opacity: 0;
     transform: translateY(16px);
   }
   to {
-    opacity: 1;
     transform: translateY(0);
   }
-}
-
-@keyframes fade-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-.bg-dot-pattern {
-  background-image: radial-gradient(circle, #40513b18 1px, transparent 1px);
-  background-size: 24px 24px;
-}
-
-html[data-theme="dark"] .bg-dot-pattern {
-  background-image: radial-gradient(
-    circle,
-    rgb(157 181 141 / 0.14) 1px,
-    transparent 1px
-  );
 }

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,76 +1,15 @@
-const hasSentryDsn = Boolean(process.env.NEXT_PUBLIC_SENTRY_DSN);
-const shouldLoadSentry = process.env.NODE_ENV === "production" && hasSentryDsn;
+import {
+  captureClientRouterTransitionStart,
+  scheduleSentryClientInit,
+} from "@/lib/sentry/client";
 
 type RouterTransitionType = "push" | "replace" | "traverse";
-type SentryClientModule = typeof import("@sentry/nextjs");
 
-let sentryClientModulePromise: null | Promise<null | SentryClientModule> = null;
-
-function loadSentryClient() {
-  if (!shouldLoadSentry) {
-    return null;
-  }
-
-  if (sentryClientModulePromise) {
-    return sentryClientModulePromise;
-  }
-
-  sentryClientModulePromise = import("@sentry/nextjs")
-    .then((Sentry) => {
-      Sentry.init({
-        dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-        enabled: true,
-        sendDefaultPii: false,
-      });
-
-      return Sentry;
-    })
-    .catch(() => null);
-
-  return sentryClientModulePromise;
-}
-
-function scheduleSentryInit() {
-  if (!shouldLoadSentry || typeof window === "undefined") {
-    return;
-  }
-
-  const startWhenIdle = () => {
-    const requestIdleCallback =
-      "requestIdleCallback" in globalThis
-        ? globalThis.requestIdleCallback
-        : null;
-
-    if (requestIdleCallback) {
-      requestIdleCallback(
-        () => {
-          void loadSentryClient();
-        },
-        { timeout: 2000 },
-      );
-      return;
-    }
-
-    globalThis.setTimeout(() => {
-      void loadSentryClient();
-    }, 0);
-  };
-
-  if (document.readyState === "complete") {
-    startWhenIdle();
-    return;
-  }
-
-  window.addEventListener("load", startWhenIdle, { once: true });
-}
-
-scheduleSentryInit();
+scheduleSentryClientInit();
 
 export function onRouterTransitionStart(
   url: string,
   navigationType: RouterTransitionType,
 ) {
-  void loadSentryClient()?.then((Sentry) => {
-    Sentry?.captureRouterTransitionStart(url, navigationType);
-  });
+  captureClientRouterTransitionStart(url, navigationType);
 }

--- a/lib/sentry/client.ts
+++ b/lib/sentry/client.ts
@@ -1,0 +1,108 @@
+"use client";
+
+type RouterTransitionType = "push" | "replace" | "traverse";
+type SentryClientModule = typeof import("@sentry/nextjs");
+type SentryScope = {
+  setExtra: (key: string, extra: unknown) => void;
+  setTag: (key: string, value: string) => void;
+};
+
+const hasSentryDsn = Boolean(process.env.NEXT_PUBLIC_SENTRY_DSN);
+const isBrowserSentryEnabled =
+  process.env.NEXT_PUBLIC_ENABLE_BROWSER_SENTRY === "true";
+const shouldLoadSentry =
+  process.env.NODE_ENV === "production" &&
+  hasSentryDsn &&
+  isBrowserSentryEnabled;
+
+let sentryClientModulePromise: null | Promise<null | SentryClientModule> = null;
+
+export function captureClientException(
+  error: unknown,
+  configureScope?: (scope: SentryScope) => void,
+) {
+  void loadSentryClient()?.then((Sentry) => {
+    if (!Sentry) {
+      return;
+    }
+
+    if (!configureScope) {
+      Sentry.captureException(error);
+      return;
+    }
+
+    Sentry.withScope((scope) => {
+      configureScope(scope);
+      Sentry.captureException(error);
+    });
+  });
+}
+
+export function captureClientRouterTransitionStart(
+  url: string,
+  navigationType: RouterTransitionType,
+) {
+  void url;
+  void navigationType;
+
+  return;
+}
+
+export function scheduleSentryClientInit() {
+  if (!shouldLoadSentry || typeof window === "undefined") {
+    return;
+  }
+
+  const scheduleAfterLoad = () => {
+    startWhenIdle(() => {
+      void loadSentryClient();
+    });
+  };
+
+  if (document.readyState === "complete") {
+    scheduleAfterLoad();
+    return;
+  }
+
+  window.addEventListener("load", scheduleAfterLoad, { once: true });
+}
+
+function loadSentryClient() {
+  if (!shouldLoadSentry) {
+    return null;
+  }
+
+  if (sentryClientModulePromise) {
+    return sentryClientModulePromise;
+  }
+
+  sentryClientModulePromise = import("@sentry/nextjs")
+    .then((Sentry) => {
+      Sentry.init({
+        dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+        enabled: true,
+        replaysOnErrorSampleRate: 0,
+        replaysSessionSampleRate: 0,
+        sendDefaultPii: false,
+        tracesSampleRate: 0,
+      });
+
+      return Sentry;
+    })
+    .catch(() => null);
+
+  return sentryClientModulePromise;
+}
+
+function startWhenIdle(callback: () => void) {
+  const requestIdleCallback =
+    "requestIdleCallback" in globalThis ? globalThis.requestIdleCallback : null;
+
+  if (requestIdleCallback) {
+    requestIdleCallback(callback, { timeout: 3000 });
+    return;
+  }
+
+  globalThis.setTimeout(callback, 1500);
+  return;
+}

--- a/lib/sentry/replay-disabled.ts
+++ b/lib/sentry/replay-disabled.ts
@@ -1,0 +1,15 @@
+type DisabledIntegration = {
+  name: string;
+};
+
+export function getReplay() {
+  return undefined;
+}
+
+export function replayCanvasIntegration(): DisabledIntegration {
+  return { name: "ReplayCanvasDisabled" };
+}
+
+export function replayIntegration(): DisabledIntegration {
+  return { name: "ReplayDisabled" };
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,8 @@ const nextConfig: NextConfig = {
   turbopack: {
     resolveAlias: {
       "../build/polyfills/polyfill-module": "./lib/modern-polyfill.js",
+      "@sentry-internal/replay": "./lib/sentry/replay-disabled.ts",
+      "@sentry-internal/replay-canvas": "./lib/sentry/replay-disabled.ts",
       "next/dist/build/polyfills/polyfill-module": "./lib/modern-polyfill.js",
     },
     rules: {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",
     "next": "16.1.6",
-    "posthog-js": "^1.365.5",
     "posthog-node": "^5.29.2",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      posthog-js:
-        specifier: ^1.365.5
-        version: 1.365.5
       posthog-node:
         specifier: ^5.29.2
         version: 5.29.2
@@ -1349,10 +1346,6 @@ packages:
     resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
     engines: {node: '>=8.0.0'}
 
-  '@opentelemetry/api-logs@0.208.0':
-    resolution: {integrity: sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==}
-    engines: {node: '>=8.0.0'}
-
   '@opentelemetry/api-logs@0.212.0':
     resolution: {integrity: sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==}
     engines: {node: '>=8.0.0'}
@@ -1371,23 +1364,11 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/core@2.2.0':
-    resolution: {integrity: sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
   '@opentelemetry/core@2.6.1':
     resolution: {integrity: sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/exporter-logs-otlp-http@0.208.0':
-    resolution: {integrity: sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
 
   '@opentelemetry/instrumentation-amqplib@0.61.0':
     resolution: {integrity: sha512-mCKoyTGfRNisge4br0NpOFSy2Z1NnEW8hbCJdUDdJFHrPqVzc4IIBPA/vX0U+LUcQqrQvJX+HMIU0dbDRe0i0Q==}
@@ -1539,48 +1520,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/otlp-exporter-base@0.208.0':
-    resolution: {integrity: sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/otlp-transformer@0.208.0':
-    resolution: {integrity: sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
   '@opentelemetry/redis-common@0.38.2':
     resolution: {integrity: sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==}
     engines: {node: ^18.19.0 || >=20.6.0}
 
-  '@opentelemetry/resources@2.2.0':
-    resolution: {integrity: sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
   '@opentelemetry/resources@2.6.1':
     resolution: {integrity: sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
-  '@opentelemetry/sdk-logs@0.208.0':
-    resolution: {integrity: sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.4.0 <1.10.0'
-
-  '@opentelemetry/sdk-metrics@2.2.0':
-    resolution: {integrity: sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.9.0 <1.10.0'
-
-  '@opentelemetry/sdk-trace-base@2.2.0':
-    resolution: {integrity: sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
@@ -1610,43 +1555,10 @@ packages:
   '@posthog/core@1.25.2':
     resolution: {integrity: sha512-h2FO7ut/BbfwpAXWpwdDHTzQgUo9ibDFEs6ZO+3cI3KPWQt5XwczK1OLAuPprcjm8T/jl0SH8jSFo5XdU4RbTg==}
 
-  '@posthog/types@1.365.5':
-    resolution: {integrity: sha512-BCdDP8AC9ruAelYWSjXFRAySY1KamLCE2KEMhdsgIjcExHzVPqwg+K5xyGR6KqBvAbXhKqtkS46pKGS8lJXZCg==}
-
   '@prisma/instrumentation@7.6.0':
     resolution: {integrity: sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==}
     peerDependencies:
       '@opentelemetry/api': ^1.8
-
-  '@protobufjs/aspromise@1.1.2':
-    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
-
-  '@protobufjs/base64@1.1.2':
-    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
-
-  '@protobufjs/codegen@2.0.4':
-    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
-
-  '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
-
-  '@protobufjs/fetch@1.1.0':
-    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
-
-  '@protobufjs/float@1.0.2':
-    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
-
-  '@protobufjs/inquire@1.1.0':
-    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
-
-  '@protobufjs/path@1.1.2':
-    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
-
-  '@protobufjs/pool@1.1.0':
-    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
-
-  '@protobufjs/utf8@1.1.0':
-    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@puppeteer/browsers@2.13.0':
     resolution: {integrity: sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==}
@@ -2436,9 +2348,6 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
-
-  '@types/trusted-types@2.0.7':
-    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -3261,9 +3170,6 @@ packages:
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
 
-  core-js@3.49.0:
-    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
-
   cosmiconfig@8.3.6:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
@@ -3456,9 +3362,6 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
-
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -3831,9 +3734,6 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
-
-  fflate@0.4.8:
-    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   figures@2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
@@ -4544,9 +4444,6 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
-  long@5.3.2:
-    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
-
   lookup-closest-locale@6.2.0:
     resolution: {integrity: sha512-/c2kL+Vnp1jnV6K6RpDTHK3dgg0Tu2VVp+elEiJpjfS1UyY7AjOYHohRug6wT0OpoX2qFgNORndE9RqesfVxWQ==}
 
@@ -5046,9 +4943,6 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
-  posthog-js@1.365.5:
-    resolution: {integrity: sha512-BJw3cmBykQHY/TK82s8UsUyQPjjMPVsI7Wy2eZRXf+GxhLnHmXZj50bQAfAKlTLHv3qwDpld17bGKXC9zLwVhg==}
-
   posthog-node@5.29.2:
     resolution: {integrity: sha512-rI7kkF0XqDc0G1qjx+Hb4iuY9NAlL+XQNoGOpnEpRNTUcXvjY6WlsRGZ9m2whgc39emrrYdszi/YT8wZkr2xsg==}
     engines: {node: ^20.20.0 || >=22.22.0}
@@ -5057,9 +4951,6 @@ packages:
     peerDependenciesMeta:
       rxjs:
         optional: true
-
-  preact@10.29.1:
-    resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -5140,10 +5031,6 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
-    engines: {node: '>=12.0.0'}
-
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -5169,9 +5056,6 @@ packages:
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
     engines: {node: '>=0.6'}
-
-  query-selector-shadow-dom@1.0.1:
-    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -6023,9 +5907,6 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
-
-  web-vitals@5.2.0:
-    resolution: {integrity: sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==}
 
   webdriver-bidi-protocol@0.4.1:
     resolution: {integrity: sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==}
@@ -7496,10 +7377,6 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@opentelemetry/api-logs@0.208.0':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-
   '@opentelemetry/api-logs@0.212.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -7514,24 +7391,10 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/semantic-conventions': 1.40.0
-
   '@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
-
-  '@opentelemetry/exporter-logs-otlp-http@0.208.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.208.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.208.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/instrumentation-amqplib@0.61.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -7751,55 +7614,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/otlp-exporter-base@0.208.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/otlp-transformer@0.208.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.208.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.1)
-      protobufjs: 7.5.4
-
   '@opentelemetry/redis-common@0.38.2': {}
-
-  '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-
-  '@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.208.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1)':
@@ -7825,37 +7645,12 @@ snapshots:
 
   '@posthog/core@1.25.2': {}
 
-  '@posthog/types@1.365.5': {}
-
   '@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/instrumentation': 0.207.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
-
-  '@protobufjs/aspromise@1.1.2': {}
-
-  '@protobufjs/base64@1.1.2': {}
-
-  '@protobufjs/codegen@2.0.4': {}
-
-  '@protobufjs/eventemitter@1.1.0': {}
-
-  '@protobufjs/fetch@1.1.0':
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.0
-
-  '@protobufjs/float@1.0.2': {}
-
-  '@protobufjs/inquire@1.1.0': {}
-
-  '@protobufjs/path@1.1.2': {}
-
-  '@protobufjs/pool@1.1.0': {}
-
-  '@protobufjs/utf8@1.1.0': {}
 
   '@puppeteer/browsers@2.13.0':
     dependencies:
@@ -8698,9 +8493,6 @@ snapshots:
       '@types/node': 20.19.30
 
   '@types/tough-cookie@4.0.5': {}
-
-  '@types/trusted-types@2.0.7':
-    optional: true
 
   '@types/ws@8.18.1':
     dependencies:
@@ -9593,8 +9385,6 @@ snapshots:
     dependencies:
       browserslist: 4.28.1
 
-  core-js@3.49.0: {}
-
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
@@ -9764,10 +9554,6 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
-
-  dompurify@3.3.3:
-    optionalDependencies:
-      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:
@@ -10338,8 +10124,6 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
-
-  fflate@0.4.8: {}
 
   figures@2.0.0:
     dependencies:
@@ -11106,8 +10890,6 @@ snapshots:
       strip-ansi: 7.1.2
       wrap-ansi: 9.0.2
 
-  long@5.3.2: {}
-
   lookup-closest-locale@6.2.0: {}
 
   loose-envify@1.4.0:
@@ -11552,27 +11334,9 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
-  posthog-js@1.365.5:
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.208.0
-      '@opentelemetry/exporter-logs-otlp-http': 0.208.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
-      '@posthog/core': 1.25.2
-      '@posthog/types': 1.365.5
-      core-js: 3.49.0
-      dompurify: 3.3.3
-      fflate: 0.4.8
-      preact: 10.29.1
-      query-selector-shadow-dom: 1.0.1
-      web-vitals: 5.2.0
-
   posthog-node@5.29.2:
     dependencies:
       '@posthog/core': 1.25.2
-
-  preact@10.29.1: {}
 
   prelude-ls@1.2.1: {}
 
@@ -11597,21 +11361,6 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-
-  protobufjs@7.5.4:
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
-      '@types/node': 20.19.30
-      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:
@@ -11660,8 +11409,6 @@ snapshots:
   qs@6.14.2:
     dependencies:
       side-channel: 1.1.0
-
-  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -12665,8 +12412,6 @@ snapshots:
       graceful-fs: 4.2.11
 
   web-streams-polyfill@3.3.3: {}
-
-  web-vitals@5.2.0: {}
 
   webdriver-bidi-protocol@0.4.1: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,8 +28,6 @@ const storybookProject = {
       "class-variance-authority",
       "clsx",
       "next/navigation",
-      "posthog-js",
-      "posthog-js/react",
       "react",
       "react-dom",
       "tailwind-merge",


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #386, #388, #390

## 📌 작업 내용

- 사용하지 않는 전역 애니메이션과 패턴 스타일을 제거하고 datetime-local 입력 스타일을 컴포넌트 CSS 모듈로 이동해 전역 CSS 범위를 축소
- 지원 현황, 지원 상세, 미리보기의 에러 상태 색상을 semantic destructive 토큰으로 통일하고 Tailwind source scanning 범위를 명확히 정리
- 브라우저 Sentry 초기화를 조건부 lazy import 헬퍼로 분리하고 Replay 관련 모듈을 비활성 shim으로 대체해 초기 클라이언트 관측 번들 포함 범위를 줄임
- 미사용 `posthog-js` 의존성과 관련 lockfile 전이 의존성을 제거해 브라우저 번들 비대화를 방지
