### PR TITLE
fix: 다크모드 토큰 적용 우선순위 수정(#396)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -59,24 +59,22 @@
   --animate-fade-up: fade-up 0.5s ease-out both;
 }
 
-@layer base {
-  html[data-theme="dark"] {
-    --color-background: #16171a;
-    --color-foreground: #f3f1ec;
-    --color-primary: #9db58d;
-    --color-primary-foreground: #0f140f;
-    --color-secondary: #202228;
-    --color-secondary-foreground: #f3f1ec;
-    --color-destructive: #f87171;
-    --color-destructive-foreground: #1f1111;
-    --color-muted: #1a1c21;
-    --color-muted-foreground: #abaeb8;
-    --color-accent: #262930;
-    --color-accent-foreground: #f3f1ec;
-    --color-border: #31343c;
-    --color-input: #31343c;
-    --color-ring: #9db58d;
-  }
+html[data-theme="dark"] {
+  --color-background: #16171a;
+  --color-foreground: #f3f1ec;
+  --color-primary: #9db58d;
+  --color-primary-foreground: #0f140f;
+  --color-secondary: #202228;
+  --color-secondary-foreground: #f3f1ec;
+  --color-destructive: #f87171;
+  --color-destructive-foreground: #1f1111;
+  --color-muted: #1a1c21;
+  --color-muted-foreground: #abaeb8;
+  --color-accent: #262930;
+  --color-accent-foreground: #f3f1ec;
+  --color-border: #31343c;
+  --color-input: #31343c;
+  --color-ring: #9db58d;
 }
 
 @keyframes fade-up {


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #396

## 📌 작업 내용

- Tailwind v4의 `@theme` 토큰보다 낮은 우선순위로 적용되던 다크모드 CSS 변수를 레이어 밖으로 이동
- `html[data-theme="dark"]` 전환 시 배경색과 전경색이 실제 계산 스타일에 반영되도록 수정
- 브라우저 검증과 lint를 통해 테마 전환 회귀가 없는지 확인


