### PR TITLE
fix: 웹뷰 환경에서 소셜 로그인 안내 추가(#403)

### DIFF
--- a/app/auth/login/google/route.ts
+++ b/app/auth/login/google/route.ts
@@ -2,14 +2,26 @@ import { NextResponse } from "next/server";
 
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { trackServerEvent } from "@/lib/analytics/server";
+import { isLikelyWebViewUserAgent } from "@/lib/auth/webview";
 import { createClient } from "@/lib/supabase/server";
 
 const CALLBACK_PATH = "/auth/callback";
 const DASHBOARD_PATH = "/dashboard";
 const ERROR_PATH = "/auth/auth-code-error";
+const LOGIN_PATH = "/login";
+const WEBVIEW_QUERY_VALUE = "1";
 
 export async function GET(request: Request): Promise<NextResponse> {
   const { origin } = new URL(request.url);
+  const userAgent = request.headers.get("user-agent") ?? "";
+
+  if (isLikelyWebViewUserAgent(userAgent)) {
+    const loginUrl = new URL(LOGIN_PATH, origin);
+    loginUrl.searchParams.set("webview", WEBVIEW_QUERY_VALUE);
+
+    return NextResponse.redirect(loginUrl, 302);
+  }
+
   const supabase = await createClient();
   const redirectTo = new URL(CALLBACK_PATH, origin);
   redirectTo.searchParams.set("next", DASHBOARD_PATH);

--- a/app/login/_components/LoginActions.tsx
+++ b/app/login/_components/LoginActions.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+import { isLikelyWebViewUserAgent } from "@/lib/auth/webview";
+
+import { GoogleLoginButton } from "./GoogleLoginButton";
+import { WebViewLoginNotice } from "./WebViewLoginNotice";
+
+type LoginActionsProps = {
+  shouldShowWebViewNotice: boolean;
+};
+
+export function LoginActions({ shouldShowWebViewNotice }: LoginActionsProps) {
+  const isClientWebView = useClientWebViewDetectionSnapshot();
+  const isWebView = shouldShowWebViewNotice || isClientWebView;
+
+  if (isWebView) {
+    return <WebViewLoginNotice />;
+  }
+
+  return <GoogleLoginButton />;
+}
+
+function getClientWebViewDetectionSnapshot(): boolean {
+  return isLikelyWebViewUserAgent(window.navigator.userAgent);
+}
+
+function getFalseSnapshot(): boolean {
+  return false;
+}
+
+function subscribeToStaticBrowserSnapshot(): () => void {
+  return () => {};
+}
+
+function useClientWebViewDetectionSnapshot(): boolean {
+  return useSyncExternalStore(
+    subscribeToStaticBrowserSnapshot,
+    getClientWebViewDetectionSnapshot,
+    getFalseSnapshot,
+  );
+}

--- a/app/login/_components/WebViewLoginNotice.tsx
+++ b/app/login/_components/WebViewLoginNotice.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import {
+  Check as CheckIcon,
+  Copy as CopyIcon,
+  ExternalLink as ExternalLinkIcon,
+  Info as InfoIcon,
+} from "lucide-react";
+import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
+
+import { Button } from "@/components/ui/button/Button";
+import { isAndroidUserAgent } from "@/lib/auth/webview";
+import { cn } from "@/lib/utils/cn";
+
+const COPY_STATUS_RESET_MS = 2_000;
+
+type CopyStatus = "copied" | "failed" | "idle";
+
+const COPY_STATUS_LABELS: Record<CopyStatus, string> = {
+  copied: "주소가 복사되었습니다",
+  failed: "주소 복사에 실패했습니다",
+  idle: "주소 복사",
+};
+
+export function WebViewLoginNotice() {
+  const [copyStatus, setCopyStatus] = useState<CopyStatus>("idle");
+  const isAndroid = useAndroidSnapshot();
+  const loginUrl = useLoginUrlSnapshot();
+
+  useEffect(() => {
+    if (copyStatus === "idle") {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setCopyStatus("idle");
+    }, COPY_STATUS_RESET_MS);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [copyStatus]);
+
+  const chromeIntentUrl = useMemo(() => {
+    if (!loginUrl) {
+      return "";
+    }
+
+    return createChromeIntentUrl(loginUrl);
+  }, [loginUrl]);
+
+  async function handleCopyLoginUrl() {
+    if (!loginUrl) {
+      return;
+    }
+
+    const didCopy = await copyTextToClipboard(loginUrl);
+
+    setCopyStatus(didCopy ? "copied" : "failed");
+  }
+
+  const isCopied = copyStatus === "copied";
+
+  return (
+    <section
+      aria-labelledby="webview-login-title"
+      className="rounded-2xl border border-primary/15 bg-primary/5 p-4 text-left"
+    >
+      <div className="flex gap-3">
+        <span
+          aria-hidden="true"
+          className="mt-0.5 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary"
+        >
+          <InfoIcon className="h-5 w-5" />
+        </span>
+
+        <div className="min-w-0 flex-1">
+          <h2
+            className="text-base leading-6 font-bold text-foreground"
+            id="webview-login-title"
+          >
+            외부 브라우저에서 로그인이 필요합니다.
+          </h2>
+          <p className="mt-2 text-sm leading-6 font-medium text-muted-foreground">
+            현재 앱 내 브라우저에서는 Google 로그인이 제한될 수 있습니다. Safari
+            또는 Chrome에서 다시 열어 주십시오.
+          </p>
+
+          <div className="mt-4 flex flex-col gap-2">
+            {isAndroid && chromeIntentUrl ? (
+              <Button asChild className="h-11 w-full" variant="default">
+                <a href={chromeIntentUrl}>
+                  <ExternalLinkIcon aria-hidden="true" className="h-4 w-4" />
+                  Chrome으로 열기
+                </a>
+              </Button>
+            ) : null}
+
+            <Button
+              className={cn(
+                "h-11 w-full",
+                isCopied && "border-primary/40 text-primary",
+              )}
+              disabled={!loginUrl}
+              onClick={handleCopyLoginUrl}
+              variant="outline"
+            >
+              {isCopied ? (
+                <CheckIcon aria-hidden="true" className="h-4 w-4" />
+              ) : (
+                <CopyIcon aria-hidden="true" className="h-4 w-4" />
+              )}
+              {COPY_STATUS_LABELS[copyStatus]}
+            </Button>
+          </div>
+
+          <p
+            aria-live="polite"
+            className="mt-3 text-xs leading-5 font-medium text-muted-foreground"
+          >
+            {isAndroid
+              ? "Chrome으로 열기가 동작하지 않으면 주소를 복사해 외부 브라우저에 붙여넣어 주십시오."
+              : "iPhone에서는 공유 버튼을 누른 뒤 Safari에서 열기를 선택해 주십시오."}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+async function copyTextToClipboard(text: string): Promise<boolean> {
+  if (window.navigator.clipboard?.writeText) {
+    try {
+      await window.navigator.clipboard.writeText(text);
+
+      return true;
+    } catch {
+      return copyTextWithHiddenTextArea(text);
+    }
+  }
+
+  return copyTextWithHiddenTextArea(text);
+}
+
+function copyTextWithHiddenTextArea(text: string): boolean {
+  const textArea = window.document.createElement("textarea");
+
+  textArea.value = text;
+  textArea.setAttribute("readonly", "");
+  textArea.style.left = "-9999px";
+  textArea.style.position = "fixed";
+  textArea.style.top = "0";
+
+  window.document.body.append(textArea);
+  textArea.focus();
+  textArea.select();
+
+  try {
+    return window.document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    textArea.remove();
+  }
+}
+
+function createChromeIntentUrl(pageUrl: string): string {
+  const url = new URL(pageUrl);
+  const path = `${url.host}${url.pathname}${url.search}${url.hash}`;
+  const scheme = url.protocol.replace(":", "");
+
+  return `intent://${path}#Intent;scheme=${scheme};package=com.android.chrome;end`;
+}
+
+function getClientAndroidSnapshot(): boolean {
+  return isAndroidUserAgent(window.navigator.userAgent);
+}
+
+function getClientLoginUrlSnapshot(): string {
+  return `${window.location.origin}/login`;
+}
+
+function getEmptyStringSnapshot(): string {
+  return "";
+}
+
+function getFalseSnapshot(): boolean {
+  return false;
+}
+
+function subscribeToStaticBrowserSnapshot(): () => void {
+  return () => {};
+}
+
+function useAndroidSnapshot(): boolean {
+  return useSyncExternalStore(
+    subscribeToStaticBrowserSnapshot,
+    getClientAndroidSnapshot,
+    getFalseSnapshot,
+  );
+}
+
+function useLoginUrlSnapshot(): string {
+  return useSyncExternalStore(
+    subscribeToStaticBrowserSnapshot,
+    getClientLoginUrlSnapshot,
+    getEmptyStringSnapshot,
+  );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,9 +1,18 @@
 import { PublicHeader } from "../_components/PublicHeader";
-import { GoogleLoginButton } from "./_components/GoogleLoginButton";
+import { LoginActions } from "./_components/LoginActions";
 
 const PRIVACY_PAGE_HREF = "/privacy";
+const WEBVIEW_QUERY_VALUE = "1";
 
-export default function LoginPage() {
+type LoginPageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const resolvedSearchParams = await searchParams;
+  const shouldShowWebViewNotice =
+    getFirstSearchParam(resolvedSearchParams?.webview) === WEBVIEW_QUERY_VALUE;
+
   return (
     <div className="flex h-dvh flex-col bg-muted/30">
       <PublicHeader />
@@ -22,7 +31,7 @@ export default function LoginPage() {
           </header>
 
           <div className="space-y-4">
-            <GoogleLoginButton />
+            <LoginActions shouldShowWebViewNotice={shouldShowWebViewNotice} />
 
             <div className="flex justify-center px-1">
               <p className="inline-flex flex-wrap items-center justify-center gap-x-1 text-center text-sm leading-5 font-medium text-muted-foreground">
@@ -41,4 +50,14 @@ export default function LoginPage() {
       </div>
     </div>
   );
+}
+
+function getFirstSearchParam(
+  value: string | string[] | undefined,
+): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return value;
 }

--- a/lib/auth/__tests__/webview.test.ts
+++ b/lib/auth/__tests__/webview.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { isAndroidUserAgent, isLikelyWebViewUserAgent } from "../webview";
+
+describe("isLikelyWebViewUserAgent", () => {
+  it("Android WebView user-agent를 웹뷰로 판단한다", () => {
+    const userAgent =
+      "Mozilla/5.0 (Linux; Android 13; Pixel 7 Build/TQ3A.230805.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/120.0.0.0 Mobile Safari/537.36";
+
+    expect(isLikelyWebViewUserAgent(userAgent)).toBe(true);
+  });
+
+  it("iOS WebView user-agent를 웹뷰로 판단한다", () => {
+    const userAgent =
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148";
+
+    expect(isLikelyWebViewUserAgent(userAgent)).toBe(true);
+  });
+
+  it("알려진 인앱 브라우저 user-agent를 웹뷰로 판단한다", () => {
+    const userAgent =
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1 Instagram 312.0.0.0.0";
+
+    expect(isLikelyWebViewUserAgent(userAgent)).toBe(true);
+  });
+
+  it("일반 Chrome 브라우저 user-agent는 웹뷰로 판단하지 않는다", () => {
+    const userAgent =
+      "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36";
+
+    expect(isLikelyWebViewUserAgent(userAgent)).toBe(false);
+  });
+});
+
+describe("isAndroidUserAgent", () => {
+  it("Android user-agent 여부를 판단한다", () => {
+    expect(isAndroidUserAgent("Mozilla/5.0 (Linux; Android 13)")).toBe(true);
+    expect(isAndroidUserAgent("Mozilla/5.0 (iPhone; CPU iPhone OS 17_2)")).toBe(
+      false,
+    );
+  });
+});

--- a/lib/auth/webview.ts
+++ b/lib/auth/webview.ts
@@ -1,0 +1,46 @@
+const KNOWN_IN_APP_BROWSER_PATTERNS = [
+  /FBAN|FBAV|FB_IAB/i,
+  /Instagram/i,
+  /KAKAOTALK/i,
+  /Line\//i,
+  /NAVER/i,
+  /Twitter/i,
+];
+
+export function isAndroidUserAgent(userAgent: string): boolean {
+  return /Android/i.test(userAgent);
+}
+
+export function isLikelyWebViewUserAgent(userAgent: string): boolean {
+  if (!userAgent) {
+    return false;
+  }
+
+  return (
+    isAndroidWebViewUserAgent(userAgent) ||
+    isIosWebViewUserAgent(userAgent) ||
+    isKnownInAppBrowserUserAgent(userAgent)
+  );
+}
+
+function isAndroidWebViewUserAgent(userAgent: string): boolean {
+  return isAndroidUserAgent(userAgent) && /\bwv\b/i.test(userAgent);
+}
+
+function isIosWebViewUserAgent(userAgent: string): boolean {
+  const isIos = /iPhone|iPad|iPod/i.test(userAgent);
+  const hasAppleWebKit = /AppleWebKit/i.test(userAgent);
+  const hasMobile = /Mobile/i.test(userAgent);
+  const hasSafari = /Safari/i.test(userAgent);
+  const isStandaloneBrowser = /CriOS|EdgiOS|FxiOS/i.test(userAgent);
+
+  return (
+    isIos && hasAppleWebKit && hasMobile && !hasSafari && !isStandaloneBrowser
+  );
+}
+
+function isKnownInAppBrowserUserAgent(userAgent: string): boolean {
+  return KNOWN_IN_APP_BROWSER_PATTERNS.some((pattern) => {
+    return pattern.test(userAgent);
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -65,6 +65,7 @@ export default defineConfig({
           environment: "node",
           include: [
             "lib/utils/**/*.test.ts",
+            "lib/auth/**/*.test.ts",
             "lib/adapters/**/*.test.ts",
             "lib/actions/**/*.test.ts",
           ],


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #403

## 📌 작업 내용

- 웹뷰 user-agent 감지 유틸을 추가해 Android WebView, iOS WebView, 주요 인앱 브라우저를 판별하도록 구성
- 로그인 화면에서 웹뷰로 판단되면 Google 로그인 버튼 대신 외부 브라우저 사용 안내와 주소 복사 액션을 노출
- OAuth 시작 라우트에서도 웹뷰 요청을 `/login?webview=1`로 되돌려 실패 가능한 소셜 로그인 진입을 방지
- 웹뷰 감지 단위 테스트를 추가하고 Vitest unit 대상에 `lib/auth` 테스트를 포함


