### PR TITLE
release: 루트 진입 인증 검증 제거

### DIFF
--- a/lib/supabase/__tests__/proxy.test.ts
+++ b/lib/supabase/__tests__/proxy.test.ts
@@ -1,0 +1,68 @@
+import { createServerClient } from "@supabase/ssr";
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { updateSession } from "../proxy";
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(),
+}));
+
+const AUTH_COOKIE_NAME = "sb-project-ref-auth-token";
+const SUPABASE_URL = "https://project-ref.supabase.co";
+
+describe("updateSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = "publishable-key";
+    process.env.NEXT_PUBLIC_SUPABASE_URL = SUPABASE_URL;
+  });
+
+  it("루트 요청에 세션 쿠키가 있으면 Supabase 검증 없이 로그인 페이지로 보낸다", async () => {
+    const request = createRequest("/", `${AUTH_COOKIE_NAME}=session-cookie`);
+
+    const response = await updateSession(request);
+
+    expect(response.headers.get("location")).toBe("https://example.com/login");
+    expect(createServerClient).not.toHaveBeenCalled();
+  });
+
+  it("루트 요청에 세션 쿠키가 없으면 Supabase 검증 없이 공개 홈을 유지한다", async () => {
+    const request = createRequest("/");
+
+    const response = await updateSession(request);
+
+    expect(response.headers.get("location")).toBeNull();
+    expect(createServerClient).not.toHaveBeenCalled();
+  });
+
+  it("보호 라우트에서 인증 claims가 없으면 로그인 페이지로 보낸다", async () => {
+    mockSupabaseClaims(null);
+
+    const response = await updateSession(createRequest("/dashboard"));
+
+    expect(response.headers.get("location")).toBe("https://example.com/login");
+  });
+
+  it("보호 라우트에서 인증 claims가 있으면 요청을 통과시킨다", async () => {
+    mockSupabaseClaims({ sub: "user-id" });
+
+    const response = await updateSession(createRequest("/dashboard"));
+
+    expect(response.headers.get("location")).toBeNull();
+  });
+});
+
+function createRequest(pathname: string, cookie?: string) {
+  return new NextRequest(`https://example.com${pathname}`, {
+    headers: cookie ? { cookie } : undefined,
+  });
+}
+
+function mockSupabaseClaims(claims: null | { sub: string }) {
+  vi.mocked(createServerClient).mockReturnValue({
+    auth: {
+      getClaims: vi.fn().mockResolvedValue({ data: { claims } }),
+    },
+  } as never);
+}

--- a/lib/supabase/proxy.ts
+++ b/lib/supabase/proxy.ts
@@ -3,7 +3,7 @@ import { type NextRequest, NextResponse } from "next/server";
 
 const ROOT_PATH = "/";
 const LOGIN_PATH = "/login";
-const DASHBOARD_PATH = "/dashboard";
+const AUTH_COOKIE_SUFFIX = "-auth-token";
 const AUTH_BYPASS_PATH_PREFIXES = [
   "/api/events",
   "/auth",
@@ -16,6 +16,18 @@ export async function updateSession(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   if (isAuthBypassPath(pathname)) {
+    return NextResponse.next({
+      request,
+    });
+  }
+
+  if (pathname === ROOT_PATH) {
+    if (hasSupabaseAuthCookie(request.cookies.getAll())) {
+      const url = request.nextUrl.clone();
+      url.pathname = LOGIN_PATH;
+      return NextResponse.redirect(url);
+    }
+
     return NextResponse.next({
       request,
     });
@@ -66,12 +78,6 @@ export async function updateSession(request: NextRequest) {
     return NextResponse.redirect(url);
   }
 
-  if (user && pathname === ROOT_PATH) {
-    const url = request.nextUrl.clone();
-    url.pathname = DASHBOARD_PATH;
-    return NextResponse.redirect(url);
-  }
-
   // IMPORTANT: You *must* return the supabaseResponse object as it is. If you're
   // creating a new response object with NextResponse.next() make sure to:
   // 1. Pass the request in it, like so:
@@ -86,6 +92,34 @@ export async function updateSession(request: NextRequest) {
   // of sync and terminate the user's session prematurely!
 
   return supabaseResponse;
+}
+
+function getSupabaseAuthCookieName() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+  if (!supabaseUrl) {
+    throw new Error("NEXT_PUBLIC_SUPABASE_URL is required.");
+  }
+
+  const projectRef = new URL(supabaseUrl).hostname.split(".")[0];
+
+  return `sb-${projectRef}${AUTH_COOKIE_SUFFIX}`;
+}
+
+function hasSupabaseAuthCookie(
+  cookies: {
+    name: string;
+    value: string;
+  }[],
+) {
+  const authCookieName = getSupabaseAuthCookieName();
+
+  return cookies.some(({ name, value }) => {
+    const isAuthCookie =
+      name === authCookieName || name.startsWith(`${authCookieName}.`);
+
+    return isAuthCookie && value.length > 0;
+  });
 }
 
 function isAuthBypassPath(pathname: string) {


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #430

## 📌 작업 내용

- 세션 쿠키가 없는 루트 요청은 Supabase 검증 없이 공개 홈을 렌더링하도록 변경해 초기 응답 경로를 단순화
- 세션 쿠키가 있는 루트 요청도 `/dashboard` 자동 진입 대신 `/login`으로 이동하도록 정리해 루트 진입 시 보호 라우트 인증 확인과 책임을 분리
- 보호 라우트의 인증 확인과 미인증 `/login` 리다이렉트 동작을 테스트로 고정해 인증 흐름 회귀를 방지
