### PR TITLE
refactor: 로그인 화면 안내 구조 정리(#405)

### DIFF
--- a/app/login/_components/LoginActions.tsx
+++ b/app/login/_components/LoginActions.tsx
@@ -7,6 +7,8 @@ import { isLikelyWebViewUserAgent } from "@/lib/auth/webview";
 import { GoogleLoginButton } from "./GoogleLoginButton";
 import { WebViewLoginNotice } from "./WebViewLoginNotice";
 
+const PRIVACY_PAGE_HREF = "/privacy";
+
 type LoginActionsProps = {
   shouldShowWebViewNotice: boolean;
 };
@@ -19,7 +21,25 @@ export function LoginActions({ shouldShowWebViewNotice }: LoginActionsProps) {
     return <WebViewLoginNotice />;
   }
 
-  return <GoogleLoginButton />;
+  return (
+    <>
+      <GoogleLoginButton />
+      <div className="flex justify-center px-1">
+        <p className="text-center text-sm leading-5 font-medium text-muted-foreground">
+          <span>계속 진행하면 </span>
+          <a
+            className="font-semibold text-primary underline underline-offset-4"
+            href={PRIVACY_PAGE_HREF}
+          >
+            개인정보처리방침
+          </a>
+          <span>에</span>
+          <br />
+          <span>동의한 것으로 간주됩니다.</span>
+        </p>
+      </div>
+    </>
+  );
 }
 
 function getClientWebViewDetectionSnapshot(): boolean {

--- a/app/login/_components/WebViewLoginNotice.tsx
+++ b/app/login/_components/WebViewLoginNotice.tsx
@@ -62,10 +62,7 @@ export function WebViewLoginNotice() {
   const isCopied = copyStatus === "copied";
 
   return (
-    <section
-      aria-labelledby="webview-login-title"
-      className="rounded-2xl border border-primary/15 bg-primary/5 p-4 text-left"
-    >
+    <section aria-labelledby="webview-login-title" className="text-left">
       <div className="flex gap-3">
         <span
           aria-hidden="true"
@@ -82,8 +79,9 @@ export function WebViewLoginNotice() {
             외부 브라우저에서 로그인이 필요합니다.
           </h2>
           <p className="mt-2 text-sm leading-6 font-medium text-muted-foreground">
-            현재 앱 내 브라우저에서는 Google 로그인이 제한될 수 있습니다. Safari
-            또는 Chrome에서 다시 열어 주십시오.
+            현재 앱 내 브라우저에서는 Google 로그인이 제한될 수 있습니다.
+            <br />
+            Safari 또는 Chrome에서 다시 열어 주세요.
           </p>
 
           <div className="mt-4 flex flex-col gap-2">
@@ -119,8 +117,8 @@ export function WebViewLoginNotice() {
             className="mt-3 text-xs leading-5 font-medium text-muted-foreground"
           >
             {isAndroid
-              ? "Chrome으로 열기가 동작하지 않으면 주소를 복사해 외부 브라우저에 붙여넣어 주십시오."
-              : "iPhone에서는 공유 버튼을 누른 뒤 Safari에서 열기를 선택해 주십시오."}
+              ? "Chrome으로 열기가 동작하지 않으면 주소를 복사해 외부 브라우저에 붙여넣어 주세요."
+              : "iPhone에서는 공유 버튼을 누른 뒤 Safari에서 열기를 선택해 주세요."}
           </p>
         </div>
       </div>
@@ -129,38 +127,12 @@ export function WebViewLoginNotice() {
 }
 
 async function copyTextToClipboard(text: string): Promise<boolean> {
-  if (window.navigator.clipboard?.writeText) {
-    try {
-      await window.navigator.clipboard.writeText(text);
-
-      return true;
-    } catch {
-      return copyTextWithHiddenTextArea(text);
-    }
-  }
-
-  return copyTextWithHiddenTextArea(text);
-}
-
-function copyTextWithHiddenTextArea(text: string): boolean {
-  const textArea = window.document.createElement("textarea");
-
-  textArea.value = text;
-  textArea.setAttribute("readonly", "");
-  textArea.style.left = "-9999px";
-  textArea.style.position = "fixed";
-  textArea.style.top = "0";
-
-  window.document.body.append(textArea);
-  textArea.focus();
-  textArea.select();
-
   try {
-    return window.document.execCommand("copy");
+    await window.navigator.clipboard.writeText(text);
+
+    return true;
   } catch {
     return false;
-  } finally {
-    textArea.remove();
   }
 }
 

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,7 +1,6 @@
 import { PublicHeader } from "../_components/PublicHeader";
 import { LoginActions } from "./_components/LoginActions";
 
-const PRIVACY_PAGE_HREF = "/privacy";
 const WEBVIEW_QUERY_VALUE = "1";
 
 type LoginPageProps = {
@@ -14,15 +13,12 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
     getFirstSearchParam(resolvedSearchParams?.webview) === WEBVIEW_QUERY_VALUE;
 
   return (
-    <div className="flex h-dvh flex-col bg-muted/30">
+    <div className="flex h-dvh flex-col bg-background">
       <PublicHeader />
       <div className="flex flex-1 flex-col items-center justify-center px-5 pb-20">
-        <div className="w-full max-w-sm rounded-[32px] border border-border/50 bg-background p-10 shadow-xl shadow-black/[0.03]">
+        <div className="w-full max-w-sm">
           <header className="mb-10 text-center">
-            <span className="text-[11px] font-bold tracking-[0.2em] text-primary uppercase">
-              Welcome
-            </span>
-            <h1 className="mt-3 text-[32px] font-bold tracking-tight text-foreground">
+            <h1 className="text-[32px] font-bold tracking-tight text-foreground">
               로그인
             </h1>
             <p className="mt-2 text-sm font-medium text-muted-foreground">
@@ -32,19 +28,6 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
 
           <div className="space-y-4">
             <LoginActions shouldShowWebViewNotice={shouldShowWebViewNotice} />
-
-            <div className="flex justify-center px-1">
-              <p className="inline-flex flex-wrap items-center justify-center gap-x-1 text-center text-sm leading-5 font-medium text-muted-foreground">
-                <span>계속 진행하면</span>
-                <a
-                  className="font-semibold text-primary underline underline-offset-4"
-                  href={PRIVACY_PAGE_HREF}
-                >
-                  개인정보처리방침
-                </a>
-                <span>에 동의한 것으로 간주됩니다.</span>
-              </p>
-            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #405

## 📌 작업 내용

- 로그인 화면의 카드형 배경을 제거해 페이지 구조를 더 단순하게 정리
- 개인정보처리방침 동의 안내를 일반 로그인 액션 영역으로 이동해 웹뷰 차단 상태에서는 표시하지 않도록 조정
- 웹뷰 로그인 안내 문구와 여백을 정리하고 클립보드 복사 처리를 기본 Clipboard API 기준으로 단순화


