### PR TITLE
refactor: 랜딩 페이지 문구와 진입 애니메이션 정리(#401)

### DIFF
--- a/app/_components/landing/HeroSection.tsx
+++ b/app/_components/landing/HeroSection.tsx
@@ -1,48 +1,23 @@
-const HERO_ANIMATION_DELAYS = {
-  heading: "140ms",
-  intro: "80ms",
-  list: "380ms",
-  summary: "220ms",
-} as const;
-
 export function HeroSection() {
   return (
     <section className="bg-background">
       <div className="mx-auto flex min-h-[calc(100svh-4.5rem)] max-w-7xl items-center px-6 py-20 lg:px-10">
         <div className="max-w-2xl">
-          <p className="animate-fade-up text-sm font-semibold tracking-[0.24em] text-primary uppercase">
+          <p className="text-sm font-semibold tracking-[0.24em] text-primary uppercase">
             201 escape
           </p>
-          <p
-            className="mt-4 animate-fade-up text-sm font-medium text-muted-foreground"
-            style={{ animationDelay: HERO_ANIMATION_DELAYS.intro }}
-          >
-            공고, 지원 단계, 면접 일정을 한곳에서 정리합니다.
-          </p>
-          <h1
-            className="mt-5 animate-fade-up text-[2.7rem] leading-[1.02] font-bold tracking-[-0.05em] text-balance text-foreground sm:text-[3.6rem] lg:text-[4.2rem]"
-            style={{ animationDelay: HERO_ANIMATION_DELAYS.heading }}
-          >
-            지원 흐름을
-            <br />더 쉽게 정리하세요.
+          <h1 className="mt-5 text-[2.7rem] leading-[1.02] font-bold tracking-[-0.05em] text-balance text-foreground sm:text-[3.6rem] lg:text-[4.2rem]">
+            흩어진 채용 공고를
+            <br />한 곳에서.
           </h1>
-          <p
-            className="mt-6 max-w-xl animate-fade-up text-base leading-7 font-medium text-muted-foreground"
-            style={{ animationDelay: HERO_ANIMATION_DELAYS.summary }}
-          >
+          <p className="mt-6 max-w-xl text-base leading-7 font-medium text-muted-foreground">
             <span className="block">
-              저장한 공고와 현재 상태, 예정된 면접 일정을 한 화면에서 확인할 수
-              있습니다.
-            </span>
-            <span className="block">
-              처음 열어도 바로 이해할 수 있는 흐름에 집중했습니다.
+              저장한 공고와 현재 상태, 예정된 면접 일정을 <br />한 곳에
+              정리하세요.
             </span>
           </p>
 
-          <ul
-            className="mt-10 grid animate-fade-up gap-3 border-t border-border pt-6 text-sm font-medium text-muted-foreground sm:grid-cols-3"
-            style={{ animationDelay: HERO_ANIMATION_DELAYS.list }}
-          >
+          <ul className="mt-10 grid gap-3 border-t border-border pt-6 text-sm font-medium text-muted-foreground sm:grid-cols-3">
             <li>공고를 저장하고 단계별로 관리</li>
             <li>면접 일정과 메모를 함께 기록</li>
             <li>전체 진행 현황을 빠르게 확인</li>


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #401

## 📌 작업 내용

- 랜딩 페이지 히어로 문구 수정
- 히어로 영역의 fade-up 애니메이션과 지연 시간 설정을 제거해 정적인 첫 화면으로 변경
- 앱 내부에서 사용하는 전역 애니메이션 토큰은 유지해 변경 범위를 랜딩 페이지로 제한


