### PR TITLE
release: 지원 탭 개수 집계 수정, 대시보드 데이터 경로·초기 청크 최적화

### DIFF
--- a/app/(protected)/ProtectedProviders.tsx
+++ b/app/(protected)/ProtectedProviders.tsx
@@ -1,53 +1,58 @@
 "use client";
 
-import dynamic from "next/dynamic";
-import { useEffect, useState } from "react";
-
-const BottomTabBar = dynamic(
-  () =>
-    import("./_components/BottomTabBar").then((mod) => ({
-      default: mod.BottomTabBar,
-    })),
-  { ssr: false },
-);
-
-const WindowScrollTopFAB = dynamic(
-  () =>
-    import("./_components/WindowScrollTopFAB").then((mod) => ({
-      default: mod.WindowScrollTopFAB,
-    })),
-  { ssr: false },
-);
+import { type ComponentType, useEffect, useState } from "react";
 
 export function ProtectedEnhancements() {
-  const [shouldMount, setShouldMount] = useState(false);
+  const [BottomTabBar, setBottomTabBar] = useState<ComponentType | null>(null);
+  const [WindowScrollTopFAB, setWindowScrollTopFAB] =
+    useState<ComponentType | null>(null);
 
   useEffect(() => {
+    let isCancelled = false;
+
+    const mountEnhancements = () => {
+      void Promise.all([
+        import("./_components/BottomTabBar"),
+        import("./_components/WindowScrollTopFAB"),
+      ]).then(([bottomTabBarModule, windowScrollTopFabModule]) => {
+        if (isCancelled) {
+          return;
+        }
+
+        setBottomTabBar(() => bottomTabBarModule.BottomTabBar);
+        setWindowScrollTopFAB(
+          () => windowScrollTopFabModule.WindowScrollTopFAB,
+        );
+      });
+    };
+
     const requestIdle = window.requestIdleCallback;
 
     if (requestIdle) {
       const idleId = requestIdle(
         () => {
-          setShouldMount(true);
+          mountEnhancements();
         },
         { timeout: 1200 },
       );
 
       return () => {
+        isCancelled = true;
         window.cancelIdleCallback(idleId);
       };
     }
 
     const timeoutId = window.setTimeout(() => {
-      setShouldMount(true);
+      mountEnhancements();
     }, 400);
 
     return () => {
+      isCancelled = true;
       window.clearTimeout(timeoutId);
     };
   }, []);
 
-  if (!shouldMount) {
+  if (!BottomTabBar || !WindowScrollTopFAB) {
     return null;
   }
 

--- a/app/(protected)/applications/_components/components/ApplicationTabs.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationTabs.tsx
@@ -3,13 +3,16 @@
 import { useId, useImperativeHandle, useRef } from "react";
 
 import type { VirtualListHandle } from "@/components/ui/virtual-list";
+import type {
+  ApplicationListItem,
+  ApplicationTabCounts,
+} from "@/lib/types/application";
 
 import { trackEvent } from "@/lib/analytics/client";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { cn } from "@/lib/utils";
 
 import type { TabValue } from "../constants";
-import type { ApplicationListItem } from "../types";
 
 import { DONE_STATUSES, IN_PROGRESS_STATUSES } from "../constants";
 import { ApplicationList } from "./ApplicationList";
@@ -27,6 +30,7 @@ export type ApplicationTabsHandle = {
 type ApplicationTabsProps = {
   applications: ApplicationListItem[];
   className?: string;
+  counts: ApplicationTabCounts;
   isFetchingNextPage?: boolean;
   listResetKey?: number | string;
   onNearEndAction?: () => void;
@@ -40,6 +44,7 @@ type ApplicationTabsProps = {
 export function ApplicationTabs({
   applications,
   className,
+  counts,
   isFetchingNextPage,
   listResetKey,
   onNearEndAction,
@@ -64,9 +69,9 @@ export function ApplicationTabs({
     label: string;
     value: TabValue;
   }> = [
-    { count: applications.length, label: "전체", value: "all" },
-    { count: inProgressApplications.length, label: "진행중", value: "active" },
-    { count: doneApplications.length, label: "완료", value: "done" },
+    { count: counts.all, label: "전체", value: "all" },
+    { count: counts.active, label: "진행중", value: "active" },
+    { count: counts.done, label: "완료", value: "done" },
   ];
   const selectedApplications = getApplicationsByTab({
     active: inProgressApplications,

--- a/app/(protected)/applications/_components/components/ApplicationsPanelClient.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanelClient.tsx
@@ -10,6 +10,7 @@ import { flushSync } from "react-dom";
 
 import type {
   ApplicationListItem,
+  ApplicationTabCounts,
   GetApplicationsPage,
 } from "@/lib/types/application";
 import type { JobStatus } from "@/lib/types/job";
@@ -21,7 +22,7 @@ import type { PeriodPreset, SortValue, TabValue } from "../constants";
 import type { ApplicationTabsHandle } from "./ApplicationTabs";
 
 import { buildApplicationsHref } from "../../_utils/route-state";
-import { PAGE_SIZE } from "../constants";
+import { DONE_STATUSES, IN_PROGRESS_STATUSES, PAGE_SIZE } from "../constants";
 import { GoToTopFAB } from "../go-to-top";
 import { ApplicationTabs } from "./ApplicationTabs";
 
@@ -76,6 +77,9 @@ export function ApplicationsPanelClient({
   >(previewApplicationId);
   const [pages, setPages] = useState<GetApplicationsPage[]>([initialPage]);
   const [paginationError, setPaginationError] = useState<null | string>(null);
+  const [tabCounts, setTabCounts] = useState<ApplicationTabCounts>(
+    initialPage.tabCounts,
+  );
 
   const applications = pages.flatMap((page) => page.items);
   const hasNextPage = pages[pages.length - 1]?.hasMore ?? false;
@@ -100,6 +104,7 @@ export function ApplicationsPanelClient({
     initialPageRef.current = initialPage;
     paginationSequenceRef.current += 1;
     setPages([initialPage]);
+    setTabCounts(initialPage.tabCounts);
     setPaginationError(null);
     setIsFetchingNextPage(false);
     setIsListScrolled(false);
@@ -177,6 +182,10 @@ export function ApplicationsPanelClient({
   }
 
   function handleStatusChange(applicationId: string, nextStatus: JobStatus) {
+    const previousStatus =
+      applications.find((application) => application.id === applicationId)
+        ?.status ?? null;
+
     setPages((currentPages) =>
       currentPages.map((page) => ({
         ...page,
@@ -189,9 +198,23 @@ export function ApplicationsPanelClient({
         }),
       })),
     );
+
+    if (previousStatus !== null && previousStatus !== nextStatus) {
+      setTabCounts((currentCounts) =>
+        getStatusChangeTabCounts({
+          counts: currentCounts,
+          nextStatus,
+          previousStatus,
+        }),
+      );
+    }
   }
 
   function handleDeleteApplication(applicationId: string) {
+    const deletedApplication =
+      applications.find((application) => application.id === applicationId) ??
+      null;
+
     setIsNavigatingFromPreview(false);
     setLocalPreviewApplicationId(null);
     setPages((currentPages) =>
@@ -200,6 +223,11 @@ export function ApplicationsPanelClient({
         items: page.items.filter((item) => item.id !== applicationId),
       })),
     );
+    if (deletedApplication !== null) {
+      setTabCounts((currentCounts) =>
+        getDeleteTabCounts(currentCounts, deletedApplication.status),
+      );
+    }
     updatePreviewHistory(null);
     router.refresh();
   }
@@ -242,6 +270,7 @@ export function ApplicationsPanelClient({
       <ApplicationTabs
         applications={applications}
         className="h-[32rem] min-h-0 sm:h-[36rem] lg:h-[40rem]"
+        counts={tabCounts}
         isFetchingNextPage={isFetchingNextPage}
         listResetKey={listResetVersion}
         onNearEndAction={() => {
@@ -302,4 +331,56 @@ export function ApplicationsPanelClient({
       />
     </>
   );
+}
+
+function getDeleteTabCounts(
+  counts: ApplicationTabCounts,
+  deletedStatus: JobStatus,
+): ApplicationTabCounts {
+  return {
+    active: Math.max(
+      0,
+      counts.active - (IN_PROGRESS_STATUSES.includes(deletedStatus) ? 1 : 0),
+    ),
+    all: Math.max(0, counts.all - 1),
+    done: Math.max(
+      0,
+      counts.done - (DONE_STATUSES.includes(deletedStatus) ? 1 : 0),
+    ),
+  };
+}
+
+function getStatusChangeTabCounts({
+  counts,
+  nextStatus,
+  previousStatus,
+}: {
+  counts: ApplicationTabCounts;
+  nextStatus: JobStatus;
+  previousStatus: JobStatus;
+}): ApplicationTabCounts {
+  return {
+    active:
+      counts.active +
+      getStatusGroupDelta(previousStatus, nextStatus, IN_PROGRESS_STATUSES),
+    all: counts.all,
+    done:
+      counts.done +
+      getStatusGroupDelta(previousStatus, nextStatus, DONE_STATUSES),
+  };
+}
+
+function getStatusGroupDelta(
+  previousStatus: JobStatus,
+  nextStatus: JobStatus,
+  statuses: readonly JobStatus[],
+): number {
+  const wasIncluded = statuses.includes(previousStatus);
+  const isIncluded = statuses.includes(nextStatus);
+
+  if (wasIncluded === isIncluded) {
+    return 0;
+  }
+
+  return isIncluded ? 1 : -1;
 }

--- a/app/(protected)/applications/_components/constants.ts
+++ b/app/(protected)/applications/_components/constants.ts
@@ -1,6 +1,11 @@
-import { APPLICATION_STATUS_META } from "@/lib/constants/application-status";
+import type { JobStatus } from "@/lib/types/job";
+
+import {
+  APPLICATION_ACTIVE_STATUSES,
+  APPLICATION_DONE_STATUSES,
+  APPLICATION_STATUS_META,
+} from "@/lib/constants/application-status";
 import { PLATFORM_LABEL } from "@/lib/constants/job-platform";
-import { JobStatus } from "@/lib/types/job";
 
 export const STATUS_META = APPLICATION_STATUS_META;
 
@@ -9,12 +14,9 @@ export { PLATFORM_LABEL };
 export { DOCS_STATUSES } from "@/lib/constants/application-status";
 
 export const IN_PROGRESS_STATUSES: JobStatus[] = [
-  "SAVED",
-  "APPLIED",
-  "DOCS_PASSED",
-  "INTERVIEWING",
+  ...APPLICATION_ACTIVE_STATUSES,
 ];
-export const DONE_STATUSES: JobStatus[] = ["OFFERED", "REJECTED"];
+export const DONE_STATUSES: JobStatus[] = [...APPLICATION_DONE_STATUSES];
 
 /**
  * 한 페이지에 로드할 지원서 수

--- a/app/(protected)/dashboard/_components/dashboard-view/DashboardChartTooltip.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DashboardChartTooltip.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from "@/components/ui";
+import { Tooltip } from "@/components/ui/tooltip/Tooltip";
 
 export type DashboardChartTooltipState = {
   description?: string;

--- a/app/(protected)/dashboard/_components/dashboard-view/DashboardCharts.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DashboardCharts.tsx
@@ -2,8 +2,10 @@ import type { FunnelStep, MonthlyCount } from "@/lib/types/application";
 
 import { DashboardFunnelBreakdown } from "./DashboardFunnelBreakdown";
 import { DashboardInsightPanel } from "./DashboardInsightPanel";
-import { FunnelChart } from "./FunnelChart";
-import { MonthlyTrendChart } from "./MonthlyTrendChart";
+import {
+  DeferredFunnelChart,
+  DeferredMonthlyTrendChart,
+} from "./DeferredDashboardCharts";
 
 type Props = {
   funnel: FunnelStep[];
@@ -29,7 +31,7 @@ export function DashboardCharts({ funnel, monthly }: Props) {
               </p>
             </div>
           </div>
-          <MonthlyTrendChart data={monthly} />
+          <DeferredMonthlyTrendChart data={monthly} />
         </div>
 
         <DashboardInsightPanel funnel={funnel} monthly={monthly} />
@@ -48,7 +50,7 @@ export function DashboardCharts({ funnel, monthly }: Props) {
               전체 지원 수를 기준으로 각 단계에 몇 건이 남아 있는지 확인합니다.
             </p>
           </div>
-          <FunnelChart data={funnel} />
+          <DeferredFunnelChart data={funnel} />
         </div>
 
         <DashboardFunnelBreakdown data={funnel} />

--- a/app/(protected)/dashboard/_components/dashboard-view/DashboardSkeleton.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DashboardSkeleton.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from "@/components/ui";
+import { Skeleton } from "@/components/ui/skeleton/Skeleton";
 
 import { FUNNEL_CHART_HEIGHT, MONTHLY_CHART_HEIGHT } from "./constants";
 

--- a/app/(protected)/dashboard/_components/dashboard-view/DeferredDashboardCharts.tsx
+++ b/app/(protected)/dashboard/_components/dashboard-view/DeferredDashboardCharts.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import type { FunnelStep, MonthlyCount } from "@/lib/types/application";
+
+import { Skeleton } from "@/components/ui/skeleton/Skeleton";
+
+import { FUNNEL_CHART_HEIGHT, MONTHLY_CHART_HEIGHT } from "./constants";
+
+type DeferredFunnelChartProps = {
+  data: FunnelStep[];
+};
+
+type DeferredMonthlyTrendChartProps = {
+  data: MonthlyCount[];
+};
+
+const FunnelChartClient = dynamic(
+  () =>
+    import("./FunnelChart").then((mod) => ({
+      default: mod.FunnelChart,
+    })),
+  {
+    loading: FunnelChartFallback,
+    ssr: false,
+  },
+);
+
+const MonthlyTrendChartClient = dynamic(
+  () =>
+    import("./MonthlyTrendChart").then((mod) => ({
+      default: mod.MonthlyTrendChart,
+    })),
+  {
+    loading: MonthlyTrendChartFallback,
+    ssr: false,
+  },
+);
+
+export function DeferredFunnelChart({ data }: DeferredFunnelChartProps) {
+  return <FunnelChartClient data={data} />;
+}
+
+export function DeferredMonthlyTrendChart({
+  data,
+}: DeferredMonthlyTrendChartProps) {
+  return <MonthlyTrendChartClient data={data} />;
+}
+
+function FunnelChartFallback() {
+  return (
+    <Skeleton
+      aria-label="단계별 잔존 비율 차트를 불러오는 중입니다"
+      className="w-full"
+      style={{ height: FUNNEL_CHART_HEIGHT }}
+    />
+  );
+}
+
+function MonthlyTrendChartFallback() {
+  return (
+    <Skeleton
+      aria-label="월별 지원 추이 차트를 불러오는 중입니다"
+      className="w-full"
+      style={{ height: MONTHLY_CHART_HEIGHT }}
+    />
+  );
+}

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 
-import { getChartData, getStatCounts } from "@/lib/actions";
+import { getDashboardData } from "@/lib/actions";
 
 import { DashboardCharts } from "./_components/dashboard-view/DashboardCharts";
 import { DashboardHeader } from "./_components/dashboard-view/DashboardHeader";
@@ -10,25 +10,33 @@ import {
   StatCardsSkeleton,
 } from "./_components/dashboard-view/DashboardSkeleton";
 
+type DashboardDataPromise = ReturnType<typeof getDashboardData>;
+
+type DashboardSectionProps = {
+  dataPromise: DashboardDataPromise;
+};
+
 export default function DashboardPage() {
+  const dashboardDataPromise = getDashboardData();
+
   return (
     <main className="min-h-screen bg-background pb-20">
       <DashboardHeader />
 
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 py-10 sm:px-6 lg:gap-20 lg:px-8 lg:py-12">
         <Suspense fallback={<StatCardsSkeleton />}>
-          <DashboardOverviewSection />
+          <DashboardOverviewSection dataPromise={dashboardDataPromise} />
         </Suspense>
         <Suspense fallback={<ChartsSkeleton />}>
-          <DashboardChartsSection />
+          <DashboardChartsSection dataPromise={dashboardDataPromise} />
         </Suspense>
       </div>
     </main>
   );
 }
 
-async function DashboardChartsSection() {
-  const result = await getChartData();
+async function DashboardChartsSection({ dataPromise }: DashboardSectionProps) {
+  const result = await dataPromise;
 
   if (!result.ok) {
     throw new Error(result.reason);
@@ -42,12 +50,14 @@ async function DashboardChartsSection() {
   );
 }
 
-async function DashboardOverviewSection() {
-  const result = await getStatCounts();
+async function DashboardOverviewSection({
+  dataPromise,
+}: DashboardSectionProps) {
+  const result = await dataPromise;
 
   if (!result.ok) {
     throw new Error(result.reason);
   }
 
-  return <DashboardOverview stats={result.data} />;
+  return <DashboardOverview stats={result.data.stats} />;
 }

--- a/lib/actions/getApplications.ts
+++ b/lib/actions/getApplications.ts
@@ -4,8 +4,14 @@ import { unstable_cache } from "next/cache";
 
 import type {
   ApplicationListItem,
+  ApplicationTabCounts,
   GetApplicationsResult,
 } from "@/lib/types/application";
+
+import {
+  APPLICATION_ACTIVE_STATUSES,
+  APPLICATION_DONE_STATUSES,
+} from "@/lib/constants/application-status";
 
 import { createClientWithToken } from "../supabase/server";
 import { getAuthContext } from "./_authContext";
@@ -16,6 +22,7 @@ import { reportQueryError } from "./_reportQueryError";
 type ApplicationsPage = {
   hasMore: boolean;
   items: ApplicationListItem[];
+  tabCounts: ApplicationTabCounts;
 };
 
 type ApplicationsQueryParams = {
@@ -76,12 +83,39 @@ export async function getApplications(
         query = query.lte("applied_at", periodEnd);
       }
 
-      const { data, error } = await query;
+      let countQuery = supabase
+        .from("applications")
+        .select("status")
+        .eq("user_id", userId);
+
+      if (search) {
+        countQuery = countQuery.ilike("company_name", `%${search}%`);
+      }
+      if (periodStart) {
+        countQuery = countQuery.gte("applied_at", periodStart);
+      }
+      if (periodEnd) {
+        countQuery = countQuery.lte("applied_at", periodEnd);
+      }
+
+      const [itemsResult, countsResult] = await Promise.all([
+        query,
+        countQuery,
+      ]);
+      const { data, error } = itemsResult;
 
       if (error) {
         const reason = normalizeQueryError(error);
         if (error.code !== AUTH_ERROR_CODE) {
           reportQueryError("getApplications", reason);
+        }
+        throw new Error(reason);
+      }
+
+      if (countsResult.error) {
+        const reason = normalizeQueryError(countsResult.error);
+        if (countsResult.error.code !== AUTH_ERROR_CODE) {
+          reportQueryError("getApplications:counts", reason);
         }
         throw new Error(reason);
       }
@@ -98,8 +132,9 @@ export async function getApplications(
       // limit + 1개를 요청해 실제로 limit개만 반환하고, 초과분이 있으면 hasMore = true
       const hasMore = items.length > limit;
       const pageItems = hasMore ? items.slice(0, limit) : items;
+      const tabCounts = getApplicationTabCounts(countsResult.data ?? []);
 
-      return { hasMore, items: pageItems };
+      return { hasMore, items: pageItems, tabCounts };
     },
     ["applications-page", userId],
     { revalidate: 60, tags: getApplicationsCacheTags(userId) },
@@ -112,4 +147,27 @@ export async function getApplications(
     const reason = e instanceof Error ? e.message : "알 수 없는 오류";
     return { code: "QUERY_ERROR", ok: false, reason };
   }
+}
+
+function getApplicationTabCounts(
+  rows: Array<{ status: ApplicationListItem["status"] }>,
+): ApplicationTabCounts {
+  let active = 0;
+  let done = 0;
+
+  for (const row of rows) {
+    if (APPLICATION_ACTIVE_STATUSES.includes(row.status)) {
+      active++;
+    }
+
+    if (APPLICATION_DONE_STATUSES.includes(row.status)) {
+      done++;
+    }
+  }
+
+  return {
+    active,
+    all: rows.length,
+    done,
+  };
 }

--- a/lib/actions/getDashboardData.ts
+++ b/lib/actions/getDashboardData.ts
@@ -17,6 +17,7 @@ import {
 
 import { createClientWithToken } from "../supabase/server";
 import { getAuthContext } from "./_authContext";
+import { getApplicationsCacheTags } from "./_cacheTags";
 import { AUTH_ERROR_CODE, normalizeQueryError } from "./_queryError";
 import { reportQueryError } from "./_reportQueryError";
 
@@ -24,34 +25,6 @@ type DashboardApplicationRow = {
   applied_at: null | string;
   status: JobStatus;
 };
-
-// cookies()를 사용하지 않으므로 unstable_cache 안에서 안전하게 실행됩니다.
-const getCachedDashboardData = unstable_cache(
-  async (userId: string, accessToken: string): Promise<DashboardData> => {
-    const supabase = createClientWithToken(accessToken);
-
-    const { data, error } = await supabase
-      .from("applications")
-      .select("applied_at, status")
-      .eq("user_id", userId);
-
-    if (error) {
-      const code =
-        error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
-      const reason = normalizeQueryError(error);
-
-      if (code === "QUERY_ERROR") {
-        reportQueryError("getDashboardData", reason);
-      }
-
-      throw new Error(reason);
-    }
-
-    return buildDashboardData(data ?? []);
-  },
-  ["dashboard-data"],
-  { revalidate: 60 },
-);
 
 export async function getDashboardData(): Promise<GetDashboardDataResult> {
   const authResult = await getAuthContext();
@@ -64,11 +37,38 @@ export async function getDashboardData(): Promise<GetDashboardDataResult> {
     };
   }
 
+  const { accessToken, userId } = authResult;
+
+  // cookies()를 사용하지 않으므로 unstable_cache 안에서 안전하게 실행됩니다.
+  const getCachedDashboardData = unstable_cache(
+    async (): Promise<DashboardData> => {
+      const supabase = createClientWithToken(accessToken);
+
+      const { data, error } = await supabase
+        .from("applications")
+        .select("applied_at, status")
+        .eq("user_id", userId);
+
+      if (error) {
+        const code =
+          error.code === AUTH_ERROR_CODE ? "AUTH_REQUIRED" : "QUERY_ERROR";
+        const reason = normalizeQueryError(error);
+
+        if (code === "QUERY_ERROR") {
+          reportQueryError("getDashboardData", reason);
+        }
+
+        throw new Error(reason);
+      }
+
+      return buildDashboardData(data ?? []);
+    },
+    ["dashboard-data", userId],
+    { revalidate: 60, tags: getApplicationsCacheTags(userId) },
+  );
+
   try {
-    const data = await getCachedDashboardData(
-      authResult.userId,
-      authResult.accessToken,
-    );
+    const data = await getCachedDashboardData();
 
     return { data, ok: true };
   } catch (e) {

--- a/lib/constants/application-status.ts
+++ b/lib/constants/application-status.ts
@@ -20,6 +20,18 @@ export const DOCS_PASSED_STATUSES = [
   "OFFERED",
 ] as const satisfies readonly JobStatus[];
 
+export const APPLICATION_ACTIVE_STATUSES: readonly JobStatus[] = [
+  "SAVED",
+  "APPLIED",
+  "DOCS_PASSED",
+  "INTERVIEWING",
+] as const;
+
+export const APPLICATION_DONE_STATUSES: readonly JobStatus[] = [
+  "OFFERED",
+  "REJECTED",
+] as const;
+
 export const INTERVIEW_STATUSES = [
   "INTERVIEWING",
   "OFFERED",

--- a/lib/types/application.ts
+++ b/lib/types/application.ts
@@ -35,6 +35,17 @@ export type ApplicationListItem = {
   status: JobStatus;
 };
 
+export type ApplicationTabCounts = {
+  active: number;
+  all: number;
+  done: number;
+};
+
+export type MonthlyCount = {
+  count: number;
+  month: string; // "YYYY-MM" 형식
+};
+
 export const applicationDetailSchema = z
   .object({
     appliedAt: z.string(),
@@ -125,6 +136,7 @@ export type GetApplicationsErrorCode = "AUTH_REQUIRED" | "QUERY_ERROR";
 export type GetApplicationsPage = {
   hasMore: boolean;
   items: ApplicationListItem[];
+  tabCounts: ApplicationTabCounts;
 };
 
 export type GetApplicationsResult =
@@ -154,11 +166,6 @@ export type GetStatCountsErrorCode = "AUTH_REQUIRED" | "QUERY_ERROR";
 export type GetStatCountsResult =
   | { code: GetStatCountsErrorCode; ok: false; reason: string }
   | { data: StatCounts; ok: true };
-
-export type MonthlyCount = {
-  count: number;
-  month: string; // "YYYY-MM" 형식
-};
 
 export type StatCounts = {
   applied: number;


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #413, #415, #417

## 📌 작업 내용

- 지원 목록 탭 배지를 필터 조건에 맞는 전체 집계 기준으로 노출하고, 상태 변경·삭제 이후에도 로컬 탭 카운트를 즉시 보정하도록 정리해 표시 불일치를 해소
- 지원 목록 응답에 전체·진행중·완료 카운트를 포함하고 지원 상태 그룹 상수를 공유해 서버 집계와 클라이언트 표시 기준을 정렬
- 대시보드 KPI와 차트 섹션이 단일 `getDashboardData` Promise를 공유하도록 합쳐 인증 컨텍스트와 DB 조회 중복을 제거하고, 사용자별 application cache tag로 무효화 흐름을 유지
- 대시보드 차트와 protected layout의 하단 탭·상단 이동 FAB를 idle 이후 동적 import로 로드해 초기 페이지 엔트리에서 상호작용 코드를 분리
- 대시보드 tooltip·skeleton import 경로를 직접 지정해 공용 UI barrel이 불필요한 청크를 끌어오지 않도록 정리