### PR TITLE
perf: 대시보드 데이터 조회 경로 단일화(#415)

### DIFF
--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 
-import { getChartData, getStatCounts } from "@/lib/actions";
+import { getDashboardData } from "@/lib/actions";
 
 import { DashboardCharts } from "./_components/dashboard-view/DashboardCharts";
 import { DashboardHeader } from "./_components/dashboard-view/DashboardHeader";
@@ -10,25 +10,33 @@ import {
   StatCardsSkeleton,
 } from "./_components/dashboard-view/DashboardSkeleton";
 
+type DashboardDataPromise = ReturnType<typeof getDashboardData>;
+
+type DashboardSectionProps = {
+  dataPromise: DashboardDataPromise;
+};
+
 export default function DashboardPage() {
+  const dashboardDataPromise = getDashboardData();
+
   return (
     <main className="min-h-screen bg-background pb-20">
       <DashboardHeader />
 
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 py-10 sm:px-6 lg:gap-20 lg:px-8 lg:py-12">
         <Suspense fallback={<StatCardsSkeleton />}>
-          <DashboardOverviewSection />
+          <DashboardOverviewSection dataPromise={dashboardDataPromise} />
         </Suspense>
         <Suspense fallback={<ChartsSkeleton />}>
-          <DashboardChartsSection />
+          <DashboardChartsSection dataPromise={dashboardDataPromise} />
         </Suspense>
       </div>
     </main>
   );
 }
 
-async function DashboardChartsSection() {
-  const result = await getChartData();
+async function DashboardChartsSection({ dataPromise }: DashboardSectionProps) {
+  const result = await dataPromise;
 
   if (!result.ok) {
     throw new Error(result.reason);
@@ -42,12 +50,14 @@ async function DashboardChartsSection() {
   );
 }
 
-async function DashboardOverviewSection() {
-  const result = await getStatCounts();
+async function DashboardOverviewSection({
+  dataPromise,
+}: DashboardSectionProps) {
+  const result = await dataPromise;
 
   if (!result.ok) {
     throw new Error(result.reason);
   }
 
-  return <DashboardOverview stats={result.data} />;
+  return <DashboardOverview stats={result.data.stats} />;
 }

--- a/lib/actions/getDashboardData.ts
+++ b/lib/actions/getDashboardData.ts
@@ -17,6 +17,7 @@ import {
 
 import { createClientWithToken } from "../supabase/server";
 import { getAuthContext } from "./_authContext";
+import { getApplicationsCacheTags } from "./_cacheTags";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 
@@ -24,34 +25,6 @@ type DashboardApplicationRow = {
   applied_at: null | string;
   status: JobStatus;
 };
-
-// cookies()를 사용하지 않으므로 unstable_cache 안에서 안전하게 실행됩니다.
-const getCachedDashboardData = unstable_cache(
-  async (userId: string, accessToken: string): Promise<DashboardData> => {
-    const supabase = createClientWithToken(accessToken);
-
-    const { data, error } = await supabase
-      .from("applications")
-      .select("applied_at, status")
-      .eq("user_id", userId);
-
-    if (error) {
-      const code =
-        error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
-      const reason = normalizeQueryError(error);
-
-      if (code === "QUERY_ERROR") {
-        reportQueryError("getDashboardData", reason);
-      }
-
-      throw new Error(reason);
-    }
-
-    return buildDashboardData(data ?? []);
-  },
-  ["dashboard-data"],
-  { revalidate: 60 },
-);
 
 export async function getDashboardData(): Promise<GetDashboardDataResult> {
   const authResult = await getAuthContext();
@@ -64,11 +37,38 @@ export async function getDashboardData(): Promise<GetDashboardDataResult> {
     };
   }
 
+  const { accessToken, userId } = authResult;
+
+  // cookies()를 사용하지 않으므로 unstable_cache 안에서 안전하게 실행됩니다.
+  const getCachedDashboardData = unstable_cache(
+    async (): Promise<DashboardData> => {
+      const supabase = createClientWithToken(accessToken);
+
+      const { data, error } = await supabase
+        .from("applications")
+        .select("applied_at, status")
+        .eq("user_id", userId);
+
+      if (error) {
+        const code =
+          error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
+        const reason = normalizeQueryError(error);
+
+        if (code === "QUERY_ERROR") {
+          reportQueryError("getDashboardData", reason);
+        }
+
+        throw new Error(reason);
+      }
+
+      return buildDashboardData(data ?? []);
+    },
+    ["dashboard-data", userId],
+    { revalidate: 60, tags: getApplicationsCacheTags(userId) },
+  );
+
   try {
-    const data = await getCachedDashboardData(
-      authResult.userId,
-      authResult.accessToken,
-    );
+    const data = await getCachedDashboardData();
 
     return { data, ok: true };
   } catch (e) {


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #415

## 📌 작업 내용

- 대시보드 KPI와 차트 섹션이 `getDashboardData` Promise 하나를 공유하도록 변경
- 분리되어 있던 통계/차트 조회를 단일 데이터 소스로 합쳐 인증 컨텍스트와 DB 조회 중복을 줄임
- 대시보드 캐시에 사용자별 application cache tag를 적용해 지원 데이터 변경 시 무효화 흐름을 유지


