### PR TITLE
fix: 지원 목록 새로고침 레이아웃 시프트 완화(#393)

### DIFF
--- a/app/(protected)/applications/_components/components/ApplicationList.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationList.tsx
@@ -25,6 +25,7 @@ type ApplicationListProps = {
   onRangeChange?: (startIndex: number, endIndex: number) => void;
   onSelectApplication: (application: ApplicationListItem) => void;
   ref?: React.Ref<VirtualListHandle>;
+  resetKey?: number | string;
 };
 
 export function ApplicationList({
@@ -35,6 +36,7 @@ export function ApplicationList({
   onRangeChange,
   onSelectApplication,
   ref,
+  resetKey,
 }: ApplicationListProps) {
   const handleRangeChange = (startIndex: number, endIndex: number) => {
     onRangeChange?.(startIndex, endIndex);
@@ -67,6 +69,7 @@ export function ApplicationList({
             onSelectAction={onSelectApplication}
           />
         )}
+        resetKey={resetKey}
       />
       {!isFetchingNextPage && <div className="h-10 shrink-0" />}
 

--- a/app/(protected)/applications/_components/components/ApplicationTabs.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationTabs.tsx
@@ -28,6 +28,7 @@ type ApplicationTabsProps = {
   applications: ApplicationListItem[];
   className?: string;
   isFetchingNextPage?: boolean;
+  listResetKey?: number | string;
   onNearEndAction?: () => void;
   onRangeChangeAction?: (startIndex: number, endIndex: number) => void;
   onSelectApplicationAction: (application: ApplicationListItem) => void;
@@ -40,6 +41,7 @@ export function ApplicationTabs({
   applications,
   className,
   isFetchingNextPage,
+  listResetKey,
   onNearEndAction,
   onRangeChangeAction,
   onSelectApplicationAction,
@@ -168,6 +170,7 @@ export function ApplicationTabs({
           onRangeChange={onRangeChangeAction}
           onSelectApplication={onSelectApplicationAction}
           ref={listRef}
+          resetKey={`${tab}:${listResetKey ?? "default"}`}
         />
       </div>
     </div>

--- a/app/(protected)/applications/_components/components/ApplicationsPanelClient.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanelClient.tsx
@@ -5,7 +5,7 @@ import type { Route } from "next";
 import { AlertCircleIcon } from "lucide-react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 
 import type {
@@ -65,10 +65,12 @@ export function ApplicationsPanelClient({
   const router = useRouter();
 
   const tabsRef = useRef<ApplicationTabsHandle>(null);
+  const initialPageRef = useRef(initialPage);
   const paginationSequenceRef = useRef(0);
   const [isFetchingNextPage, setIsFetchingNextPage] = useState(false);
   const [isListScrolled, setIsListScrolled] = useState(false);
   const [isNavigatingFromPreview, setIsNavigatingFromPreview] = useState(false);
+  const [listResetVersion, setListResetVersion] = useState(0);
   const [localPreviewApplicationId, setLocalPreviewApplicationId] = useState<
     null | string
   >(previewApplicationId);
@@ -90,12 +92,18 @@ export function ApplicationsPanelClient({
     setLocalPreviewApplicationId(previewApplicationId);
   }, [previewApplicationId]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    if (initialPageRef.current === initialPage) {
+      return;
+    }
+
+    initialPageRef.current = initialPage;
     paginationSequenceRef.current += 1;
     setPages([initialPage]);
     setPaginationError(null);
     setIsFetchingNextPage(false);
     setIsListScrolled(false);
+    setListResetVersion((version) => version + 1);
   }, [initialPage]);
 
   function updateRoute(nextState: RouteStateUpdate) {
@@ -222,6 +230,7 @@ export function ApplicationsPanelClient({
         applications={applications}
         className="h-[32rem] min-h-0 sm:h-[36rem] lg:h-[40rem]"
         isFetchingNextPage={isFetchingNextPage}
+        listResetKey={listResetVersion}
         onNearEndAction={() => {
           void handleNearEnd();
         }}

--- a/app/(protected)/applications/_components/components/ApplicationsPanelFallback.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanelFallback.tsx
@@ -5,7 +5,7 @@ const ROW_SKELETON_KEYS = [0, 1, 2, 3, 4] as const;
 
 export function ApplicationsPanelFallback() {
   return (
-    <div className="flex flex-col">
+    <div className="flex h-[32rem] min-h-0 flex-col sm:h-[36rem] lg:h-[40rem]">
       <div className="border-b border-border/70 bg-background px-5 sm:px-6">
         <div className="flex items-end gap-5 py-3">
           {TAB_SKELETON_KEYS.map((key) => (
@@ -19,8 +19,8 @@ export function ApplicationsPanelFallback() {
         </div>
       </div>
 
-      <div className="px-4 sm:px-5">
-        <div className="h-[32rem] min-h-0 space-y-3 overflow-hidden pt-4 sm:h-[36rem] lg:h-[40rem]">
+      <div className="min-h-0 flex-1 px-4 sm:px-5">
+        <div className="h-full space-y-3 overflow-hidden pt-4">
           {ROW_SKELETON_KEYS.map((index) => (
             <div
               className="rounded-2xl border border-border/60 px-4 py-4"

--- a/app/(protected)/applications/loading.tsx
+++ b/app/(protected)/applications/loading.tsx
@@ -2,7 +2,11 @@ import { Skeleton } from "@/components/ui/skeleton/Skeleton";
 
 import { ApplicationsPanelFallback } from "./_components/components/ApplicationsPanelFallback";
 
-const PERIOD_CHIP_KEYS = [0, 1, 2, 3] as const;
+const PERIOD_CHIP_SKELETON_CLASSES = [
+  "h-10 w-14 rounded-full",
+  "h-10 w-24 rounded-full",
+  "h-10 w-20 rounded-full",
+] as const;
 
 export default function ApplicationsLoading() {
   return (
@@ -26,10 +30,14 @@ function ApplicationFiltersFallback() {
       <div className="grid gap-4">
         <Skeleton className="h-12 w-full rounded-2xl" />
         <div className="flex flex-wrap items-center gap-2">
-          {PERIOD_CHIP_KEYS.map((key) => (
-            <Skeleton className="h-8 w-16 rounded-full" key={key} />
-          ))}
-          <Skeleton className="ml-auto h-8 w-28 rounded-full" />
+          <div className="flex flex-wrap gap-2">
+            {PERIOD_CHIP_SKELETON_CLASSES.map((className) => (
+              <Skeleton className={className} key={className} />
+            ))}
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Skeleton className="h-10 w-40 rounded-full" />
+          </div>
         </div>
       </div>
     </section>

--- a/components/ui/virtual-list/VirtualList.tsx
+++ b/components/ui/virtual-list/VirtualList.tsx
@@ -21,6 +21,8 @@ type VirtualItemMeasurerProps = {
   onMeasure: (index: number, height: number) => void;
 };
 
+type VirtualListContentProps<T> = Omit<VirtualListProps<T>, "resetKey">;
+
 type VirtualListProps<T> = {
   /**
    * 스크롤 컨테이너의 접근성 레이블.
@@ -72,6 +74,11 @@ type VirtualListProps<T> = {
    * 아이템을 렌더링하는 함수.
    */
   renderItem: (item: T, index: number) => ReactNode;
+  /**
+   * 데이터셋 의미가 바뀔 때 높이 측정 캐시와 스크롤 위치를 초기화하기 위한 키.
+   * 무한 스크롤처럼 같은 데이터셋에 아이템을 append하는 경우에는 변경하지 않습니다.
+   */
+  resetKey?: number | string;
 };
 
 /**
@@ -84,67 +91,10 @@ type VirtualListProps<T> = {
  *
  * 데이터셋 교체 시 높이 캐시 초기화:
  * - 아이템 수가 줄어드는 경우(필터링 등): 자동으로 범위 밖 측정값을 정리합니다.
- * - 같은 개수의 완전히 다른 데이터로 교체하는 경우: `key` prop으로 컴포넌트를 리셋하세요.
- *   예) `<VirtualList key={activeTabId} ... />`
+ * - 같은 개수의 완전히 다른 데이터로 교체하는 경우: `resetKey`를 변경해 캐시와 스크롤을 리셋하세요.
  */
-export function VirtualList<T>({
-  "aria-label": ariaLabel,
-  className,
-  emptyState,
-  estimatedItemHeight,
-  items,
-  keyExtractor,
-  onRangeChange,
-  overscan,
-  paddingBottom,
-  paddingTop,
-  ref,
-  renderItem,
-}: VirtualListProps<T>) {
-  const {
-    containerRef,
-    handleScroll,
-    measureItem,
-    scrollToIndex,
-    totalHeight,
-    virtualItems,
-  } = useVirtualList({
-    estimatedItemHeight,
-    itemCount: items.length,
-    onRangeChange,
-    overscan,
-    paddingBottom,
-    paddingTop,
-  });
-
-  useImperativeHandle(ref, () => ({ scrollToIndex }), [scrollToIndex]);
-
-  if (items.length === 0) {
-    return emptyState ?? null;
-  }
-
-  return (
-    <div
-      aria-label={ariaLabel}
-      className={cn("overflow-y-auto", className)}
-      onScroll={handleScroll}
-      ref={containerRef}
-      role="list"
-    >
-      <div className="relative" style={{ height: totalHeight }}>
-        {virtualItems.map(({ index, offsetTop }) => (
-          <VirtualItemMeasurer
-            index={index}
-            key={keyExtractor(items[index], index)}
-            offsetTop={offsetTop}
-            onMeasure={measureItem}
-          >
-            {renderItem(items[index], index)}
-          </VirtualItemMeasurer>
-        ))}
-      </div>
-    </div>
-  );
+export function VirtualList<T>({ resetKey, ...props }: VirtualListProps<T>) {
+  return <VirtualListContent<T> key={resetKey ?? "default"} {...props} />;
 }
 
 /**
@@ -190,6 +140,66 @@ function VirtualItemMeasurer({
       style={{ top: offsetTop }}
     >
       {children}
+    </div>
+  );
+}
+
+function VirtualListContent<T>({
+  "aria-label": ariaLabel,
+  className,
+  emptyState,
+  estimatedItemHeight,
+  items,
+  keyExtractor,
+  onRangeChange,
+  overscan,
+  paddingBottom,
+  paddingTop,
+  ref,
+  renderItem,
+}: VirtualListContentProps<T>) {
+  const {
+    containerRef,
+    handleScroll,
+    measureItem,
+    scrollToIndex,
+    totalHeight,
+    virtualItems,
+  } = useVirtualList({
+    estimatedItemHeight,
+    itemCount: items.length,
+    onRangeChange,
+    overscan,
+    paddingBottom,
+    paddingTop,
+  });
+
+  useImperativeHandle(ref, () => ({ scrollToIndex }), [scrollToIndex]);
+
+  if (items.length === 0) {
+    return emptyState ?? null;
+  }
+
+  return (
+    <div
+      aria-label={ariaLabel}
+      className={cn("overflow-y-auto", className)}
+      onScroll={handleScroll}
+      ref={containerRef}
+      role="list"
+    >
+      <div className="relative" style={{ height: totalHeight }}>
+        {virtualItems.map(({ index, offsetTop }) => (
+          <VirtualItemMeasurer
+            index={index}
+            key={keyExtractor(items[index], index)}
+            offsetTop={offsetTop}
+            onMeasure={measureItem}
+          >
+            {renderItem(items[index], index)}
+          </VirtualItemMeasurer>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #393

## 📌 작업 내용

- 가상 리스트에 resetKey를 추가해 지원 목록 데이터셋이 교체될 때 측정 캐시와 스크롤 상태를 초기화하도록 수정
- router.refresh로 initialPage가 바뀌는 경우 페인트 전에 목록 상태를 갱신해 이전 row 높이 캐시가 새 항목에 재사용되는 문제를 방지
- 탭 전환 시에도 리스트 resetKey를 변경해 탭별 데이터셋과 가상화 상태가 섞이지 않도록 개선
- 지원 목록 Suspense fallback 높이를 실제 패널 높이와 맞춰 로딩 전환 중 레이아웃 시프트를 줄임
- 모바일 로딩 스켈레톤의 기간 필터와 정렬 컨트롤 배치를 실제 필터 UI와 맞춰 최신순 영역 위치 불일치를 수정


