### PR TITLE
perf: 보호 페이지 인증 컨텍스트 중복 조회 제거(#408)

### DIFF
--- a/lib/actions/__tests__/_auth.test.ts
+++ b/lib/actions/__tests__/_auth.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getAuthenticatedUserId } from "../_auth";
+
+const mockGetClaims = vi.fn();
+const { mockTrackAuthenticatedUserActivity } = vi.hoisted(() => ({
+  mockTrackAuthenticatedUserActivity: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics/server", () => ({
+  trackAuthenticatedUserActivity: mockTrackAuthenticatedUserActivity,
+}));
+
+describe("getAuthenticatedUserId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("전달된 access token으로 claims를 검증한다", async () => {
+    mockGetClaims.mockResolvedValue({
+      data: { claims: { sub: "user-1" } },
+      error: null,
+    });
+
+    const result = await getAuthenticatedUserId(
+      {
+        auth: {
+          getClaims: mockGetClaims,
+        },
+      } as never,
+      "access-token",
+    );
+
+    expect(mockGetClaims).toHaveBeenCalledWith("access-token");
+    expect(mockTrackAuthenticatedUserActivity).toHaveBeenCalledWith("user-1");
+    expect(result).toEqual({
+      ok: true,
+      userId: "user-1",
+    });
+  });
+
+  it("token 없이 호출되면 기존처럼 claims를 직접 조회한다", async () => {
+    mockGetClaims.mockResolvedValue({
+      data: { claims: { sub: "user-2" } },
+      error: null,
+    });
+
+    await getAuthenticatedUserId({
+      auth: {
+        getClaims: mockGetClaims,
+      },
+    } as never);
+
+    expect(mockGetClaims).toHaveBeenCalledWith(undefined);
+  });
+
+  it("claims 검증에 실패하면 인증 실패를 반환한다", async () => {
+    mockGetClaims.mockResolvedValue({
+      data: { claims: null },
+      error: { message: "invalid token" },
+    });
+
+    const result = await getAuthenticatedUserId(
+      {
+        auth: {
+          getClaims: mockGetClaims,
+        },
+      } as never,
+      "expired-token",
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "로그인이 필요합니다.",
+    });
+    expect(mockTrackAuthenticatedUserActivity).not.toHaveBeenCalled();
+  });
+});

--- a/lib/actions/_auth.ts
+++ b/lib/actions/_auth.ts
@@ -20,8 +20,9 @@ type ServerSupabaseClient = Awaited<ReturnType<typeof createClient>>;
 
 export async function getAuthenticatedUserId(
   supabase: ServerSupabaseClient,
+  accessToken?: string,
 ): Promise<AuthenticatedUserIdResult> {
-  const { data, error } = await supabase.auth.getClaims();
+  const { data, error } = await supabase.auth.getClaims(accessToken);
   const userId = data?.claims?.sub;
 
   if (error || typeof userId !== "string" || userId.length === 0) {

--- a/lib/actions/_authContext.ts
+++ b/lib/actions/_authContext.ts
@@ -13,17 +13,17 @@ export type AuthContextResult =
 
 export const getAuthContext = cache(async (): Promise<AuthContextResult> => {
   const supabase = await createClient();
-  const authResult = await getAuthenticatedUserId(supabase);
-
-  if (!authResult.ok) {
-    return { ok: false, reason: authResult.reason };
-  }
-
   const { data: sessionData } = await supabase.auth.getSession();
   const accessToken = sessionData.session?.access_token;
 
   if (!accessToken) {
     return { ok: false, reason: AUTH_REQUIRED_REASON };
+  }
+
+  const authResult = await getAuthenticatedUserId(supabase, accessToken);
+
+  if (!authResult.ok) {
+    return { ok: false, reason: authResult.reason };
   }
 
   return { accessToken, ok: true, userId: authResult.userId };


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #408

## 📌 작업 내용

- 서버 인증 컨텍스트에서 세션을 한 번만 조회하고 access token 기반으로 claims를 검증하도록 흐름을 정리
- dashboard와 applications를 포함한 보호 페이지 공통 경로에서 중복 인증 확인 비용을 줄여 idle 후 첫 진입 시 불필요한 지연을 완화
- getAuthenticatedUserId와 auth context 동작을 검증하는 테스트를 추가해 인증 회귀를 방지


