### PR TITLE
fix: 지원 탭 개수 집계 기준 수정(#413)

### DIFF
--- a/app/(protected)/applications/_components/components/ApplicationTabs.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationTabs.tsx
@@ -3,13 +3,16 @@
 import { useId, useImperativeHandle, useRef } from "react";
 
 import type { VirtualListHandle } from "@/components/ui/virtual-list";
+import type {
+  ApplicationListItem,
+  ApplicationTabCounts,
+} from "@/lib/types/application";
 
 import { trackEvent } from "@/lib/analytics/client";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { cn } from "@/lib/utils";
 
 import type { TabValue } from "../constants";
-import type { ApplicationListItem } from "../types";
 
 import { DONE_STATUSES, IN_PROGRESS_STATUSES } from "../constants";
 import { ApplicationList } from "./ApplicationList";
@@ -27,6 +30,7 @@ export type ApplicationTabsHandle = {
 type ApplicationTabsProps = {
   applications: ApplicationListItem[];
   className?: string;
+  counts: ApplicationTabCounts;
   isFetchingNextPage?: boolean;
   listResetKey?: number | string;
   onNearEndAction?: () => void;
@@ -40,6 +44,7 @@ type ApplicationTabsProps = {
 export function ApplicationTabs({
   applications,
   className,
+  counts,
   isFetchingNextPage,
   listResetKey,
   onNearEndAction,
@@ -64,9 +69,9 @@ export function ApplicationTabs({
     label: string;
     value: TabValue;
   }> = [
-    { count: applications.length, label: "전체", value: "all" },
-    { count: inProgressApplications.length, label: "진행중", value: "active" },
-    { count: doneApplications.length, label: "완료", value: "done" },
+    { count: counts.all, label: "전체", value: "all" },
+    { count: counts.active, label: "진행중", value: "active" },
+    { count: counts.done, label: "완료", value: "done" },
   ];
   const selectedApplications = getApplicationsByTab({
     active: inProgressApplications,

--- a/app/(protected)/applications/_components/components/ApplicationsPanelClient.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanelClient.tsx
@@ -10,6 +10,7 @@ import { flushSync } from "react-dom";
 
 import type {
   ApplicationListItem,
+  ApplicationTabCounts,
   GetApplicationsPage,
 } from "@/lib/types/application";
 import type { JobStatus } from "@/lib/types/job";
@@ -21,7 +22,7 @@ import type { PeriodPreset, SortValue, TabValue } from "../constants";
 import type { ApplicationTabsHandle } from "./ApplicationTabs";
 
 import { buildApplicationsHref } from "../../_utils/route-state";
-import { PAGE_SIZE } from "../constants";
+import { DONE_STATUSES, IN_PROGRESS_STATUSES, PAGE_SIZE } from "../constants";
 import { GoToTopFAB } from "../go-to-top";
 import { ApplicationTabs } from "./ApplicationTabs";
 
@@ -76,6 +77,9 @@ export function ApplicationsPanelClient({
   >(previewApplicationId);
   const [pages, setPages] = useState<GetApplicationsPage[]>([initialPage]);
   const [paginationError, setPaginationError] = useState<null | string>(null);
+  const [tabCounts, setTabCounts] = useState<ApplicationTabCounts>(
+    initialPage.tabCounts,
+  );
 
   const applications = pages.flatMap((page) => page.items);
   const hasNextPage = pages[pages.length - 1]?.hasMore ?? false;
@@ -100,6 +104,7 @@ export function ApplicationsPanelClient({
     initialPageRef.current = initialPage;
     paginationSequenceRef.current += 1;
     setPages([initialPage]);
+    setTabCounts(initialPage.tabCounts);
     setPaginationError(null);
     setIsFetchingNextPage(false);
     setIsListScrolled(false);
@@ -177,6 +182,10 @@ export function ApplicationsPanelClient({
   }
 
   function handleStatusChange(applicationId: string, nextStatus: JobStatus) {
+    const previousStatus =
+      applications.find((application) => application.id === applicationId)
+        ?.status ?? null;
+
     setPages((currentPages) =>
       currentPages.map((page) => ({
         ...page,
@@ -189,9 +198,23 @@ export function ApplicationsPanelClient({
         }),
       })),
     );
+
+    if (previousStatus !== null && previousStatus !== nextStatus) {
+      setTabCounts((currentCounts) =>
+        getStatusChangeTabCounts({
+          counts: currentCounts,
+          nextStatus,
+          previousStatus,
+        }),
+      );
+    }
   }
 
   function handleDeleteApplication(applicationId: string) {
+    const deletedApplication =
+      applications.find((application) => application.id === applicationId) ??
+      null;
+
     setIsNavigatingFromPreview(false);
     setLocalPreviewApplicationId(null);
     setPages((currentPages) =>
@@ -200,6 +223,11 @@ export function ApplicationsPanelClient({
         items: page.items.filter((item) => item.id !== applicationId),
       })),
     );
+    if (deletedApplication !== null) {
+      setTabCounts((currentCounts) =>
+        getDeleteTabCounts(currentCounts, deletedApplication.status),
+      );
+    }
     updatePreviewHistory(null);
     router.refresh();
   }
@@ -242,6 +270,7 @@ export function ApplicationsPanelClient({
       <ApplicationTabs
         applications={applications}
         className="h-[32rem] min-h-0 sm:h-[36rem] lg:h-[40rem]"
+        counts={tabCounts}
         isFetchingNextPage={isFetchingNextPage}
         listResetKey={listResetVersion}
         onNearEndAction={() => {
@@ -302,4 +331,56 @@ export function ApplicationsPanelClient({
       />
     </>
   );
+}
+
+function getDeleteTabCounts(
+  counts: ApplicationTabCounts,
+  deletedStatus: JobStatus,
+): ApplicationTabCounts {
+  return {
+    active: Math.max(
+      0,
+      counts.active - (IN_PROGRESS_STATUSES.includes(deletedStatus) ? 1 : 0),
+    ),
+    all: Math.max(0, counts.all - 1),
+    done: Math.max(
+      0,
+      counts.done - (DONE_STATUSES.includes(deletedStatus) ? 1 : 0),
+    ),
+  };
+}
+
+function getStatusChangeTabCounts({
+  counts,
+  nextStatus,
+  previousStatus,
+}: {
+  counts: ApplicationTabCounts;
+  nextStatus: JobStatus;
+  previousStatus: JobStatus;
+}): ApplicationTabCounts {
+  return {
+    active:
+      counts.active +
+      getStatusGroupDelta(previousStatus, nextStatus, IN_PROGRESS_STATUSES),
+    all: counts.all,
+    done:
+      counts.done +
+      getStatusGroupDelta(previousStatus, nextStatus, DONE_STATUSES),
+  };
+}
+
+function getStatusGroupDelta(
+  previousStatus: JobStatus,
+  nextStatus: JobStatus,
+  statuses: readonly JobStatus[],
+): number {
+  const wasIncluded = statuses.includes(previousStatus);
+  const isIncluded = statuses.includes(nextStatus);
+
+  if (wasIncluded === isIncluded) {
+    return 0;
+  }
+
+  return isIncluded ? 1 : -1;
 }

--- a/app/(protected)/applications/_components/constants.ts
+++ b/app/(protected)/applications/_components/constants.ts
@@ -1,6 +1,11 @@
-import { APPLICATION_STATUS_META } from "@/lib/constants/application-status";
+import type { JobStatus } from "@/lib/types/job";
+
+import {
+  APPLICATION_ACTIVE_STATUSES,
+  APPLICATION_DONE_STATUSES,
+  APPLICATION_STATUS_META,
+} from "@/lib/constants/application-status";
 import { PLATFORM_LABEL } from "@/lib/constants/job-platform";
-import { JobStatus } from "@/lib/types/job";
 
 export const STATUS_META = APPLICATION_STATUS_META;
 
@@ -9,12 +14,9 @@ export { PLATFORM_LABEL };
 export { DOCS_STATUSES } from "@/lib/constants/application-status";
 
 export const IN_PROGRESS_STATUSES: JobStatus[] = [
-  "SAVED",
-  "APPLIED",
-  "DOCS_PASSED",
-  "INTERVIEWING",
+  ...APPLICATION_ACTIVE_STATUSES,
 ];
-export const DONE_STATUSES: JobStatus[] = ["OFFERED", "REJECTED"];
+export const DONE_STATUSES: JobStatus[] = [...APPLICATION_DONE_STATUSES];
 
 /**
  * 한 페이지에 로드할 지원서 수

--- a/lib/actions/getApplications.ts
+++ b/lib/actions/getApplications.ts
@@ -4,8 +4,14 @@ import { unstable_cache } from "next/cache";
 
 import type {
   ApplicationListItem,
+  ApplicationTabCounts,
   GetApplicationsResult,
 } from "@/lib/types/application";
+
+import {
+  APPLICATION_ACTIVE_STATUSES,
+  APPLICATION_DONE_STATUSES,
+} from "@/lib/constants/application-status";
 
 import { createClientWithToken } from "../supabase/server";
 import { getAuthContext } from "./_authContext";
@@ -16,6 +22,7 @@ import { reportQueryError } from "./_reportQueryError";
 type ApplicationsPage = {
   hasMore: boolean;
   items: ApplicationListItem[];
+  tabCounts: ApplicationTabCounts;
 };
 
 type ApplicationsQueryParams = {
@@ -76,12 +83,39 @@ export async function getApplications(
         query = query.lte("applied_at", periodEnd);
       }
 
-      const { data, error } = await query;
+      let countQuery = supabase
+        .from("applications")
+        .select("status")
+        .eq("user_id", userId);
+
+      if (search) {
+        countQuery = countQuery.ilike("company_name", `%${search}%`);
+      }
+      if (periodStart) {
+        countQuery = countQuery.gte("applied_at", periodStart);
+      }
+      if (periodEnd) {
+        countQuery = countQuery.lte("applied_at", periodEnd);
+      }
+
+      const [itemsResult, countsResult] = await Promise.all([
+        query,
+        countQuery,
+      ]);
+      const { data, error } = itemsResult;
 
       if (error) {
         const reason = normalizeQueryError(error);
         if (error.code !== AUTH_ERROR_CODE) {
           reportQueryError("getApplications", reason);
+        }
+        throw new Error(reason);
+      }
+
+      if (countsResult.error) {
+        const reason = normalizeQueryError(countsResult.error);
+        if (countsResult.error.code !== AUTH_ERROR_CODE) {
+          reportQueryError("getApplications:counts", reason);
         }
         throw new Error(reason);
       }
@@ -98,8 +132,9 @@ export async function getApplications(
       // limit + 1개를 요청해 실제로 limit개만 반환하고, 초과분이 있으면 hasMore = true
       const hasMore = items.length > limit;
       const pageItems = hasMore ? items.slice(0, limit) : items;
+      const tabCounts = getApplicationTabCounts(countsResult.data ?? []);
 
-      return { hasMore, items: pageItems };
+      return { hasMore, items: pageItems, tabCounts };
     },
     ["applications-page", userId],
     { revalidate: 60, tags: getApplicationsCacheTags(userId) },
@@ -112,4 +147,27 @@ export async function getApplications(
     const reason = e instanceof Error ? e.message : "알 수 없는 오류";
     return { code: "QUERY_ERROR", ok: false, reason };
   }
+}
+
+function getApplicationTabCounts(
+  rows: Array<{ status: ApplicationListItem["status"] }>,
+): ApplicationTabCounts {
+  let active = 0;
+  let done = 0;
+
+  for (const row of rows) {
+    if (APPLICATION_ACTIVE_STATUSES.includes(row.status)) {
+      active++;
+    }
+
+    if (APPLICATION_DONE_STATUSES.includes(row.status)) {
+      done++;
+    }
+  }
+
+  return {
+    active,
+    all: rows.length,
+    done,
+  };
 }

--- a/lib/constants/application-status.ts
+++ b/lib/constants/application-status.ts
@@ -20,6 +20,18 @@ export const DOCS_PASSED_STATUSES = [
   "OFFERED",
 ] as const satisfies readonly JobStatus[];
 
+export const APPLICATION_ACTIVE_STATUSES: readonly JobStatus[] = [
+  "SAVED",
+  "APPLIED",
+  "DOCS_PASSED",
+  "INTERVIEWING",
+] as const;
+
+export const APPLICATION_DONE_STATUSES: readonly JobStatus[] = [
+  "OFFERED",
+  "REJECTED",
+] as const;
+
 export const INTERVIEW_STATUSES = [
   "INTERVIEWING",
   "OFFERED",

--- a/lib/types/application.ts
+++ b/lib/types/application.ts
@@ -35,6 +35,17 @@ export type ApplicationListItem = {
   status: JobStatus;
 };
 
+export type ApplicationTabCounts = {
+  active: number;
+  all: number;
+  done: number;
+};
+
+export type MonthlyCount = {
+  count: number;
+  month: string; // "YYYY-MM" 형식
+};
+
 export const applicationDetailSchema = z
   .object({
     appliedAt: z.string(),
@@ -125,6 +136,7 @@ export type GetApplicationsErrorCode = "AUTH_REQUIRED" | "QUERY_ERROR";
 export type GetApplicationsPage = {
   hasMore: boolean;
   items: ApplicationListItem[];
+  tabCounts: ApplicationTabCounts;
 };
 
 export type GetApplicationsResult =
@@ -154,11 +166,6 @@ export type GetStatCountsErrorCode = "AUTH_REQUIRED" | "QUERY_ERROR";
 export type GetStatCountsResult =
   | { code: GetStatCountsErrorCode; ok: false; reason: string }
   | { data: StatCounts; ok: true };
-
-export type MonthlyCount = {
-  count: number;
-  month: string; // "YYYY-MM" 형식
-};
 
 export type StatCounts = {
   applied: number;


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #413

## 📌 작업 내용

- 지원 목록 탭 배지가 현재 로드된 페이지 수가 아니라 필터 조건에 맞는 전체 집계 기준으로 표시되도록 수정
- 지원 목록 조회 응답에 전체, 진행중, 완료 탭 카운트를 포함
- 상태 변경과 삭제 이후에도 로컬 탭 카운트를 즉시 보정해 UI 표시가 어긋나지 않도록 처리
- 지원 상태 그룹 상수를 공유해 서버 집계와 클라이언트 표시 기준을 일치시킴


