### PR TITLE
release: 지원 목록 레이아웃 시프트 완화, 모바일 하단 바·인증 컨텍스트 개선

### DIFF
--- a/app/(protected)/ProtectedProviders.tsx
+++ b/app/(protected)/ProtectedProviders.tsx
@@ -2,8 +2,9 @@
 
 import { type ComponentType, useEffect, useState } from "react";
 
+import { BottomTabBar } from "./_components/BottomTabBar";
+
 export function ProtectedEnhancements() {
-  const [BottomTabBar, setBottomTabBar] = useState<ComponentType | null>(null);
   const [WindowScrollTopFAB, setWindowScrollTopFAB] =
     useState<ComponentType | null>(null);
 
@@ -11,18 +12,12 @@ export function ProtectedEnhancements() {
     let isCancelled = false;
 
     const mountEnhancements = () => {
-      void Promise.all([
-        import("./_components/BottomTabBar"),
-        import("./_components/WindowScrollTopFAB"),
-      ]).then(([bottomTabBarModule, windowScrollTopFabModule]) => {
+      void import("./_components/WindowScrollTopFAB").then((module) => {
         if (isCancelled) {
           return;
         }
 
-        setBottomTabBar(() => bottomTabBarModule.BottomTabBar);
-        setWindowScrollTopFAB(
-          () => windowScrollTopFabModule.WindowScrollTopFAB,
-        );
+        setWindowScrollTopFAB(() => module.WindowScrollTopFAB);
       });
     };
 
@@ -52,14 +47,10 @@ export function ProtectedEnhancements() {
     };
   }, []);
 
-  if (!BottomTabBar || !WindowScrollTopFAB) {
-    return null;
-  }
-
   return (
     <>
       <BottomTabBar />
-      <WindowScrollTopFAB />
+      {WindowScrollTopFAB ? <WindowScrollTopFAB /> : null}
     </>
   );
 }

--- a/app/(protected)/applications/_components/components/ApplicationList.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationList.tsx
@@ -10,13 +10,13 @@ import type { ApplicationListItem } from "../types";
 import { ApplicationRow } from "./ApplicationRow";
 
 // ApplicationRow의 실측 전 초기 높이 추정값(px).
-// py-4(32) + 회사명(22.5) + 직군명(21) + gap-2(8) + 상태행(21) ≈ 105
-const ESTIMATED_ROW_HEIGHT = 105;
+// py-4(32) + 제목 영역(48) + gap-2.5(10) + 메타 행(20) + border-b(1) = 111
+const ESTIMATED_ROW_HEIGHT = 111;
 
 // 끝에서 몇 개 전에 다음 페이지를 미리 로드할지.
 const NEAR_END_THRESHOLD = 5;
-const LIST_BOTTOM_PADDING = 40;
 const PAGINATION_SKELETON_KEYS = [0, 1, 2] as const;
+const LIST_PADDING_BOTTOM = 40;
 
 type ApplicationListProps = {
   applications: ApplicationListItem[];
@@ -35,8 +35,8 @@ type ApplicationListRow =
       type: "application";
     }
   | {
-      key: number;
-      type: "pagination-skeleton";
+      id: string;
+      type: "skeleton";
     };
 
 export function ApplicationList({
@@ -56,15 +56,19 @@ export function ApplicationList({
     })),
     ...(isFetchingNextPage
       ? PAGINATION_SKELETON_KEYS.map((key) => ({
-          key,
-          type: "pagination-skeleton" as const,
+          id: `pagination-skeleton-${key}`,
+          type: "skeleton" as const,
         }))
       : []),
   ];
 
   const handleRangeChange = (startIndex: number, endIndex: number) => {
     onRangeChange?.(startIndex, endIndex);
-    if (onNearEnd && endIndex >= applications.length - NEAR_END_THRESHOLD) {
+    if (
+      onNearEnd &&
+      !isFetchingNextPage &&
+      endIndex >= applications.length - NEAR_END_THRESHOLD
+    ) {
       onNearEnd();
     }
   };
@@ -84,22 +88,24 @@ export function ApplicationList({
         emptyState={emptyState}
         estimatedItemHeight={ESTIMATED_ROW_HEIGHT}
         items={rows}
-        keyExtractor={(row) =>
-          row.type === "application"
-            ? row.application.id
-            : `pagination-skeleton-${row.key}`
+        keyExtractor={(item) =>
+          item.type === "application" ? item.application.id : item.id
         }
         onRangeChange={handleRangeChange}
-        paddingBottom={LIST_BOTTOM_PADDING}
+        paddingBottom={LIST_PADDING_BOTTOM}
         ref={ref}
-        renderItem={(row) => {
-          if (row.type === "pagination-skeleton") {
-            return <ApplicationRowSkeleton shouldAnnounce={row.key === 0} />;
+        renderItem={(item, index) => {
+          if (item.type === "skeleton") {
+            return (
+              <ApplicationRowSkeleton
+                shouldAnnounce={index === applications.length}
+              />
+            );
           }
 
           return (
             <ApplicationRow
-              application={row.application}
+              application={item.application}
               onSelectAction={onSelectApplication}
             />
           );
@@ -119,23 +125,22 @@ function ApplicationRowSkeleton({
     <div
       aria-label={shouldAnnounce ? "추가 항목을 불러오는 중입니다" : undefined}
       aria-live={shouldAnnounce ? "polite" : undefined}
-      className="border-b border-border/70 py-4"
+      className="border-b border-border/70"
       role={shouldAnnounce ? "status" : undefined}
     >
-      <div className="flex w-full items-start justify-between gap-4">
+      <div className="flex min-h-[110px] w-full items-start justify-between gap-4 px-1 py-4">
         <div className="flex min-w-0 flex-1 flex-col gap-2.5">
-          <div className="flex flex-col gap-1.5">
-            <Skeleton className="h-4.5 w-24" />
-            <Skeleton className="h-4 w-40" />
+          <div className="flex flex-col">
+            <Skeleton className="mt-0.5 h-4.5 w-24" />
+            <Skeleton className="mt-1 h-6 w-40" />
           </div>
           <div className="flex flex-wrap items-center gap-2">
-            <Skeleton className="h-6 w-16 rounded-full" />
-            <Skeleton className="h-4 w-14" />
-            <Skeleton className="h-4 w-12" />
+            <Skeleton className="h-5 w-16 rounded-full" />
+            <Skeleton className="h-5 w-12" />
           </div>
         </div>
-        <div className="flex flex-col items-end gap-2">
-          <Skeleton className="h-4.5 w-24" />
+        <div className="flex shrink-0 items-center gap-2 pt-1">
+          <Skeleton className="hidden h-5 w-12 sm:block" />
           <Skeleton className="size-4" />
         </div>
       </div>

--- a/app/(protected)/applications/_components/components/ApplicationRow.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationRow.tsx
@@ -27,7 +27,7 @@ export function ApplicationRow({
       <button
         aria-label={`${application.companyName} ${application.positionTitle} 지원 미리보기 열기`}
         className={cn(
-          "group flex w-full items-start justify-between gap-4 px-1 py-4 text-left transition-colors",
+          "group flex min-h-[110px] w-full items-start justify-between gap-4 px-1 py-4 text-left transition-colors",
           "cursor-pointer hover:bg-muted/30",
           "focus-visible:rounded-2xl focus-visible:bg-muted/30 focus-visible:ring-2 focus-visible:ring-primary/15 focus-visible:outline-none",
         )}
@@ -38,29 +38,29 @@ export function ApplicationRow({
         type="button"
       >
         <div className="flex min-w-0 flex-1 flex-col gap-2.5">
-          <div className="flex flex-col gap-1">
-            <span className="text-[15px] font-bold tracking-tight text-foreground">
+          <div className="flex flex-col">
+            <span className="text-[15px] leading-5 font-bold tracking-tight text-foreground">
               {application.companyName}
             </span>
-            <span className="truncate text-sm leading-6 font-medium text-muted-foreground">
+            <span className="mt-1 truncate text-sm leading-6 font-medium text-muted-foreground">
               {application.positionTitle}
             </span>
           </div>
           <div className="flex flex-wrap items-center gap-2">
             <span
               className={cn(
-                "rounded-full px-2.5 py-1 text-[10px] font-bold tracking-wider uppercase",
+                "rounded-full px-2.5 py-1 text-[10px] leading-3 font-bold tracking-wider uppercase",
                 badgeClassName,
               )}
             >
               {label}
             </span>
             {application.platform !== "MANUAL" && (
-              <span className="text-[11px] font-semibold tracking-wide text-muted-foreground uppercase">
+              <span className="text-[11px] leading-5 font-semibold tracking-wide text-muted-foreground uppercase">
                 {PLATFORM_LABEL[application.platform]}
               </span>
             )}
-            <span className="text-sm text-muted-foreground/80">
+            <span className="text-sm leading-5 text-muted-foreground/80">
               <TimeAgo dateString={application.appliedAt} />
             </span>
           </div>

--- a/app/(protected)/applications/_components/components/ApplicationsPanelFallback.tsx
+++ b/app/(protected)/applications/_components/components/ApplicationsPanelFallback.tsx
@@ -7,41 +7,44 @@ export function ApplicationsPanelFallback() {
   return (
     <div className="flex h-[32rem] min-h-0 flex-col sm:h-[36rem] lg:h-[40rem]">
       <div className="border-b border-border/70 bg-background px-5 sm:px-6">
-        <div className="flex items-end gap-5 py-3">
+        <div className="flex h-auto items-end gap-5 rounded-none bg-transparent p-0">
           {TAB_SKELETON_KEYS.map((key) => (
-            <Skeleton
-              className={
-                key === 1 ? "h-6 w-20 rounded-full" : "h-6 w-16 rounded-full"
-              }
-              key={key}
-            />
+            <div className="flex items-center gap-1.5 px-1 pb-3" key={key}>
+              <Skeleton className={key === 1 ? "h-5 w-10" : "h-5 w-8"} />
+              <Skeleton className="h-4 w-5 rounded-full" />
+            </div>
           ))}
         </div>
       </div>
 
       <div className="min-h-0 flex-1 px-4 sm:px-5">
-        <div className="h-full space-y-3 overflow-hidden pt-4">
+        <div className="h-full overflow-hidden pt-2 pb-10 lg:pr-4">
           {ROW_SKELETON_KEYS.map((index) => (
-            <div
-              className="rounded-2xl border border-border/60 px-4 py-4"
-              key={index}
-            >
-              <div className="flex items-start justify-between gap-4">
-                <div className="flex min-w-0 flex-1 flex-col gap-3">
-                  <div className="space-y-2">
-                    <Skeleton className="h-4.5 w-24" />
-                    <Skeleton className="h-4 w-40" />
-                  </div>
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Skeleton className="h-6 w-16 rounded-full" />
-                    <Skeleton className="h-4 w-14" />
-                    <Skeleton className="h-4 w-20" />
-                  </div>
-                </div>
-                <Skeleton className="mt-1 h-4 w-16" />
-              </div>
-            </div>
+            <ApplicationRowFallback key={index} />
           ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ApplicationRowFallback() {
+  return (
+    <div className="border-b border-border/70">
+      <div className="flex min-h-[110px] w-full items-start justify-between gap-4 px-1 py-4">
+        <div className="flex min-w-0 flex-1 flex-col gap-2.5">
+          <div className="flex flex-col">
+            <Skeleton className="mt-0.5 h-4.5 w-24" />
+            <Skeleton className="mt-1 h-6 w-40" />
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Skeleton className="h-5 w-16 rounded-full" />
+            <Skeleton className="h-5 w-12" />
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2 pt-1">
+          <Skeleton className="hidden h-5 w-12 sm:block" />
+          <Skeleton className="size-4" />
         </div>
       </div>
     </div>

--- a/app/(protected)/applications/loading.tsx
+++ b/app/(protected)/applications/loading.tsx
@@ -3,9 +3,9 @@ import { Skeleton } from "@/components/ui/skeleton/Skeleton";
 import { ApplicationsPanelFallback } from "./_components/components/ApplicationsPanelFallback";
 
 const PERIOD_CHIP_SKELETON_CLASSES = [
-  "h-10 w-14 rounded-full",
-  "h-10 w-24 rounded-full",
-  "h-10 w-20 rounded-full",
+  "h-[38px] w-14 rounded-full",
+  "h-[38px] w-24 rounded-full",
+  "h-[38px] w-20 rounded-full",
 ] as const;
 
 export default function ApplicationsLoading() {
@@ -28,7 +28,7 @@ function ApplicationFiltersFallback() {
       className="bg-background/95 px-5 py-5 backdrop-blur-sm sm:px-6"
     >
       <div className="grid gap-4">
-        <Skeleton className="h-12 w-full rounded-2xl" />
+        <Skeleton className="h-[50px] w-full rounded-2xl" />
         <div className="flex flex-wrap items-center gap-2">
           <div className="flex flex-wrap gap-2">
             {PERIOD_CHIP_SKELETON_CLASSES.map((className) => (
@@ -36,7 +36,7 @@ function ApplicationFiltersFallback() {
             ))}
           </div>
           <div className="flex flex-wrap items-center gap-2">
-            <Skeleton className="h-10 w-40 rounded-full" />
+            <Skeleton className="h-[38px] w-40 rounded-full" />
           </div>
         </div>
       </div>

--- a/lib/actions/_authContext.ts
+++ b/lib/actions/_authContext.ts
@@ -1,7 +1,8 @@
 import "server-only";
 import { cache } from "react";
 
-import { createClient } from "@/lib/supabase/server";
+import { createClientWithToken } from "@/lib/supabase/server";
+import { getSupabaseAccessTokenFromCookie } from "@/lib/supabase/session";
 
 import { getAuthenticatedUserId } from "./_auth";
 
@@ -12,14 +13,13 @@ export type AuthContextResult =
   | { ok: false; reason: string };
 
 export const getAuthContext = cache(async (): Promise<AuthContextResult> => {
-  const supabase = await createClient();
-  const { data: sessionData } = await supabase.auth.getSession();
-  const accessToken = sessionData.session?.access_token;
+  const accessToken = await getSupabaseAccessTokenFromCookie();
 
   if (!accessToken) {
     return { ok: false, reason: AUTH_REQUIRED_REASON };
   }
 
+  const supabase = createClientWithToken(accessToken);
   const authResult = await getAuthenticatedUserId(supabase, accessToken);
 
   if (!authResult.ok) {

--- a/lib/supabase/__tests__/session.test.ts
+++ b/lib/supabase/__tests__/session.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getSupabaseAccessTokenFromCookie } from "../session";
+
+const mockCookies = vi.hoisted(() => vi.fn());
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("next/headers", () => ({
+  cookies: mockCookies,
+}));
+
+const SUPABASE_URL = "https://project-ref.supabase.co";
+const AUTH_COOKIE_NAME = "sb-project-ref-auth-token";
+
+describe("getSupabaseAccessTokenFromCookie", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = SUPABASE_URL;
+  });
+
+  it("Supabase 세션 쿠키에서 access token을 읽는다", async () => {
+    mockCookies.mockResolvedValue({
+      getAll: () => [
+        {
+          name: AUTH_COOKIE_NAME,
+          value: JSON.stringify({ access_token: "access-token" }),
+        },
+      ],
+    });
+
+    await expect(getSupabaseAccessTokenFromCookie()).resolves.toBe(
+      "access-token",
+    );
+  });
+
+  it("base64url로 인코딩된 세션 쿠키를 디코딩한다", async () => {
+    mockCookies.mockResolvedValue({
+      getAll: () => [
+        {
+          name: AUTH_COOKIE_NAME,
+          value: `base64-${toBase64Url(
+            JSON.stringify({ access_token: "encoded-token" }),
+          )}`,
+        },
+      ],
+    });
+
+    await expect(getSupabaseAccessTokenFromCookie()).resolves.toBe(
+      "encoded-token",
+    );
+  });
+
+  it("chunk로 분리된 세션 쿠키를 합쳐서 읽는다", async () => {
+    const cookieValue = JSON.stringify({ access_token: "chunked-token" });
+
+    mockCookies.mockResolvedValue({
+      getAll: () => [
+        { name: `${AUTH_COOKIE_NAME}.0`, value: cookieValue.slice(0, 20) },
+        { name: `${AUTH_COOKIE_NAME}.1`, value: cookieValue.slice(20) },
+      ],
+    });
+
+    await expect(getSupabaseAccessTokenFromCookie()).resolves.toBe(
+      "chunked-token",
+    );
+  });
+
+  it("세션 쿠키가 없으면 null을 반환한다", async () => {
+    mockCookies.mockResolvedValue({
+      getAll: () => [],
+    });
+
+    await expect(getSupabaseAccessTokenFromCookie()).resolves.toBeNull();
+  });
+});
+
+function toBase64Url(value: string) {
+  return Buffer.from(value, "utf8").toString("base64url");
+}

--- a/lib/supabase/session.ts
+++ b/lib/supabase/session.ts
@@ -1,0 +1,104 @@
+import "server-only";
+import { cookies } from "next/headers";
+
+const AUTH_COOKIE_SUFFIX = "-auth-token";
+const BASE64_PREFIX = "base64-";
+
+type SupabaseSessionCookie = {
+  access_token?: unknown;
+};
+
+export async function getSupabaseAccessTokenFromCookie() {
+  const cookieStore = await cookies();
+  const authCookieName = getSupabaseAuthCookieName();
+  const cookieValue = combineCookieChunks(
+    authCookieName,
+    cookieStore.getAll().map(({ name, value }) => ({ name, value })),
+  );
+
+  if (!cookieValue) {
+    return null;
+  }
+
+  const decodedCookieValue = decodeSupabaseCookieValue(cookieValue);
+
+  if (!decodedCookieValue) {
+    return null;
+  }
+
+  try {
+    const session = JSON.parse(decodedCookieValue) as SupabaseSessionCookie;
+
+    if (typeof session.access_token !== "string") {
+      return null;
+    }
+
+    return session.access_token;
+  } catch {
+    return null;
+  }
+}
+
+function combineCookieChunks(
+  cookieName: string,
+  cookiesToRead: { name: string; value: string }[],
+) {
+  const unchunkedCookie = cookiesToRead.find(({ name }) => name === cookieName);
+
+  if (unchunkedCookie?.value) {
+    return unchunkedCookie.value;
+  }
+
+  const chunks: string[] = [];
+
+  for (let index = 0; ; index++) {
+    const chunkName = `${cookieName}.${index}`;
+    const chunk = cookiesToRead.find(({ name }) => name === chunkName);
+
+    if (!chunk?.value) {
+      break;
+    }
+
+    chunks.push(chunk.value);
+  }
+
+  if (chunks.length === 0) {
+    return null;
+  }
+
+  return chunks.join("");
+}
+
+function decodeBase64Url(value: string) {
+  const base64 = value.replaceAll("-", "+").replaceAll("_", "/");
+  const paddedBase64 = base64.padEnd(
+    base64.length + ((4 - (base64.length % 4)) % 4),
+    "=",
+  );
+
+  return Buffer.from(paddedBase64, "base64").toString("utf8");
+}
+
+function decodeSupabaseCookieValue(value: string) {
+  if (!value.startsWith(BASE64_PREFIX)) {
+    return value;
+  }
+
+  try {
+    return decodeBase64Url(value.slice(BASE64_PREFIX.length));
+  } catch {
+    return null;
+  }
+}
+
+function getSupabaseAuthCookieName() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+  if (!supabaseUrl) {
+    throw new Error("NEXT_PUBLIC_SUPABASE_URL is required.");
+  }
+
+  const projectRef = new URL(supabaseUrl).hostname.split(".")[0];
+
+  return `sb-${projectRef}${AUTH_COOKIE_SUFFIX}`;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -68,6 +68,7 @@ export default defineConfig({
             "lib/auth/**/*.test.ts",
             "lib/adapters/**/*.test.ts",
             "lib/actions/**/*.test.ts",
+            "lib/supabase/**/*.test.ts",
           ],
           name: "unit",
         },


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #423, #425, #427

## 📌 작업 내용

- 페이지네이션 로딩 스켈레톤을 VirtualList row로 통합하고 지원 row·fallback 치수를 실제 렌더링 구조에 맞춰 지원 목록 로딩 중 레이아웃 시프트를 완화
- 보호 레이아웃에서 모바일 하단 바를 정적 import로 전환해 FAB 지연 로딩과 분리하고 하단 내비게이션이 즉시 표시되도록 개선
- Supabase 세션 쿠키에서 access token을 읽는 서버 전용 헬퍼를 추가하고 `getAuthContext`의 `auth.getSession()` 호출을 제거해 token 기반 claims 검증 흐름으로 정리
- base64url 및 chunked Supabase auth cookie 처리 테스트와 Vitest 대상 설정을 추가해 인증 쿠키 파싱 회귀를 방지
