### PR TITLE
perf: 모바일 하단 바 즉시 렌더링(#425)

### DIFF
--- a/app/(protected)/ProtectedProviders.tsx
+++ b/app/(protected)/ProtectedProviders.tsx
@@ -2,8 +2,9 @@
 
 import { type ComponentType, useEffect, useState } from "react";
 
+import { BottomTabBar } from "./_components/BottomTabBar";
+
 export function ProtectedEnhancements() {
-  const [BottomTabBar, setBottomTabBar] = useState<ComponentType | null>(null);
   const [WindowScrollTopFAB, setWindowScrollTopFAB] =
     useState<ComponentType | null>(null);
 
@@ -11,18 +12,12 @@ export function ProtectedEnhancements() {
     let isCancelled = false;
 
     const mountEnhancements = () => {
-      void Promise.all([
-        import("./_components/BottomTabBar"),
-        import("./_components/WindowScrollTopFAB"),
-      ]).then(([bottomTabBarModule, windowScrollTopFabModule]) => {
+      void import("./_components/WindowScrollTopFAB").then((module) => {
         if (isCancelled) {
           return;
         }
 
-        setBottomTabBar(() => bottomTabBarModule.BottomTabBar);
-        setWindowScrollTopFAB(
-          () => windowScrollTopFabModule.WindowScrollTopFAB,
-        );
+        setWindowScrollTopFAB(() => module.WindowScrollTopFAB);
       });
     };
 
@@ -52,14 +47,10 @@ export function ProtectedEnhancements() {
     };
   }, []);
 
-  if (!BottomTabBar || !WindowScrollTopFAB) {
-    return null;
-  }
-
   return (
     <>
       <BottomTabBar />
-      <WindowScrollTopFAB />
+      {WindowScrollTopFAB ? <WindowScrollTopFAB /> : null}
     </>
   );
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #425

## 📌 작업 내용

- 보호 레이아웃 보조 UI에서 BottomTabBar를 동적 import 대상에서 제외하고 정적 import로 전환
- WindowScrollTopFAB의 idle 기반 지연 로딩은 유지해 비핵심 스크롤 보조 기능만 늦게 로딩되도록 정리
- 하단 바가 FAB 로딩 완료를 기다리느라 모바일에서 늦게 표시되지 않도록 개선


