### PR TITLE
perf: 대시보드 초기 클라이언트 청크 축소(#417)

### DIFF
--- a/app/(protected)/ProtectedProviders.tsx
+++ b/app/(protected)/ProtectedProviders.tsx
@@ -1,53 +1,58 @@
 "use client";
 
-import dynamic from "next/dynamic";
-import { useEffect, useState } from "react";
-
-const BottomTabBar = dynamic(
-  () =>
-    import("./_components/BottomTabBar").then((mod) => ({
-      default: mod.BottomTabBar,
-    })),
-  { ssr: false },
-);
-
-const WindowScrollTopFAB = dynamic(
-  () =>
-    import("./_components/WindowScrollTopFAB").then((mod) => ({
-      default: mod.WindowScrollTopFAB,
-    })),
-  { ssr: false },
-);
+import { type ComponentType, useEffect, useState } from "react";
 
 export function ProtectedEnhancements() {
-  const [shouldMount, setShouldMount] = useState(false);
+  const [BottomTabBar, setBottomTabBar] = useState<ComponentType | null>(null);
+  const [WindowScrollTopFAB, setWindowScrollTopFAB] =
+    useState<ComponentType | null>(null);
 
   useEffect(() => {
+    let isCancelled = false;
+
+    const mountEnhancements = () => {
+      void Promise.all([
+        import("./_components/BottomTabBar"),
+        import("./_components/WindowScrollTopFAB"),
+      ]).then(([bottomTabBarModule, windowScrollTopFabModule]) => {
+        if (isCancelled) {
+          return;
+        }
+
+        setBottomTabBar(() => bottomTabBarModule.BottomTabBar);
+        setWindowScrollTopFAB(
+          () => windowScrollTopFabModule.WindowScrollTopFAB,
+        );
+      });
+    };
+
     const requestIdle = window.requestIdleCallback;
 
     if (requestIdle) {
       const idleId = requestIdle(
         () => {
-          setShouldMount(true);
+          mountEnhancements();
         },
         { timeout: 1200 },
       );
 
       return () => {
+        isCancelled = true;
         window.cancelIdleCallback(idleId);
       };
     }
 
     const timeoutId = window.setTimeout(() => {
-      setShouldMount(true);
+      mountEnhancements();
     }, 400);
 
     return () => {
+      isCancelled = true;
       window.clearTimeout(timeoutId);
     };
   }, []);
 
-  if (!shouldMount) {
+  if (!BottomTabBar || !WindowScrollTopFAB) {
     return null;
   }
 

--- a/app/(protected)/dashboard/_components/dashboard-view/DashboardChartTooltip.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DashboardChartTooltip.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from "@/components/ui";
+import { Tooltip } from "@/components/ui/tooltip/Tooltip";
 
 export type DashboardChartTooltipState = {
   description?: string;

--- a/app/(protected)/dashboard/_components/dashboard-view/DashboardCharts.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DashboardCharts.tsx
@@ -2,8 +2,10 @@ import type { FunnelStep, MonthlyCount } from "@/lib/types/application";
 
 import { DashboardFunnelBreakdown } from "./DashboardFunnelBreakdown";
 import { DashboardInsightPanel } from "./DashboardInsightPanel";
-import { FunnelChart } from "./FunnelChart";
-import { MonthlyTrendChart } from "./MonthlyTrendChart";
+import {
+  DeferredFunnelChart,
+  DeferredMonthlyTrendChart,
+} from "./DeferredDashboardCharts";
 
 type Props = {
   funnel: FunnelStep[];
@@ -29,7 +31,7 @@ export function DashboardCharts({ funnel, monthly }: Props) {
               </p>
             </div>
           </div>
-          <MonthlyTrendChart data={monthly} />
+          <DeferredMonthlyTrendChart data={monthly} />
         </div>
 
         <DashboardInsightPanel funnel={funnel} monthly={monthly} />
@@ -48,7 +50,7 @@ export function DashboardCharts({ funnel, monthly }: Props) {
               전체 지원 수를 기준으로 각 단계에 몇 건이 남아 있는지 확인합니다.
             </p>
           </div>
-          <FunnelChart data={funnel} />
+          <DeferredFunnelChart data={funnel} />
         </div>
 
         <DashboardFunnelBreakdown data={funnel} />

--- a/app/(protected)/dashboard/_components/dashboard-view/DashboardSkeleton.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DashboardSkeleton.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from "@/components/ui";
+import { Skeleton } from "@/components/ui/skeleton/Skeleton";
 
 import { FUNNEL_CHART_HEIGHT, MONTHLY_CHART_HEIGHT } from "./constants";
 

--- a/app/(protected)/dashboard/_components/dashboard-view/DeferredDashboardCharts.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DeferredDashboardCharts.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import type { FunnelStep, MonthlyCount } from "@/lib/types/application";
+
+import { Skeleton } from "@/components/ui/skeleton/Skeleton";
+
+import { FUNNEL_CHART_HEIGHT, MONTHLY_CHART_HEIGHT } from "./constants";
+
+type DeferredFunnelChartProps = {
+  data: FunnelStep[];
+};
+
+type DeferredMonthlyTrendChartProps = {
+  data: MonthlyCount[];
+};
+
+const FunnelChartClient = dynamic(
+  () =>
+    import("./FunnelChart").then((mod) => ({
+      default: mod.FunnelChart,
+    })),
+  {
+    loading: FunnelChartFallback,
+    ssr: false,
+  },
+);
+
+const MonthlyTrendChartClient = dynamic(
+  () =>
+    import("./MonthlyTrendChart").then((mod) => ({
+      default: mod.MonthlyTrendChart,
+    })),
+  {
+    loading: MonthlyTrendChartFallback,
+    ssr: false,
+  },
+);
+
+export function DeferredFunnelChart({ data }: DeferredFunnelChartProps) {
+  return <FunnelChartClient data={data} />;
+}
+
+export function DeferredMonthlyTrendChart({
+  data,
+}: DeferredMonthlyTrendChartProps) {
+  return <MonthlyTrendChartClient data={data} />;
+}
+
+function FunnelChartFallback() {
+  return (
+    <Skeleton
+      aria-label="단계별 잔존 비율 차트를 불러오는 중입니다"
+      className="w-full"
+      style={{ height: FUNNEL_CHART_HEIGHT }}
+    />
+  );
+}
+
+function MonthlyTrendChartFallback() {
+  return (
+    <Skeleton
+      aria-label="월별 지원 추이 차트를 불러오는 중입니다"
+      className="w-full"
+      style={{ height: MONTHLY_CHART_HEIGHT }}
+    />
+  );
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #417

## 📌 작업 내용

- 대시보드 차트 컴포넌트를 지연 로드해 초기 페이지 엔트리에서 차트 상호작용 코드를 분리
- protected layout의 하단 탭과 상단 이동 FAB를 idle 이후 동적 import로 로드하도록 변경
- 대시보드 tooltip과 skeleton import를 직접 경로로 좁혀 공용 UI barrel이 불필요한 청크를 끌어오지 않도록 수정
- `/dashboard/page` 초기 entry에서 `db6247...` 청크가 제외되는 것을 build 산출물로 확인


