### PR TITLE
fix: 로그인 상태의 랜딩페이지 접근 복구(#433)

### DIFF
--- a/lib/supabase/__tests__/proxy.test.ts
+++ b/lib/supabase/__tests__/proxy.test.ts
@@ -18,12 +18,12 @@ describe("updateSession", () => {
     process.env.NEXT_PUBLIC_SUPABASE_URL = SUPABASE_URL;
   });
 
-  it("루트 요청에 세션 쿠키가 있으면 Supabase 검증 없이 로그인 페이지로 보낸다", async () => {
+  it("루트 요청에 세션 쿠키가 있어도 Supabase 검증 없이 공개 홈을 유지한다", async () => {
     const request = createRequest("/", `${AUTH_COOKIE_NAME}=session-cookie`);
 
     const response = await updateSession(request);
 
-    expect(response.headers.get("location")).toBe("https://example.com/login");
+    expect(response.headers.get("location")).toBeNull();
     expect(createServerClient).not.toHaveBeenCalled();
   });
 

--- a/lib/supabase/proxy.ts
+++ b/lib/supabase/proxy.ts
@@ -3,7 +3,6 @@ import { type NextRequest, NextResponse } from "next/server";
 
 const ROOT_PATH = "/";
 const LOGIN_PATH = "/login";
-const AUTH_COOKIE_SUFFIX = "-auth-token";
 const AUTH_BYPASS_PATH_PREFIXES = [
   "/api/events",
   "/auth",
@@ -22,12 +21,6 @@ export async function updateSession(request: NextRequest) {
   }
 
   if (pathname === ROOT_PATH) {
-    if (hasSupabaseAuthCookie(request.cookies.getAll())) {
-      const url = request.nextUrl.clone();
-      url.pathname = LOGIN_PATH;
-      return NextResponse.redirect(url);
-    }
-
     return NextResponse.next({
       request,
     });
@@ -92,34 +85,6 @@ export async function updateSession(request: NextRequest) {
   // of sync and terminate the user's session prematurely!
 
   return supabaseResponse;
-}
-
-function getSupabaseAuthCookieName() {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-
-  if (!supabaseUrl) {
-    throw new Error("NEXT_PUBLIC_SUPABASE_URL is required.");
-  }
-
-  const projectRef = new URL(supabaseUrl).hostname.split(".")[0];
-
-  return `sb-${projectRef}${AUTH_COOKIE_SUFFIX}`;
-}
-
-function hasSupabaseAuthCookie(
-  cookies: {
-    name: string;
-    value: string;
-  }[],
-) {
-  const authCookieName = getSupabaseAuthCookieName();
-
-  return cookies.some(({ name, value }) => {
-    const isAuthCookie =
-      name === authCookieName || name.startsWith(`${authCookieName}.`);
-
-    return isAuthCookie && value.length > 0;
-  });
 }
 
 function isAuthBypassPath(pathname: string) {


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #433

## 📌 작업 내용

- 루트 요청에서 Supabase auth 쿠키가 있을 때 `/login`으로 리다이렉트하던 분기를 제거
- `/`는 로그인 여부와 관계없이 공개 랜딩을 렌더링하고, 보호 라우트 인증 검사는 기존 흐름을 유지
- 프록시 테스트 기대값을 갱신해 세션 쿠키가 있어도 루트 접근이 유지되도록 회귀를 방지


