### PR TITLE
refactor: 대시보드 인증 컨텍스트 세션 조회 축소(#427)

### DIFF
--- a/lib/actions/_authContext.ts
+++ b/lib/actions/_authContext.ts
@@ -1,7 +1,8 @@
 import "server-only";
 import { cache } from "react";
 
-import { createClient } from "@/lib/supabase/server";
+import { createClientWithToken } from "@/lib/supabase/server";
+import { getSupabaseAccessTokenFromCookie } from "@/lib/supabase/session";
 
 import { getAuthenticatedUserId } from "./_auth";
 
@@ -12,14 +13,13 @@ export type AuthContextResult =
   | { ok: false; reason: string };
 
 export const getAuthContext = cache(async (): Promise<AuthContextResult> => {
-  const supabase = await createClient();
-  const { data: sessionData } = await supabase.auth.getSession();
-  const accessToken = sessionData.session?.access_token;
+  const accessToken = await getSupabaseAccessTokenFromCookie();
 
   if (!accessToken) {
     return { ok: false, reason: AUTH_REQUIRED_REASON };
   }
 
+  const supabase = createClientWithToken(accessToken);
   const authResult = await getAuthenticatedUserId(supabase, accessToken);
 
   if (!authResult.ok) {

--- a/lib/supabase/__tests__/session.test.ts
+++ b/lib/supabase/__tests__/session.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getSupabaseAccessTokenFromCookie } from "../session";
+
+const mockCookies = vi.hoisted(() => vi.fn());
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("next/headers", () => ({
+  cookies: mockCookies,
+}));
+
+const SUPABASE_URL = "https://project-ref.supabase.co";
+const AUTH_COOKIE_NAME = "sb-project-ref-auth-token";
+
+describe("getSupabaseAccessTokenFromCookie", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = SUPABASE_URL;
+  });
+
+  it("Supabase 세션 쿠키에서 access token을 읽는다", async () => {
+    mockCookies.mockResolvedValue({
+      getAll: () => [
+        {
+          name: AUTH_COOKIE_NAME,
+          value: JSON.stringify({ access_token: "access-token" }),
+        },
+      ],
+    });
+
+    await expect(getSupabaseAccessTokenFromCookie()).resolves.toBe(
+      "access-token",
+    );
+  });
+
+  it("base64url로 인코딩된 세션 쿠키를 디코딩한다", async () => {
+    mockCookies.mockResolvedValue({
+      getAll: () => [
+        {
+          name: AUTH_COOKIE_NAME,
+          value: `base64-${toBase64Url(
+            JSON.stringify({ access_token: "encoded-token" }),
+          )}`,
+        },
+      ],
+    });
+
+    await expect(getSupabaseAccessTokenFromCookie()).resolves.toBe(
+      "encoded-token",
+    );
+  });
+
+  it("chunk로 분리된 세션 쿠키를 합쳐서 읽는다", async () => {
+    const cookieValue = JSON.stringify({ access_token: "chunked-token" });
+
+    mockCookies.mockResolvedValue({
+      getAll: () => [
+        { name: `${AUTH_COOKIE_NAME}.0`, value: cookieValue.slice(0, 20) },
+        { name: `${AUTH_COOKIE_NAME}.1`, value: cookieValue.slice(20) },
+      ],
+    });
+
+    await expect(getSupabaseAccessTokenFromCookie()).resolves.toBe(
+      "chunked-token",
+    );
+  });
+
+  it("세션 쿠키가 없으면 null을 반환한다", async () => {
+    mockCookies.mockResolvedValue({
+      getAll: () => [],
+    });
+
+    await expect(getSupabaseAccessTokenFromCookie()).resolves.toBeNull();
+  });
+});
+
+function toBase64Url(value: string) {
+  return Buffer.from(value, "utf8").toString("base64url");
+}

--- a/lib/supabase/session.ts
+++ b/lib/supabase/session.ts
@@ -1,0 +1,104 @@
+import "server-only";
+import { cookies } from "next/headers";
+
+const AUTH_COOKIE_SUFFIX = "-auth-token";
+const BASE64_PREFIX = "base64-";
+
+type SupabaseSessionCookie = {
+  access_token?: unknown;
+};
+
+export async function getSupabaseAccessTokenFromCookie() {
+  const cookieStore = await cookies();
+  const authCookieName = getSupabaseAuthCookieName();
+  const cookieValue = combineCookieChunks(
+    authCookieName,
+    cookieStore.getAll().map(({ name, value }) => ({ name, value })),
+  );
+
+  if (!cookieValue) {
+    return null;
+  }
+
+  const decodedCookieValue = decodeSupabaseCookieValue(cookieValue);
+
+  if (!decodedCookieValue) {
+    return null;
+  }
+
+  try {
+    const session = JSON.parse(decodedCookieValue) as SupabaseSessionCookie;
+
+    if (typeof session.access_token !== "string") {
+      return null;
+    }
+
+    return session.access_token;
+  } catch {
+    return null;
+  }
+}
+
+function combineCookieChunks(
+  cookieName: string,
+  cookiesToRead: { name: string; value: string }[],
+) {
+  const unchunkedCookie = cookiesToRead.find(({ name }) => name === cookieName);
+
+  if (unchunkedCookie?.value) {
+    return unchunkedCookie.value;
+  }
+
+  const chunks: string[] = [];
+
+  for (let index = 0; ; index++) {
+    const chunkName = `${cookieName}.${index}`;
+    const chunk = cookiesToRead.find(({ name }) => name === chunkName);
+
+    if (!chunk?.value) {
+      break;
+    }
+
+    chunks.push(chunk.value);
+  }
+
+  if (chunks.length === 0) {
+    return null;
+  }
+
+  return chunks.join("");
+}
+
+function decodeBase64Url(value: string) {
+  const base64 = value.replaceAll("-", "+").replaceAll("_", "/");
+  const paddedBase64 = base64.padEnd(
+    base64.length + ((4 - (base64.length % 4)) % 4),
+    "=",
+  );
+
+  return Buffer.from(paddedBase64, "base64").toString("utf8");
+}
+
+function decodeSupabaseCookieValue(value: string) {
+  if (!value.startsWith(BASE64_PREFIX)) {
+    return value;
+  }
+
+  try {
+    return decodeBase64Url(value.slice(BASE64_PREFIX.length));
+  } catch {
+    return null;
+  }
+}
+
+function getSupabaseAuthCookieName() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+  if (!supabaseUrl) {
+    throw new Error("NEXT_PUBLIC_SUPABASE_URL is required.");
+  }
+
+  const projectRef = new URL(supabaseUrl).hostname.split(".")[0];
+
+  return `sb-${projectRef}${AUTH_COOKIE_SUFFIX}`;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -68,6 +68,7 @@ export default defineConfig({
             "lib/auth/**/*.test.ts",
             "lib/adapters/**/*.test.ts",
             "lib/actions/**/*.test.ts",
+            "lib/supabase/**/*.test.ts",
           ],
           name: "unit",
         },


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #427

## 📌 작업 내용

- Supabase 세션 쿠키에서 access token을 직접 읽는 서버 전용 헬퍼를 추가
- `getAuthContext`에서 `auth.getSession()` 호출을 제거하고 token 기반 클라이언트로 claims 검증을 수행
- base64url 및 chunked Supabase auth cookie 처리 테스트를 추가해 세션 쿠키 파싱 회귀를 방지
- Supabase 단위 테스트 경로를 Vitest 설정에 포함


