### PR TITLE
fix: 로그인 사용자의 루트 진입 경로 복구(#436)

### DIFF
--- a/lib/supabase/__tests__/proxy.test.ts
+++ b/lib/supabase/__tests__/proxy.test.ts
@@ -18,22 +18,24 @@ describe("updateSession", () => {
     process.env.NEXT_PUBLIC_SUPABASE_URL = SUPABASE_URL;
   });
 
-  it("루트 요청에 세션 쿠키가 있어도 Supabase 검증 없이 공개 홈을 유지한다", async () => {
+  it("루트 요청에 인증 claims가 있으면 대시보드로 보낸다", async () => {
+    mockSupabaseClaims({ sub: "user-id" });
     const request = createRequest("/", `${AUTH_COOKIE_NAME}=session-cookie`);
 
     const response = await updateSession(request);
 
-    expect(response.headers.get("location")).toBeNull();
-    expect(createServerClient).not.toHaveBeenCalled();
+    expect(response.headers.get("location")).toBe(
+      "https://example.com/dashboard",
+    );
   });
 
-  it("루트 요청에 세션 쿠키가 없으면 Supabase 검증 없이 공개 홈을 유지한다", async () => {
+  it("루트 요청에 인증 claims가 없으면 공개 홈을 유지한다", async () => {
+    mockSupabaseClaims(null);
     const request = createRequest("/");
 
     const response = await updateSession(request);
 
     expect(response.headers.get("location")).toBeNull();
-    expect(createServerClient).not.toHaveBeenCalled();
   });
 
   it("보호 라우트에서 인증 claims가 없으면 로그인 페이지로 보낸다", async () => {

--- a/lib/supabase/proxy.ts
+++ b/lib/supabase/proxy.ts
@@ -2,6 +2,7 @@ import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
 
 const ROOT_PATH = "/";
+const DASHBOARD_PATH = "/dashboard";
 const LOGIN_PATH = "/login";
 const AUTH_BYPASS_PATH_PREFIXES = [
   "/api/events",
@@ -15,12 +16,6 @@ export async function updateSession(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   if (isAuthBypassPath(pathname)) {
-    return NextResponse.next({
-      request,
-    });
-  }
-
-  if (pathname === ROOT_PATH) {
     return NextResponse.next({
       request,
     });
@@ -64,6 +59,12 @@ export async function updateSession(request: NextRequest) {
   const { data } = await supabase.auth.getClaims();
 
   const user = data?.claims;
+
+  if (user && pathname === ROOT_PATH) {
+    const url = request.nextUrl.clone();
+    url.pathname = DASHBOARD_PATH;
+    return NextResponse.redirect(url);
+  }
 
   if (!user && pathname !== ROOT_PATH) {
     const url = request.nextUrl.clone();


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #436

## 📌 작업 내용

- 루트 요청에서도 세션 claims를 확인해 로그인 사용자는 `/dashboard`로 이동하도록 수정
- 미로그인 사용자는 기존처럼 공개 홈을 유지해 랜딩 접근 흐름을 보존
- 프록시 테스트를 갱신해 로그인/미로그인 루트 요청 동작을 검증


